### PR TITLE
fix(finetune): update Unsloth integration

### DIFF
--- a/.github/workflows/test-finetune.yaml
+++ b/.github/workflows/test-finetune.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/pkg/aikit/config/finetune_specs.go
+++ b/pkg/aikit/config/finetune_specs.go
@@ -13,13 +13,25 @@ type FineTuneConfig struct {
 func (c *FineTuneConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain FineTuneConfig
 
-	decoded := plain{
-		Config: FineTuneConfigSpec{
-			Unsloth: FineTuneConfigUnslothSpec{LoadIn4bit: true},
-		},
-	}
+	var decoded plain
 	if err := unmarshal(&decoded); err != nil {
 		return err
+	}
+
+	var fields struct {
+		Config *struct {
+			Unsloth *struct {
+				LoadIn4bit *bool `yaml:"loadIn4bit"`
+			} `yaml:"unsloth"`
+		} `yaml:"config"`
+	}
+	if err := unmarshal(&fields); err != nil {
+		return err
+	}
+
+	decoded.Config.Unsloth.LoadIn4bit = true
+	if fields.Config != nil && fields.Config.Unsloth != nil && fields.Config.Unsloth.LoadIn4bit != nil {
+		decoded.Config.Unsloth.LoadIn4bit = *fields.Config.Unsloth.LoadIn4bit
 	}
 
 	*c = FineTuneConfig(decoded)

--- a/pkg/aikit/config/finetune_specs.go
+++ b/pkg/aikit/config/finetune_specs.go
@@ -9,6 +9,23 @@ type FineTuneConfig struct {
 	Output     FineTuneOutputSpec `yaml:"output"`
 }
 
+// UnmarshalYAML applies nested fine-tuning defaults even when optional config sections are omitted.
+func (c *FineTuneConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain FineTuneConfig
+
+	decoded := plain{
+		Config: FineTuneConfigSpec{
+			Unsloth: FineTuneConfigUnslothSpec{LoadIn4bit: true},
+		},
+	}
+	if err := unmarshal(&decoded); err != nil {
+		return err
+	}
+
+	*c = FineTuneConfig(decoded)
+	return nil
+}
+
 type FineTuneConfigSpec struct {
 	Unsloth FineTuneConfigUnslothSpec `yaml:"unsloth"`
 }
@@ -32,6 +49,19 @@ type FineTuneConfigUnslothSpec struct {
 	WeightDecay               float64 `yaml:"weightDecay"`
 	LrSchedulerType           string  `yaml:"lrSchedulerType"`
 	Seed                      int     `yaml:"seed"`
+}
+
+// UnmarshalYAML applies the documented four-bit loading default while preserving explicit false values.
+func (c *FineTuneConfigUnslothSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain FineTuneConfigUnslothSpec
+
+	decoded := plain{LoadIn4bit: true}
+	if err := unmarshal(&decoded); err != nil {
+		return err
+	}
+
+	*c = FineTuneConfigUnslothSpec(decoded)
+	return nil
 }
 
 type FineTuneOutputSpec struct {

--- a/pkg/aikit/config/specs.go
+++ b/pkg/aikit/config/specs.go
@@ -6,18 +6,24 @@ import (
 )
 
 func NewFromBytes(b []byte) (*InferenceConfig, *FineTuneConfig, error) {
-	inferenceConfig := &InferenceConfig{}
-	fineTuneConfig := &FineTuneConfig{}
-	var err error
-	err = yaml.Unmarshal(b, inferenceConfig)
-	if err == nil {
-		return inferenceConfig, nil, nil
+	var fields map[string]interface{}
+	if err := yaml.Unmarshal(b, &fields); err != nil {
+		return nil, nil, errors.Wrap(err, "unmarshal config")
 	}
 
-	err = yaml.Unmarshal(b, fineTuneConfig)
-	if err == nil {
+	_, hasBaseModel := fields["baseModel"]
+	_, hasDatasets := fields["datasets"]
+	if hasBaseModel || hasDatasets {
+		fineTuneConfig := &FineTuneConfig{}
+		if err := yaml.Unmarshal(b, fineTuneConfig); err != nil {
+			return nil, nil, errors.Wrap(err, "unmarshal config")
+		}
 		return nil, fineTuneConfig, nil
 	}
 
-	return nil, nil, errors.Wrap(err, "unmarshal config")
+	inferenceConfig := &InferenceConfig{}
+	if err := yaml.Unmarshal(b, inferenceConfig); err != nil {
+		return nil, nil, errors.Wrap(err, "unmarshal config")
+	}
+	return inferenceConfig, nil, nil
 }

--- a/pkg/aikit/config/specs_test.go
+++ b/pkg/aikit/config/specs_test.go
@@ -65,3 +65,57 @@ foo
 		})
 	}
 }
+
+func TestNewFromBytesPreservesDisabledFourBitLoading(t *testing.T) {
+	_, fineTuneConfig, err := NewFromBytes([]byte(`
+apiVersion: v1alpha1
+baseModel: test-model
+datasets:
+  - source: test-dataset
+    type: alpaca
+config:
+  unsloth:
+    loadIn4bit: false
+`))
+	if err != nil {
+		t.Fatalf("NewFromBytes() error = %v", err)
+	}
+	if fineTuneConfig == nil {
+		t.Fatal("NewFromBytes() returned no fine-tune config")
+	}
+	if fineTuneConfig.Config.Unsloth.LoadIn4bit {
+		t.Fatal("loadIn4bit = true, want false")
+	}
+}
+
+func TestNewFromBytesDefaultsFourBitLoading(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{name: "config omitted"},
+		{name: "unsloth omitted", config: "config: {}"},
+		{name: "load setting omitted", config: "config:\n  unsloth: {}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "apiVersion: v1alpha1\n" +
+				"baseModel: test-model\n" +
+				"datasets:\n" +
+				"  - source: test-dataset\n" +
+				"    type: alpaca\n" +
+				tt.config + "\n"
+			_, fineTuneConfig, err := NewFromBytes([]byte(input))
+			if err != nil {
+				t.Fatalf("NewFromBytes() error = %v", err)
+			}
+			if fineTuneConfig == nil {
+				t.Fatal("NewFromBytes() returned no fine-tune config")
+			}
+			if !fineTuneConfig.Config.Unsloth.LoadIn4bit {
+				t.Fatal("loadIn4bit = false, want true")
+			}
+		})
+	}
+}

