### PR TITLE
chore: bump LocalAI to v4.1.3

### DIFF
--- a/.github/workflows/mirror-localai.yml
+++ b/.github/workflows/mirror-localai.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "LocalAI version tag (e.g. v4.0.0)"
+        description: "LocalAI version tag (e.g. v4.1.3)"
         required: true
-        default: v4.0.0
+        default: v4.1.3
 
 permissions:
   contents: read

--- a/pkg/aikit2llb/inference/convert.go
+++ b/pkg/aikit2llb/inference/convert.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	distrolessBase                = "ghcr.io/kaito-project/aikit/base:latest"
-	localAIBinaryVersion          = "v4.0.0"
+	localAIBinaryVersion          = "v4.1.3"
 	localAILlamaCppBackendVersion = localAIBinaryVersion
 	localAILegacyBackendVersion   = "v3.12.1"
 	localAIRepo                   = "ghcr.io/kaito-project/aikit/localai:"


### PR DESCRIPTION
**What this PR does / why we need it**:

- bump the LocalAI binary version from `v4.0.0` to `v4.1.3`
- update the manual mirror workflow example/default to `v4.1.3` so it stays in sync

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
N/A

**Special notes for your reviewer**:

- validated with `go test ./pkg/aikit2llb/inference/...`