### PR TITLE
fix(inference): validate cached runner backend

### DIFF
--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -233,7 +233,7 @@ fi`
 // generateHFModelConfig generates the download and config logic for diffusers/vllm backends.
 // These backends pass the HuggingFace model ID through to LocalAI config at runtime.
 func generateHFModelConfig(backend string) string {
-	return fmt.Sprintf(`# Check if model config matches the requested model (volume mount caching)
+	return fmt.Sprintf(`# Check if model config matches the requested name, backend, and source (volume mount caching)
 %[1]s
 if [[ -f "/models/aikit-model.yaml" ]] &&
   grep -qxF "name: ${MODEL_NAME}" /models/aikit-model.yaml 2>/dev/null &&

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -239,10 +239,10 @@ if [[ -f "/models/aikit-model.yaml" ]] &&
   grep -qxF "name: ${MODEL_NAME}" /models/aikit-model.yaml 2>/dev/null &&
   grep -qxF "backend: %[2]s" /models/aikit-model.yaml 2>/dev/null &&
   grep -qxF "  model: ${MODEL}" /models/aikit-model.yaml 2>/dev/null; then
-  echo "Found existing model config matching $MODEL in /models, skipping setup"
+  echo "Found existing %[2]s model config matching $MODEL in /models, skipping setup"
 else
   if [[ -f "/models/aikit-model.yaml" ]]; then
-    echo "Cached config does not match requested model ($MODEL), regenerating"
+    echo "Cached config does not match requested backend/model (%[2]s, $MODEL), regenerating"
   fi
   # For %[2]s backend, generate a LocalAI model config pointing to the HF model
   echo "Generating LocalAI config for %[2]s backend with model: $MODEL"

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -237,6 +237,7 @@ func generateHFModelConfig(backend string) string {
 %[1]s
 if [[ -f "/models/aikit-model.yaml" ]] &&
   grep -qxF "name: ${MODEL_NAME}" /models/aikit-model.yaml 2>/dev/null &&
+  grep -qxF "backend: %[2]s" /models/aikit-model.yaml 2>/dev/null &&
   grep -qxF "  model: ${MODEL}" /models/aikit-model.yaml 2>/dev/null; then
   echo "Found existing model config matching $MODEL in /models, skipping setup"
 else

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -296,9 +296,10 @@ func TestGenerateHFModelConfig(t *testing.T) {
 				t.Error("should respect HF_TOKEN")
 			}
 
-			// Should handle model mismatch
-			if !strings.Contains(script, "does not match requested model") {
-				t.Error("should detect and handle model mismatch on cached volume")
+			// Cache logs should identify the backend that matched or changed.
+			if !strings.Contains(script, "Found existing "+tt.backend+" model config") ||
+				!strings.Contains(script, "does not match requested backend/model ("+tt.backend) {
+				t.Error("should identify the backend in cache hit and mismatch logs")
 			}
 		})
 	}

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -281,8 +281,9 @@ func TestGenerateHFModelConfig(t *testing.T) {
 
 			// Cached configs should match both the new alias and the requested model.
 			if !strings.Contains(script, `grep -qxF "name: ${MODEL_NAME}"`) ||
+				!strings.Contains(script, `grep -qxF "backend: `+tt.backend+`"`) ||
 				!strings.Contains(script, `grep -qxF "  model: ${MODEL}"`) {
-				t.Error("should validate the cached model name and source")
+				t.Error("should validate the cached model name, backend, and source")
 			}
 
 			// Should contain correct backend reference

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -279,7 +279,7 @@ func TestGenerateHFModelConfig(t *testing.T) {
 				t.Error("should normalize fragments, queries, and trailing slashes before deriving the model name")
 			}
 
-			// Cached configs should match both the new alias and the requested model.
+			// Cached configs should match the alias, backend, and requested model source.
 			if !strings.Contains(script, `grep -qxF "name: ${MODEL_NAME}"`) ||
 				!strings.Contains(script, `grep -qxF "backend: `+tt.backend+`"`) ||
 				!strings.Contains(script, `grep -qxF "  model: ${MODEL}"`) {


### PR DESCRIPTION
## Summary

- require cached runner model configurations to match the requested backend as well as the model alias and source
- regenerate `/models/aikit-model.yaml` when a shared volume switches between diffusers and vLLM runners
- follow up on the valid suppressed Copilot review feedback from #813

## Validation

- `go test ./pkg/aikit2llb/inference -run 'TestGenerateHFModelConfig|TestRunnerModelNameScript' -count=1`
- `golangci-lint run ./... --timeout 5m --new-from-rev=origin/main`
- local Codex autoreview: clean, no actionable findings