--- a/pkg/aikit/config/specs_test.go
+++ b/pkg/aikit/config/specs_test.go
@@ -66,36 +66,18 @@ foo
 	}
 }
 
-func TestNewFromBytesPreservesDisabledFourBitLoading(t *testing.T) {
-	_, fineTuneConfig, err := NewFromBytes([]byte(`
-apiVersion: v1alpha1
-baseModel: test-model
-datasets:
-  - source: test-dataset
-    type: alpaca
-config:
-  unsloth:
-    loadIn4bit: false
-`))
-	if err != nil {
-		t.Fatalf("NewFromBytes() error = %v", err)
-	}
-	if fineTuneConfig == nil {
-		t.Fatal("NewFromBytes() returned no fine-tune config")
-	}
-	if fineTuneConfig.Config.Unsloth.LoadIn4bit {
-		t.Fatal("loadIn4bit = true, want false")
-	}
-}
-
 func TestNewFromBytesDefaultsFourBitLoading(t *testing.T) {
 	tests := []struct {
-		name   string
-		config string
+		name           string
+		config         string
+		wantLoadIn4bit bool
 	}{
-		{name: "config omitted"},
-		{name: "unsloth omitted", config: "config: {}"},
-		{name: "load setting omitted", config: "config:\n  unsloth: {}"},
+		{name: "config omitted", wantLoadIn4bit: true},
+		{name: "config null", config: "config:\n", wantLoadIn4bit: true},
+		{name: "config empty", config: "config: {}\n", wantLoadIn4bit: true},
+		{name: "unsloth null", config: "config:\n  unsloth:\n", wantLoadIn4bit: true},
+		{name: "unsloth empty", config: "config:\n  unsloth: {}\n", wantLoadIn4bit: true},
+		{name: "load setting false", config: "config:\n  unsloth:\n    loadIn4bit: false\n", wantLoadIn4bit: false},
 	}
 
 	for _, tt := range tests {
@@ -105,7 +87,7 @@ func TestNewFromBytesDefaultsFourBitLoading(t *testing.T) {
 				"datasets:\n" +
 				"  - source: test-dataset\n" +
 				"    type: alpaca\n" +
-				tt.config + "\n"
+				tt.config
 			_, fineTuneConfig, err := NewFromBytes([]byte(input))
 			if err != nil {
 				t.Fatalf("NewFromBytes() error = %v", err)
@@ -113,8 +95,8 @@ func TestNewFromBytesDefaultsFourBitLoading(t *testing.T) {
 			if fineTuneConfig == nil {
 				t.Fatal("NewFromBytes() returned no fine-tune config")
 			}
-			if !fineTuneConfig.Config.Unsloth.LoadIn4bit {
-				t.Fatal("loadIn4bit = false, want true")
+			if fineTuneConfig.Config.Unsloth.LoadIn4bit != tt.wantLoadIn4bit {
+				t.Fatalf("loadIn4bit = %t, want %t", fineTuneConfig.Config.Unsloth.LoadIn4bit, tt.wantLoadIn4bit)
 			}
 		})
 	}

--- a/pkg/aikit2llb/finetune/convert.go
+++ b/pkg/aikit2llb/finetune/convert.go
@@ -16,9 +16,12 @@ const (
 	torchVersion   = "2.10.0"
 	sourceVenv     = ". .venv/bin/activate"
 
-	nvidiaMknod = "NVIDIA_MAJOR=$(awk '$2 == \"nvidia\" { print $1; exit }' /proc/devices) && " +
+	nvidiaPrimaryMajorAWK = `$2 == "nvidia-frontend" { frontend = $1 } $2 == "nvidia" { legacy = $1 } ` +
+		`END { if (frontend != "") { print frontend } else if (legacy != "") { print legacy } ` +
+		`else { print "failed to find NVIDIA primary character device major (expected nvidia-frontend or nvidia)" > "/dev/stderr"; exit 1 } }`
+	nvidiaMknod = "NVIDIA_MAJOR=$(awk '" + nvidiaPrimaryMajorAWK + "' /proc/devices) && " +
 		"NVIDIA_UVM_MAJOR=$(awk '$2 == \"nvidia-uvm\" { print $1; exit }' /proc/devices) && " +
-		"test -n \"$NVIDIA_MAJOR\" && test -n \"$NVIDIA_UVM_MAJOR\" && " +
+		"test -n \"$NVIDIA_UVM_MAJOR\" && " +
 		"rm -f /dev/nvidiactl /dev/nvidia-uvm /dev/nvidia-uvm-tools /dev/nvidia0 && " +
 		"mknod --mode 666 /dev/nvidiactl c \"$NVIDIA_MAJOR\" 255 && " +
 		"mknod --mode 666 /dev/nvidia-uvm c \"$NVIDIA_UVM_MAJOR\" 0 && " +

--- a/pkg/aikit2llb/finetune/convert.go
+++ b/pkg/aikit2llb/finetune/convert.go
@@ -4,17 +4,26 @@ import (
 	"fmt"
 
 	"github.com/kaito-project/aikit/pkg/aikit/config"
+	finetunescript "github.com/kaito-project/aikit/pkg/finetune"
 	"github.com/kaito-project/aikit/pkg/utils"
-	"github.com/kaito-project/aikit/pkg/version"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/system"
 	"gopkg.in/yaml.v2"
 )
 
 const (
-	unslothCommitOrTag = "fb77505f8429566f5d21d6ea5318c342e8a67991" // September-2024
-	nvidiaMknod        = "mknod --mode 666 /dev/nvidiactl c 195 255 && mknod --mode 666 /dev/nvidia-uvm c 235 0 && mknod --mode 666 /dev/nvidia-uvm-tools c 235 1 && mknod --mode 666 /dev/nvidia0 c 195 0 && nvidia-smi"
-	sourceVenv         = ". .venv/bin/activate"
+	unslothVersion = "2026.8.1"
+	torchVersion   = "2.10.0"
+	sourceVenv     = ". .venv/bin/activate"
+
+	nvidiaMknod = "NVIDIA_MAJOR=$(awk '$2 == \"nvidia\" { print $1; exit }' /proc/devices) && " +
+		"NVIDIA_UVM_MAJOR=$(awk '$2 == \"nvidia-uvm\" { print $1; exit }' /proc/devices) && " +
+		"test -n \"$NVIDIA_MAJOR\" && test -n \"$NVIDIA_UVM_MAJOR\" && " +
+		"rm -f /dev/nvidiactl /dev/nvidia-uvm /dev/nvidia-uvm-tools /dev/nvidia0 && " +
+		"mknod --mode 666 /dev/nvidiactl c \"$NVIDIA_MAJOR\" 255 && " +
+		"mknod --mode 666 /dev/nvidia-uvm c \"$NVIDIA_UVM_MAJOR\" 0 && " +
+		"mknod --mode 666 /dev/nvidia-uvm-tools c \"$NVIDIA_UVM_MAJOR\" 1 && " +
+		"mknod --mode 666 /dev/nvidia0 c \"$NVIDIA_MAJOR\" 0 && nvidia-smi"
 )
 
 func Aikit2LLB(c *config.FineTuneConfig) llb.State {
@@ -23,7 +32,7 @@ func Aikit2LLB(c *config.FineTuneConfig) llb.State {
 		value string
 	}{
 		{key: "PATH", value: system.DefaultPathEnv("linux") + ":/usr/local/cuda/bin"},
-		{key: "NVIDIA_REQUIRE_CUDA", value: "cuda>=12.0"},
+		{key: "NVIDIA_REQUIRE_CUDA", value: "cuda>=12.6"},
 		{key: "NVIDIA_DRIVER_CAPABILITIES", value: "compute,utility"},
 		{key: "NVIDIA_VISIBLE_DEVICES", value: "all"},
 		{key: "LD_LIBRARY_PATH", value: "/usr/local/cuda/lib64"},
@@ -36,25 +45,24 @@ func Aikit2LLB(c *config.FineTuneConfig) llb.State {
 
 	// installing dependencies
 	// due to buildkit run limitations, we need to install nvidia drivers and driver version must match the host
-	state = state.Run(utils.Sh("apt-get update && apt-get install -y --no-install-recommends python3-dev python3 python3-pip python-is-python3 git wget kmod && cd /root && VERSION=$(cat /proc/driver/nvidia/version | sed -n 's/.*NVIDIA UNIX x86_64 Kernel Module  \\([0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\).*/\\1/p') && wget --no-verbose https://download.nvidia.com/XFree86/Linux-x86_64/$VERSION/NVIDIA-Linux-x86_64-$VERSION.run && chmod +x NVIDIA-Linux-x86_64-$VERSION.run && ./NVIDIA-Linux-x86_64-$VERSION.run -x && rm NVIDIA-Linux-x86_64-$VERSION.run && /root/NVIDIA-Linux-x86_64-$VERSION/nvidia-installer -a -s --skip-depmod --no-dkms --no-nvidia-modprobe --no-questions --no-systemd --no-x-check --no-kernel-modules --no-kernel-module-source && rm -rf /root/NVIDIA-Linux-x86_64-$VERSION")).Root()
+	state = state.Run(utils.Sh("apt-get update && apt-get install -y --no-install-recommends cmake python3-dev python3 python3-pip python-is-python3 git wget kmod && cd /root && VERSION=$(cat /proc/driver/nvidia/version | sed -n 's/.*NVIDIA UNIX x86_64 Kernel Module  \\([0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\).*/\\1/p') && wget --no-verbose https://download.nvidia.com/XFree86/Linux-x86_64/$VERSION/NVIDIA-Linux-x86_64-$VERSION.run && chmod +x NVIDIA-Linux-x86_64-$VERSION.run && ./NVIDIA-Linux-x86_64-$VERSION.run -x && rm NVIDIA-Linux-x86_64-$VERSION.run && /root/NVIDIA-Linux-x86_64-$VERSION/nvidia-installer -a -s --skip-depmod --no-dkms --no-nvidia-modprobe --no-questions --no-systemd --no-x-check --no-kernel-modules --no-kernel-module-source && rm -rf /root/NVIDIA-Linux-x86_64-$VERSION")).Root()
 
 	var scratch llb.State
 	if c.Target == utils.TargetUnsloth {
-		// installing unsloth and its dependencies
-		// uv does not support installing xformers via unsloth pyproject
-		state = state.Run(utils.Shf("pip install --upgrade pip uv && uv venv --system-site-packages && %[1]s && uv pip install --upgrade --force-reinstall packaging torch==2.4.0 ipython ninja packaging bitsandbytes setuptools==69.5.1 wheel psutil transformers==4.44.2 numpy==2.0.2 && uv pip install flash-attn --no-build-isolation && python -m pip install 'unsloth[cu121_ampere_torch240] @ git+https://github.com/unslothai/unsloth.git@%[2]s'", sourceVenv, unslothCommitOrTag)).Root()
+		// Install the latest tested Unsloth release and its matching CUDA 12.6/PyTorch 2.10 dependencies.
+		state = state.Run(utils.Shf(
+			"pip install --upgrade pip uv && "+
+				"uv venv --system-site-packages && %[1]s && "+
+				"uv pip install --torch-backend=cu126 'torch==%[2]s' "+
+				"'unsloth[cu126-torch2100]==%[3]s' 'unsloth-zoo==%[3]s'",
+			sourceVenv,
+			torchVersion,
+			unslothVersion,
+		)).Root()
 
-		version := version.Version
-		if version == "" {
-			version = "main"
-		}
-		unslothScriptURL := fmt.Sprintf("https://raw.githubusercontent.com/kaito-project/aikit/%s/pkg/finetune/target_unsloth.py", version)
-		var opts []llb.HTTPOption
-		opts = append(opts, llb.Chmod(0o755))
-		unslothScript := llb.HTTP(unslothScriptURL, opts...)
 		state = state.File(
-			llb.Copy(unslothScript, utils.FileNameFromURL(unslothScriptURL), "/"),
-			llb.WithCustomName("Copying "+utils.FileNameFromURL(unslothScriptURL)),
+			llb.Mkfile("/target_unsloth.py", 0o755, finetunescript.TargetUnsloth),
+			llb.WithCustomName("Copying target_unsloth.py"),
 		)
 	}
 

--- a/pkg/aikit2llb/finetune/convert_test.go
+++ b/pkg/aikit2llb/finetune/convert_test.go
@@ -2,6 +2,7 @@ package finetune
 
 import (
 	"context"
+	"os/exec"
 	"reflect"
 	"slices"
 	"strings"
@@ -162,13 +163,67 @@ func TestAikit2LLBDiscoversNvidiaDeviceMajors(t *testing.T) {
 	trainingOp := findFineTuneExec(t, ops, "python -m target_unsloth")
 	trainingCommand := strings.Join(trainingOp.op.GetExec().Meta.Args, "\x00")
 
-	for _, fragment := range []string{"/proc/devices", "nvidia-uvm", "$NVIDIA_UVM_MAJOR", "$NVIDIA_MAJOR"} {
+	for _, fragment := range []string{"/proc/devices", "nvidia-frontend", "nvidia-uvm", "$NVIDIA_UVM_MAJOR", "$NVIDIA_MAJOR"} {
 		if !strings.Contains(trainingCommand, fragment) {
 			t.Errorf("training command does not contain dynamic NVIDIA device fragment %q: %q", fragment, trainingCommand)
 		}
 	}
 	if strings.Contains(trainingCommand, "nvidia-uvm c 235") {
 		t.Fatalf("training command still contains the stale hard-coded NVIDIA UVM major: %q", trainingCommand)
+	}
+}
+
+func TestNvidiaPrimaryMajorAWK(t *testing.T) {
+	tests := []struct {
+		name        string
+		devices     string
+		wantMajor   string
+		wantFailure bool
+	}{
+		{
+			name:      "frontend",
+			devices:   "Character devices:\n195 nvidia-frontend\n511 nvidia-uvm\n",
+			wantMajor: "195",
+		},
+		{
+			name:      "legacy fallback",
+			devices:   "Character devices:\n195 nvidia\n511 nvidia-uvm\n",
+			wantMajor: "195",
+		},
+		{
+			name:      "frontend preferred over legacy",
+			devices:   "Character devices:\n195 nvidia\n509 nvidia-frontend\n511 nvidia-uvm\n",
+			wantMajor: "509",
+		},
+		{
+			name:        "missing primary device",
+			devices:     "Character devices:\n511 nvidia-uvm\n",
+			wantFailure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("awk", nvidiaPrimaryMajorAWK)
+			cmd.Stdin = strings.NewReader(tt.devices)
+			output, err := cmd.CombinedOutput()
+			if tt.wantFailure {
+				if err == nil {
+					t.Fatalf("device discovery unexpectedly succeeded: %q", output)
+				}
+				if !strings.Contains(string(output), "expected nvidia-frontend or nvidia") {
+					t.Fatalf("device discovery failure = %q, want actionable error", output)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("device discovery failed: %v: %s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != tt.wantMajor {
+				t.Fatalf("device major = %q, want %q", got, tt.wantMajor)
+			}
+		})
 	}
 }
 

--- a/pkg/aikit2llb/finetune/convert_test.go
+++ b/pkg/aikit2llb/finetune/convert_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kaito-project/aikit/pkg/aikit/config"
+	finetunescript "github.com/kaito-project/aikit/pkg/finetune"
 	"github.com/kaito-project/aikit/pkg/utils"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/pb"
@@ -58,7 +59,7 @@ func TestAikit2LLBMaterializesConfigAfterDependencies(t *testing.T) {
 
 	wantEnv := []string{
 		"PATH=" + system.DefaultPathEnv("linux") + ":/usr/local/cuda/bin",
-		"NVIDIA_REQUIRE_CUDA=cuda>=12.0",
+		"NVIDIA_REQUIRE_CUDA=cuda>=12.6",
 		"NVIDIA_DRIVER_CAPABILITIES=compute,utility",
 		"NVIDIA_VISIBLE_DEVICES=all",
 		"LD_LIBRARY_PATH=/usr/local/cuda/lib64",
@@ -69,9 +70,13 @@ func TestAikit2LLBMaterializesConfigAfterDependencies(t *testing.T) {
 		}
 	}
 
-	dependencyOp := findFineTuneExec(t, ops, "uv pip install --upgrade --force-reinstall")
+	dependencyOp := findFineTuneExec(t, ops, "unsloth[cu126-torch2100]")
+	scriptOp, scriptFile := findFineTuneFile(t, ops, "/target_unsloth.py")
 	trainingOp := findFineTuneExec(t, ops, "python -m target_unsloth")
 	configOp, configFile := findFineTuneConfigFile(t, ops)
+	if scriptFile.Mode != 0o755 || !slices.Equal(scriptFile.Data, finetunescript.TargetUnsloth) {
+		t.Fatalf("script mkfile = mode %o data %q, want mode %o embedded script", scriptFile.Mode, string(scriptFile.Data), 0o755)
+	}
 	wantConfig, err := yaml.Marshal(cfg)
 	if err != nil {
 		t.Fatalf("marshal expected config: %v", err)
@@ -82,8 +87,18 @@ func TestAikit2LLBMaterializesConfigAfterDependencies(t *testing.T) {
 	if dependencyOp.index >= configOp.index {
 		t.Fatalf("dependency op index %d must precede config op index %d", dependencyOp.index, configOp.index)
 	}
+	if dependencyOp.index >= scriptOp.index || scriptOp.index >= configOp.index {
+		t.Fatalf("dependency, script, and config op indexes must be ordered: dependency=%d script=%d config=%d", dependencyOp.index, scriptOp.index, configOp.index)
+	}
 	if len(trainingOp.op.Inputs) != 1 || trainingOp.op.Inputs[0].Digest != configOp.digest.String() {
 		t.Fatalf("training op inputs = %#v, want config digest %s", trainingOp.op.Inputs, configOp.digest)
+	}
+	outputCopy := findFineTuneGGUFCopy(t, ops)
+	if strings.TrimPrefix(outputCopy.Src, "/") != "model/*.gguf" {
+		t.Errorf("GGUF copy source = %q, want model/*.gguf", outputCopy.Src)
+	}
+	if strings.TrimPrefix(outputCopy.Dest, "/") != "output-q4_k_m.gguf" {
+		t.Errorf("GGUF copy destination = %q, want output-q4_k_m.gguf", outputCopy.Dest)
 	}
 	for _, graphOp := range ops {
 		if exec := graphOp.op.GetExec(); exec != nil {
@@ -97,13 +112,63 @@ func TestAikit2LLBMaterializesConfigAfterDependencies(t *testing.T) {
 	changedConfig := *cfg
 	changedConfig.BaseModel = "a config-only change"
 	changedOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, &changedConfig))
-	changedDependencyOp := findFineTuneExec(t, changedOps, "uv pip install --upgrade --force-reinstall")
+	changedDependencyOp := findFineTuneExec(t, changedOps, "unsloth[cu126-torch2100]")
+	changedScriptOp, _ := findFineTuneFile(t, changedOps, "/target_unsloth.py")
 	changedConfigOp, _ := findFineTuneConfigFile(t, changedOps)
 	if dependencyOp.digest != changedDependencyOp.digest {
 		t.Fatalf("config-only change invalidated dependency op: got %s, want %s", changedDependencyOp.digest, dependencyOp.digest)
 	}
 	if configOp.digest == changedConfigOp.digest {
 		t.Fatalf("config file op digest did not change after config change: %s", configOp.digest)
+	}
+	if scriptOp.digest != changedScriptOp.digest {
+		t.Fatalf("config-only change invalidated script op: got %s, want %s", changedScriptOp.digest, scriptOp.digest)
+	}
+}
+
+func TestAikit2LLBUsesCurrentUnslothDependencies(t *testing.T) {
+	ops := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, fineTuneTestConfig()))
+	dependencyOp := findFineTuneExec(t, ops, "unsloth[cu126-torch2100]")
+	dependencyCommand := strings.Join(dependencyOp.op.GetExec().Meta.Args, "\x00")
+
+	wantFragments := []string{
+		"torch==" + torchVersion,
+		"unsloth[cu126-torch2100]==" + unslothVersion,
+		"unsloth-zoo==" + unslothVersion,
+		"--torch-backend=cu126",
+	}
+	for _, fragment := range wantFragments {
+		if !strings.Contains(dependencyCommand, fragment) {
+			t.Errorf("dependency command does not contain %q: %q", fragment, dependencyCommand)
+		}
+	}
+
+	staleFragments := []string{
+		"transformers==4.44.2",
+		"torch==2.4.0",
+		"torch==2.4.1",
+		"git+https://github.com/unslothai/unsloth.git",
+		"fb77505f8429566f5d21d6ea5318c342e8a67991",
+	}
+	for _, fragment := range staleFragments {
+		if strings.Contains(dependencyCommand, fragment) {
+			t.Errorf("dependency command still contains stale fragment %q: %q", fragment, dependencyCommand)
+		}
+	}
+}
+
+func TestAikit2LLBDiscoversNvidiaDeviceMajors(t *testing.T) {
+	ops := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, fineTuneTestConfig()))
+	trainingOp := findFineTuneExec(t, ops, "python -m target_unsloth")
+	trainingCommand := strings.Join(trainingOp.op.GetExec().Meta.Args, "\x00")
+
+	for _, fragment := range []string{"/proc/devices", "nvidia-uvm", "$NVIDIA_UVM_MAJOR", "$NVIDIA_MAJOR"} {
+		if !strings.Contains(trainingCommand, fragment) {
+			t.Errorf("training command does not contain dynamic NVIDIA device fragment %q: %q", fragment, trainingCommand)
+		}
+	}
+	if strings.Contains(trainingCommand, "nvidia-uvm c 235") {
+		t.Fatalf("training command still contains the stale hard-coded NVIDIA UVM major: %q", trainingCommand)
 	}
 }
 
@@ -165,17 +230,39 @@ func findFineTuneExec(t *testing.T, ops []fineTuneDefinitionOp, commandFragment 
 func findFineTuneConfigFile(t *testing.T, ops []fineTuneDefinitionOp) (fineTuneDefinitionOp, *pb.FileActionMkFile) {
 	t.Helper()
 
+	return findFineTuneFile(t, ops, "/config.yaml")
+}
+
+func findFineTuneFile(t *testing.T, ops []fineTuneDefinitionOp, path string) (fineTuneDefinitionOp, *pb.FileActionMkFile) {
+	t.Helper()
+
 	for _, graphOp := range ops {
 		if fileOp := graphOp.op.GetFile(); fileOp != nil {
 			for _, action := range fileOp.Actions {
-				if mkfile := action.GetMkfile(); mkfile != nil && mkfile.Path == "/config.yaml" {
+				if mkfile := action.GetMkfile(); mkfile != nil && mkfile.Path == path {
 					return graphOp, mkfile
 				}
 			}
 		}
 	}
-	t.Fatal("config mkfile action not found")
+	t.Fatalf("mkfile action for %q not found", path)
 	return fineTuneDefinitionOp{}, nil
+}
+
+func findFineTuneGGUFCopy(t *testing.T, ops []fineTuneDefinitionOp) *pb.FileActionCopy {
+	t.Helper()
+
+	for _, graphOp := range ops {
+		if fileOp := graphOp.op.GetFile(); fileOp != nil {
+			for _, action := range fileOp.Actions {
+				if copyAction := action.GetCopy(); copyAction != nil && strings.HasSuffix(copyAction.Src, "*.gguf") {
+					return copyAction
+				}
+			}
+		}
+	}
+	t.Fatal("GGUF copy action not found")
+	return nil
 }
 
 func cloneFineTuneDefinition(definition [][]byte) [][]byte {

--- a/pkg/finetune/target.go
+++ b/pkg/finetune/target.go
@@ -1,0 +1,8 @@
+package finetune
+
+import _ "embed"
+
+// TargetUnsloth contains the Unsloth fine-tuning entrypoint used by the BuildKit frontend.
+//
+//go:embed target_unsloth.py
+var TargetUnsloth []byte

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -1,46 +1,50 @@
 #!/usr/bin/env python3
 
-from unsloth import is_bfloat16_supported
-from transformers import TrainingArguments, DataCollatorForSeq2Seq
-from unsloth import FastLanguageModel
-import torch
-from trl import SFTTrainer
-from transformers import TrainingArguments
+import shutil
+from pathlib import Path
+
+from unsloth import FastLanguageModel, is_bfloat16_supported
 from datasets import load_dataset
+from trl import SFTConfig, SFTTrainer
 import yaml
 
-with open('config.yaml', 'r') as config_file:
-    try:
-        data = yaml.safe_load(config_file)
-        print(data)
-    except yaml.YAMLError as exc:
-        print(exc)
 
-cfg = data.get('config').get('unsloth')
-max_seq_length = cfg.get('maxSeqLength')
+with open("/config.yaml", "r", encoding="utf-8") as config_file:
+    data = yaml.safe_load(config_file)
+print(data)
+
+cfg = data["config"]["unsloth"]
+max_seq_length = cfg["maxSeqLength"]
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name=data.get('baseModel'),
+    model_name=data["baseModel"],
     max_seq_length=max_seq_length,
     dtype=None,
-    load_in_4bit=True,
+    load_in_4bit=cfg["loadIn4bit"],
 )
 
 model = FastLanguageModel.get_peft_model(
     model,
-    r = 16, # Choose any number > 0 ! Suggested 8, 16, 32, 64, 128
-    target_modules = ["q_proj", "k_proj", "v_proj", "o_proj",
-                      "gate_proj", "up_proj", "down_proj",],
-    lora_alpha = 16,
-    lora_dropout = 0, # Supports any, but = 0 is optimized
-    bias = "none",    # Supports any, but = "none" is optimized
+    r=16,
+    target_modules=[
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ],
+    lora_alpha=16,
+    lora_dropout=0,
+    bias="none",
     use_gradient_checkpointing="unsloth",
-    random_state = 3407,
-    use_rslora = False,  # We support rank stabilized LoRA
-    loftq_config = None, # And LoftQ
+    random_state=cfg["seed"],
+    use_rslora=False,
+    loftq_config=None,
 )
 
-# TODO: right now, this is hardcoded for alpaca. use the dataset type here in the future to make this customizable
+# Alpaca is the only dataset type currently supported by the AIKit fine-tuning API.
 alpaca_prompt = """Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
 
 ### Instruction:
@@ -52,56 +56,67 @@ alpaca_prompt = """Below is an instruction that describes a task, paired with an
 ### Response:
 {}"""
 
-EOS_TOKEN = tokenizer.eos_token
+eos_token = tokenizer.eos_token
+
+
 def formatting_prompts_func(examples):
-    instructions = examples["instruction"]
-    inputs       = examples["input"]
-    outputs      = examples["output"]
     texts = []
-    for instruction, input, output in zip(instructions, inputs, outputs):
-        # Must add EOS_TOKEN, otherwise your generation will go on forever!
-        text = alpaca_prompt.format(instruction, input, output) + EOS_TOKEN
-        texts.append(text)
-    return { "text" : texts, }
-pass
+    for instruction, input_text, output_text in zip(
+        examples["instruction"], examples["input"], examples["output"]
+    ):
+        texts.append(alpaca_prompt.format(instruction, input_text, output_text) + eos_token)
+    return {"text": texts}
 
-from datasets import load_dataset
-source = data.get('datasets')[0]['source']
 
-if source.startswith('http'):
+source = data["datasets"][0]["source"]
+if source.startswith("http"):
     dataset = load_dataset("json", data_files={"train": source}, split="train")
 else:
-    dataset = load_dataset(source, split = "train")
+    dataset = load_dataset(source, split="train")
 
 dataset = dataset.map(formatting_prompts_func, batched=True)
+bfloat16_supported = is_bfloat16_supported()
 
 trainer = SFTTrainer(
     model=model,
     train_dataset=dataset,
-    dataset_text_field="text",
-    max_seq_length=max_seq_length,
-    data_collator=DataCollatorForSeq2Seq(tokenizer=tokenizer),
-    tokenizer=tokenizer,
-    dataset_num_proc = 2,
-    packing = cfg.get('packing'), # Can make training 5x faster for short sequences.
-    args=TrainingArguments(
-        per_device_train_batch_size=cfg.get('batchSize'),
-        gradient_accumulation_steps=cfg.get('gradientAccumulationSteps'),
-        warmup_steps=cfg.get('warmupSteps'),
-        max_steps=cfg.get('maxSteps'),
-        learning_rate = cfg.get('learningRate'),
-        fp16=not is_bfloat16_supported(),
-        bf16=is_bfloat16_supported(),
-        logging_steps=cfg.get('loggingSteps'),
-        optim=cfg.get('optimizer'),
-        weight_decay = cfg.get('weightDecay'),
-        lr_scheduler_type = cfg.get('lrSchedulerType'),
-        seed=cfg.get('seed'),
+    processing_class=tokenizer,
+    args=SFTConfig(
         output_dir="outputs",
+        dataset_text_field="text",
+        dataset_num_proc=2,
+        max_length=max_seq_length,
+        packing=cfg["packing"],
+        per_device_train_batch_size=cfg["batchSize"],
+        gradient_accumulation_steps=cfg["gradientAccumulationSteps"],
+        warmup_steps=cfg["warmupSteps"],
+        max_steps=cfg["maxSteps"],
+        learning_rate=cfg["learningRate"],
+        fp16=not bfloat16_supported,
+        bf16=bfloat16_supported,
+        logging_steps=cfg["loggingSteps"],
+        optim=cfg["optimizer"],
+        weight_decay=cfg["weightDecay"],
+        lr_scheduler_type=cfg["lrSchedulerType"],
+        seed=cfg["seed"],
+        save_strategy="no",
+        report_to="none",
     ),
 )
 trainer.train()
 
-output = data.get('output')
-model.save_pretrained_gguf(output.get('name'), tokenizer,
-                           quantization_method=output.get('quantize'))
+export_directory = Path("/aikit-unsloth-export")
+export_result = model.save_pretrained_gguf(
+    export_directory,
+    tokenizer,
+    quantization_method=data["output"]["quantize"],
+)
+gguf_files = export_result.get("gguf_files", [])
+if len(gguf_files) != 1:
+    raise RuntimeError(f"expected exactly one GGUF output, found {gguf_files}")
+
+artifact_directory = Path("/model")
+artifact_directory.mkdir(parents=True, exist_ok=True)
+Path(gguf_files[0]).replace(artifact_directory / Path(gguf_files[0]).name)
+shutil.rmtree(export_directory, ignore_errors=True)
+shutil.rmtree(Path(f"{export_directory}_gguf"), ignore_errors=True)

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -11,7 +11,7 @@ import yaml
 
 with open("/config.yaml", "r", encoding="utf-8") as config_file:
     data = yaml.safe_load(config_file)
-print(data)
+print("Loaded fine-tuning configuration.")
 
 cfg = data["config"]["unsloth"]
 max_seq_length = cfg["maxSeqLength"]

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -20,7 +20,7 @@ const (
 	UbuntuBase       = "docker.io/library/ubuntu:22.04"
 	Ubuntu24Base     = "docker.io/library/ubuntu:24.04"
 	AppleSiliconBase = "ghcr.io/kaito-project/aikit/applesilicon/base:latest"
-	CudaDevel        = "nvcr.io/nvidia/cuda:12.3.2-devel-ubuntu22.04"
+	CudaDevel        = "nvcr.io/nvidia/cuda:12.6.3-devel-ubuntu22.04"
 	ROCmDevel        = "rocm/dev-ubuntu-22.04:7.2"
 
 	PlatformLinux = "linux"


### PR DESCRIPTION
## Summary

- update the fine-tuning stack to Unsloth and Unsloth Zoo 2026.8.1 with PyTorch 2.10.0 on CUDA 12.6
- migrate the training entrypoint to the current TRL `SFTConfig` and `processing_class` APIs
- embed the matching Python entrypoint in the frontend instead of downloading a potentially mismatched script from `main`
- normalize current Unsloth GGUF output handling so custom output names work
- discover NVIDIA device majors dynamically and include `cmake` for llama.cpp fallback builds
- preserve the public `loadIn4bit` boolean API while applying its documented default and correctly identifying fine-tune configs with omitted optional sections

## Root cause

The previous integration pinned a September 2024 Unsloth commit while allowing modern transitive dependencies to resolve. On August 2, 2026, that produced an incompatible TRL/Transformers stack and failed during import before model loading. The old script also used legacy trainer arguments, downloaded its implementation from an external branch at build time, assumed GGUF files remained under `model/`, and hard-coded NVIDIA UVM device numbers.

## Impact

Fine-tuning builds now use a reproducible current Unsloth stack, execute the script compiled into the frontend, train successfully on current TRL, and export a correctly named GGUF artifact. Explicit `loadIn4bit: false` remains supported while omitted values default to true.

## Validation

All validation was run on `sertac-vm-gpu-amp2` with an NVIDIA A100 80 GB GPU; no local Docker or local builds were used.

- `make test`
- `golangci-lint v2.11.2` — 0 issues
- `python3 -m py_compile pkg/finetune/target_unsloth.py`
- dependency/GPU sentinel build reached the expected missing-model error without import or accelerator failures
- one-step TinyLlama fine-tune with a four-record Alpaca dataset
- GGUF export with a non-default output name
- CUDA inference image build and successful chat-completions request using the generated GGUF
- final independent review reported no remaining concrete findings