### PR TITLE
feat(finetune): support multiple datasets

### DIFF
--- a/.github/stack-merge-trigger
+++ b/.github/stack-merge-trigger
@@ -1,1 +1,0 @@
-PR 834 stacked merge validation

--- a/.github/stack-merge-trigger
+++ b/.github/stack-merge-trigger
@@ -1,0 +1,1 @@
+PR 834 stacked merge validation

--- a/.github/workflows/test-finetune.yaml
+++ b/.github/workflows/test-finetune.yaml
@@ -16,6 +16,7 @@ on:
           - prompt-completion-smoke
           - text-smoke
           - loader-smoke
+          - multiple-datasets-smoke
           - full
 
 permissions: read-all
@@ -40,6 +41,7 @@ jobs:
 
           run_mode="${{ inputs.mode }}"
           smoke_dataset_file=""
+          smoke_dataset_file_2=""
           case "$run_mode" in
             smoke)
               smoke_dataset_file="${GITHUB_WORKSPACE}/test/fixtures/alpaca-smoke.jsonl"
@@ -61,6 +63,10 @@ jobs:
               ;;
             loader-smoke)
               smoke_dataset_file="${GITHUB_WORKSPACE}/test/fixtures/prompt-completion-loader-smoke.parquet"
+              ;;
+            multiple-datasets-smoke)
+              smoke_dataset_file="${GITHUB_WORKSPACE}/test/fixtures/multiple-alpaca-smoke.jsonl"
+              smoke_dataset_file_2="${GITHUB_WORKSPACE}/test/fixtures/multiple-text-smoke.jsonl"
               ;;
             full) ;;
             *)
@@ -85,6 +91,7 @@ jobs:
             echo "DATASET_CONTAINER_NAME=aikit-finetune-$run_key-dataset"
             echo "DATASET_SERVER_IMAGE=busybox:1.37.0@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"
             echo "SMOKE_DATASET_FILE=$smoke_dataset_file"
+            echo "SMOKE_DATASET_FILE_2=$smoke_dataset_file_2"
           } >> "$GITHUB_ENV"
 
       - name: Verify GPU and CDI builder
@@ -179,6 +186,10 @@ jobs:
 
           test -s "$SMOKE_DATASET_FILE"
           dataset_directory=$(dirname -- "$SMOKE_DATASET_FILE")
+          if [[ -n "$SMOKE_DATASET_FILE_2" ]]; then
+            test -s "$SMOKE_DATASET_FILE_2"
+            test "$(dirname -- "$SMOKE_DATASET_FILE_2")" = "$dataset_directory"
+          fi
           docker run \
             --name "$DATASET_CONTAINER_NAME" \
             --detach \
@@ -205,7 +216,15 @@ jobs:
           test -n "$host_ip"
           dataset_url="http://${host_ip}:${dataset_port}/$(basename "$SMOKE_DATASET_FILE")"
           curl --fail --silent --show-error --retry 20 --retry-all-errors --retry-delay 1 --retry-max-time 30 "$dataset_url" --output /dev/null
-          echo "SMOKE_DATASET_URL=$dataset_url" >> "$GITHUB_ENV"
+          dataset_url_2=""
+          if [[ -n "$SMOKE_DATASET_FILE_2" ]]; then
+            dataset_url_2="http://${host_ip}:${dataset_port}/$(basename "$SMOKE_DATASET_FILE_2")"
+            curl --fail --silent --show-error --retry 20 --retry-all-errors --retry-delay 1 --retry-max-time 30 "$dataset_url_2" --output /dev/null
+          fi
+          {
+            echo "SMOKE_DATASET_URL=$dataset_url"
+            echo "SMOKE_DATASET_URL_2=$dataset_url_2"
+          } >> "$GITHUB_ENV"
 
       - name: Generate mode-specific configs
         shell: bash
@@ -243,6 +262,11 @@ jobs:
               dataset_url="${SMOKE_DATASET_URL:?loader smoke dataset URL is required}"
               dataset_checksum="sha256:$(sha256sum "$SMOKE_DATASET_FILE" | awk '{print $1}')"
               ;;
+            multiple-datasets-smoke)
+              source_config="$GITHUB_WORKSPACE/test/aikitfile-unsloth-multiple-datasets-smoke.yaml"
+              dataset_url="${SMOKE_DATASET_URL:?first multiple-datasets smoke URL is required}"
+              dataset_url_2="${SMOKE_DATASET_URL_2:?second multiple-datasets smoke URL is required}"
+              ;;
             full)
               source_config="$GITHUB_WORKSPACE/test/aikitfile-unsloth.yaml"
               dataset_url=""
@@ -250,8 +274,10 @@ jobs:
           esac
 
           dataset_placeholder="__AIKIT_SMOKE_DATASET_URL__"
+          dataset_placeholder_2="__AIKIT_SMOKE_DATASET_URL_2__"
           dataset_checksum_placeholder="__AIKIT_SMOKE_DATASET_CHECKSUM__"
           gguf_placeholder="__AIKIT_GGUF_OUTPUT__"
+          dataset_url_2="${dataset_url_2:-}"
           dataset_checksum="${dataset_checksum:-}"
 
           placeholder_count() {
@@ -371,6 +397,7 @@ jobs:
             dataset_placeholder_count=1
           fi
           intermediate_config="${FINETUNE_CONFIG}.dataset"
+          second_intermediate_config="${FINETUNE_CONFIG}.dataset-second"
           render_config \
             "$source_config" \
             "$intermediate_config" \
@@ -378,17 +405,28 @@ jobs:
             "$dataset_url" \
             "$dataset_placeholder_count"
 
+          dataset_placeholder_count_2=0
+          if [[ -n "$dataset_url_2" ]]; then
+            dataset_placeholder_count_2=1
+          fi
+          render_config \
+            "$intermediate_config" \
+            "$second_intermediate_config" \
+            "$dataset_placeholder_2" \
+            "$dataset_url_2" \
+            "$dataset_placeholder_count_2"
+
           dataset_checksum_placeholder_count=0
           if [[ -n "$dataset_checksum" ]]; then
             dataset_checksum_placeholder_count=1
           fi
           render_config \
-            "$intermediate_config" \
+            "$second_intermediate_config" \
             "$FINETUNE_CONFIG" \
             "$dataset_checksum_placeholder" \
             "$dataset_checksum" \
             "$dataset_checksum_placeholder_count"
-          rm -f -- "$intermediate_config"
+          rm -f -- "$intermediate_config" "$second_intermediate_config"
 
           output_name=$(output_scalar "$FINETUNE_CONFIG" "name")
           output_quantize=$(output_scalar "$FINETUNE_CONFIG" "quantize")
@@ -529,7 +567,7 @@ jobs:
           docker image rm --force "$CUSTOM_IMAGE" > /dev/null 2>&1 || true
           docker image rm --force "$AIKIT_IMAGE" > /dev/null 2>&1 || true
 
-          for generated_path in "$OUTPUT_DIR" "$FINETUNE_CONFIG" "${FINETUNE_CONFIG}.dataset" "$CUSTOM_CONFIG"; do
+          for generated_path in "$OUTPUT_DIR" "$FINETUNE_CONFIG" "${FINETUNE_CONFIG}.dataset" "${FINETUNE_CONFIG}.dataset-second" "$CUSTOM_CONFIG"; do
             case "$generated_path" in
               "$RUNNER_TEMP"/*) rm -rf -- "$generated_path" || true ;;
               *) echo "refusing to remove path outside runner temp: $generated_path" >&2 ;;

--- a/.github/workflows/test-finetune.yaml
+++ b/.github/workflows/test-finetune.yaml
@@ -17,6 +17,7 @@ on:
           - text-smoke
           - loader-smoke
           - multiple-datasets-smoke
+          - dpo-smoke
           - full
 
 permissions: read-all
@@ -67,6 +68,9 @@ jobs:
             multiple-datasets-smoke)
               smoke_dataset_file="${GITHUB_WORKSPACE}/test/fixtures/multiple-alpaca-smoke.jsonl"
               smoke_dataset_file_2="${GITHUB_WORKSPACE}/test/fixtures/multiple-text-smoke.jsonl"
+              ;;
+            dpo-smoke)
+              smoke_dataset_file="${GITHUB_WORKSPACE}/test/fixtures/preference-smoke.jsonl"
               ;;
             full) ;;
             *)
@@ -266,6 +270,11 @@ jobs:
               source_config="$GITHUB_WORKSPACE/test/aikitfile-unsloth-multiple-datasets-smoke.yaml"
               dataset_url="${SMOKE_DATASET_URL:?first multiple-datasets smoke URL is required}"
               dataset_url_2="${SMOKE_DATASET_URL_2:?second multiple-datasets smoke URL is required}"
+              ;;
+            dpo-smoke)
+              source_config="$GITHUB_WORKSPACE/test/aikitfile-unsloth-dpo-smoke.yaml"
+              dataset_url="${SMOKE_DATASET_URL:?DPO smoke dataset URL is required}"
+              dataset_checksum="sha256:$(sha256sum "$SMOKE_DATASET_FILE" | awk '{print $1}')"
               ;;
             full)
               source_config="$GITHUB_WORKSPACE/test/aikitfile-unsloth.yaml"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -61,6 +61,17 @@ jobs:
       - name: Go unit tests
         run: make test
 
+      - name: Install Python dataset test dependencies
+        run: |
+          uv pip install --system \
+            --exclude-newer 2026-08-05T00:00:00Z \
+            "datasets==4.3.0" \
+            "fsspec==2025.9.0" \
+            "huggingface-hub==1.26.0" \
+            "numpy==2.2.6" \
+            "pandas==2.3.3" \
+            "pyarrow==25.0.0"
+
       - name: Python unit tests
         run: make test-python
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Install Python dataset test dependencies
         run: |
-          uv pip install --system \
+          uv venv --python python3 .venv
+          uv pip install --python .venv/bin/python \
             --exclude-newer 2026-08-05T00:00:00Z \
             "datasets==4.3.0" \
             "fsspec==2025.9.0" \
@@ -73,7 +74,7 @@ jobs:
             "pyarrow==25.0.0"
 
       - name: Python unit tests
-        run: make test-python
+        run: PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH" make test-python
 
       - name: Test image size checker
         run: scripts/ci/check-image-size_test.sh

--- a/pkg/aikit/config/finetune_specs.go
+++ b/pkg/aikit/config/finetune_specs.go
@@ -16,7 +16,8 @@ const (
 	defaultGradientAccumulationSteps = 4
 	defaultWarmupSteps               = 10
 	defaultMaxSteps                  = 60
-	defaultLearningRate              = 0.0002
+	defaultSFTLearningRate           = 0.0002
+	defaultDPOLearningRate           = 0.000001
 	defaultLoggingSteps              = 1
 	defaultOptimizer                 = "adamw_8bit"
 	defaultWeightDecay               = 0.01
@@ -30,15 +31,19 @@ const (
 	datasetLoaderFieldSplit          = "split"
 	datasetLoaderFieldRevision       = "revision"
 	datasetLoaderFieldChecksum       = "checksum"
+	defaultDPOBeta                   = 0.1
+	defaultDPOLossType               = utils.DPOLossSigmoid
+	defaultDPOMaxPromptLength        = 512
 )
 
 type FineTuneConfig struct {
-	APIVersion string             `yaml:"apiVersion"`
-	Target     string             `yaml:"target"`
-	BaseModel  string             `yaml:"baseModel"`
-	Datasets   []Dataset          `yaml:"datasets"`
-	Config     FineTuneConfigSpec `yaml:"config"`
-	Output     FineTuneOutputSpec `yaml:"output"`
+	APIVersion string                `yaml:"apiVersion"`
+	Target     string                `yaml:"target"`
+	BaseModel  string                `yaml:"baseModel"`
+	Objective  FineTuneObjectiveSpec `yaml:"objective,omitempty"`
+	Datasets   []Dataset             `yaml:"datasets"`
+	Config     FineTuneConfigSpec    `yaml:"config"`
+	Output     FineTuneOutputSpec    `yaml:"output"`
 }
 
 // UnmarshalYAML normalizes fine-tuning defaults while preserving explicitly configured zero values.
@@ -54,6 +59,24 @@ func (c *FineTuneConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 type FineTuneConfigSpec struct {
 	Unsloth FineTuneConfigUnslothSpec `yaml:"unsloth"`
+}
+
+// FineTuneObjectiveSpec selects the training objective independently of the dataset record schema.
+type FineTuneObjectiveSpec struct {
+	Type            string  `yaml:"type"`
+	Beta            float64 `yaml:"beta,omitempty"`
+	LossType        string  `yaml:"lossType,omitempty"`
+	MaxPromptLength int     `yaml:"maxPromptLength,omitempty"`
+
+	betaConfigured            bool
+	lossTypeConfigured        bool
+	maxPromptLengthConfigured bool
+}
+
+// HasDPOSettings reports whether DPO-only settings were explicitly configured or populated.
+func (o FineTuneObjectiveSpec) HasDPOSettings() bool {
+	return o.betaConfigured || o.lossTypeConfigured || o.maxPromptLengthConfigured ||
+		o.Beta != 0 || o.LossType != "" || o.MaxPromptLength != 0
 }
 
 type Dataset struct {
@@ -181,12 +204,20 @@ type FineTuneOutputSpec struct {
 }
 
 type rawFineTuneConfig struct {
-	APIVersion string                 `yaml:"apiVersion"`
-	Target     string                 `yaml:"target"`
-	BaseModel  string                 `yaml:"baseModel"`
-	Datasets   []Dataset              `yaml:"datasets"`
-	Config     *rawFineTuneConfigSpec `yaml:"config"`
-	Output     *rawFineTuneOutputSpec `yaml:"output"`
+	APIVersion string                    `yaml:"apiVersion"`
+	Target     string                    `yaml:"target"`
+	BaseModel  string                    `yaml:"baseModel"`
+	Objective  *rawFineTuneObjectiveSpec `yaml:"objective"`
+	Datasets   []Dataset                 `yaml:"datasets"`
+	Config     *rawFineTuneConfigSpec    `yaml:"config"`
+	Output     *rawFineTuneOutputSpec    `yaml:"output"`
+}
+
+type rawFineTuneObjectiveSpec struct {
+	Type            *string  `yaml:"type"`
+	Beta            *float64 `yaml:"beta"`
+	LossType        *string  `yaml:"lossType"`
+	MaxPromptLength *int     `yaml:"maxPromptLength"`
 }
 
 type rawFineTuneConfigSpec struct {
@@ -220,22 +251,51 @@ func (c rawFineTuneConfig) normalize() FineTuneConfig {
 	if c.Config != nil {
 		rawUnsloth = c.Config.Unsloth
 	}
+	objective := normalizeFineTuneObjective(c.Objective)
 
 	return FineTuneConfig{
 		APIVersion: c.APIVersion,
 		Target:     c.Target,
 		BaseModel:  c.BaseModel,
+		Objective:  objective,
 		Datasets:   c.Datasets,
 		Config: FineTuneConfigSpec{
-			Unsloth: normalizeUnslothConfig(rawUnsloth),
+			Unsloth: normalizeUnslothConfig(rawUnsloth, objective.Type),
 		},
 		Output: normalizeFineTuneOutput(c.Output),
 	}
 }
 
-func normalizeUnslothConfig(c *rawFineTuneConfigUnslothSpec) FineTuneConfigUnslothSpec {
+func normalizeFineTuneObjective(c *rawFineTuneObjectiveSpec) FineTuneObjectiveSpec {
+	if c == nil {
+		return FineTuneObjectiveSpec{Type: utils.ObjectiveSFT}
+	}
+
+	objectiveType := valueOrDefault(c.Type, utils.ObjectiveSFT)
+	objective := FineTuneObjectiveSpec{
+		Type:                      objectiveType,
+		Beta:                      valueOrDefault(c.Beta, 0),
+		LossType:                  valueOrDefault(c.LossType, ""),
+		MaxPromptLength:           valueOrDefault(c.MaxPromptLength, 0),
+		betaConfigured:            c.Beta != nil,
+		lossTypeConfigured:        c.LossType != nil,
+		maxPromptLengthConfigured: c.MaxPromptLength != nil,
+	}
+	if objectiveType == utils.ObjectiveDPO {
+		objective.Beta = valueOrDefault(c.Beta, defaultDPOBeta)
+		objective.LossType = valueOrDefault(c.LossType, defaultDPOLossType)
+		objective.MaxPromptLength = valueOrDefault(c.MaxPromptLength, defaultDPOMaxPromptLength)
+	}
+	return objective
+}
+
+func normalizeUnslothConfig(c *rawFineTuneConfigUnslothSpec, objectiveType string) FineTuneConfigUnslothSpec {
 	if c == nil {
 		c = &rawFineTuneConfigUnslothSpec{}
+	}
+	learningRate := defaultSFTLearningRate
+	if objectiveType == utils.ObjectiveDPO {
+		learningRate = defaultDPOLearningRate
 	}
 	return FineTuneConfigUnslothSpec{
 		Packing:                   valueOrDefault(c.Packing, false),
@@ -246,7 +306,7 @@ func normalizeUnslothConfig(c *rawFineTuneConfigUnslothSpec) FineTuneConfigUnslo
 		GradientAccumulationSteps: valueOrDefault(c.GradientAccumulationSteps, defaultGradientAccumulationSteps),
 		WarmupSteps:               valueOrDefault(c.WarmupSteps, defaultWarmupSteps),
 		MaxSteps:                  valueOrDefault(c.MaxSteps, defaultMaxSteps),
-		LearningRate:              valueOrDefault(c.LearningRate, defaultLearningRate),
+		LearningRate:              valueOrDefault(c.LearningRate, learningRate),
 		LoggingSteps:              valueOrDefault(c.LoggingSteps, defaultLoggingSteps),
 		Optimizer:                 valueOrDefault(c.Optimizer, defaultOptimizer),
 		WeightDecay:               valueOrDefault(c.WeightDecay, defaultWeightDecay),

--- a/pkg/aikit/config/specs_test.go
+++ b/pkg/aikit/config/specs_test.go
@@ -393,3 +393,51 @@ datasets:
 		t.Fatalf("loader split = %q, want train", got)
 	}
 }
+
+func TestNewFromBytesPreservesMultipleDatasetOrderAndLoaders(t *testing.T) {
+	input := []byte(`
+apiVersion: v1alpha1
+baseModel: test-model
+datasets:
+  - source: organization/first
+    type: text
+    loader:
+      type: huggingface
+      split: train
+      revision: 0123456789abcdef0123456789abcdef01234567
+  - source: https://example.test/second.parquet
+    type: prompt-completion
+    loader:
+      type: parquet
+      split: validation
+      checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+`)
+
+	_, fineTuneConfig, err := NewFromBytes(input)
+	if err != nil {
+		t.Fatalf("NewFromBytes() error = %v", err)
+	}
+	want := []Dataset{
+		{
+			Source: "organization/first",
+			Type:   utils.DatasetText,
+			Loader: &DatasetLoaderSpec{
+				Type:     utils.DatasetLoaderHuggingFace,
+				Split:    "train",
+				Revision: "0123456789abcdef0123456789abcdef01234567",
+			},
+		},
+		{
+			Source: "https://example.test/second.parquet",
+			Type:   utils.DatasetPromptCompletion,
+			Loader: &DatasetLoaderSpec{
+				Type:     utils.DatasetLoaderParquet,
+				Split:    "validation",
+				Checksum: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+		},
+	}
+	if !reflect.DeepEqual(fineTuneConfig.Datasets, want) {
+		t.Fatalf("datasets = %#v, want %#v", fineTuneConfig.Datasets, want)
+	}
+}

--- a/pkg/aikit/config/specs_test.go
+++ b/pkg/aikit/config/specs_test.go
@@ -97,6 +97,7 @@ func TestNewFromBytesNormalizesFineTuneDefaults(t *testing.T) {
 		Seed:                      42,
 	}
 	wantOutput := FineTuneOutputSpec{Quantize: "q4_k_m", Name: "aikit-model"}
+	wantObjective := FineTuneObjectiveSpec{Type: utils.ObjectiveSFT}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -116,8 +117,118 @@ func TestNewFromBytesNormalizesFineTuneDefaults(t *testing.T) {
 			if !reflect.DeepEqual(fineTuneConfig.Config.Unsloth, wantUnsloth) {
 				t.Errorf("unsloth config = %#v, want %#v", fineTuneConfig.Config.Unsloth, wantUnsloth)
 			}
+			if fineTuneConfig.Objective != wantObjective {
+				t.Errorf("objective = %#v, want %#v", fineTuneConfig.Objective, wantObjective)
+			}
 			if !reflect.DeepEqual(fineTuneConfig.Output, wantOutput) {
 				t.Errorf("output config = %#v, want %#v", fineTuneConfig.Output, wantOutput)
+			}
+		})
+	}
+}
+
+func TestNewFromBytesNormalizesFineTuneObjectives(t *testing.T) {
+	tests := []struct {
+		name               string
+		objectiveYAML      string
+		learningRateYAML   string
+		wantObjective      FineTuneObjectiveSpec
+		wantLearningRate   float64
+		wantHasDPOSettings bool
+	}{
+		{
+			name:             "omitted defaults to SFT",
+			wantObjective:    FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
+			wantLearningRate: defaultSFTLearningRate,
+		},
+		{
+			name:             "null defaults to SFT",
+			objectiveYAML:    "objective: null\n",
+			wantObjective:    FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
+			wantLearningRate: defaultSFTLearningRate,
+		},
+		{
+			name:             "empty defaults to SFT",
+			objectiveYAML:    "objective: {}\n",
+			wantObjective:    FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
+			wantLearningRate: defaultSFTLearningRate,
+		},
+		{
+			name:             "explicit SFT",
+			objectiveYAML:    "objective:\n  type: sft\n",
+			wantObjective:    FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
+			wantLearningRate: defaultSFTLearningRate,
+		},
+		{
+			name:          "DPO defaults",
+			objectiveYAML: "objective:\n  type: dpo\n",
+			wantObjective: FineTuneObjectiveSpec{
+				Type: utils.ObjectiveDPO, Beta: defaultDPOBeta, LossType: defaultDPOLossType, MaxPromptLength: defaultDPOMaxPromptLength,
+			},
+			wantLearningRate:   defaultDPOLearningRate,
+			wantHasDPOSettings: true,
+		},
+		{
+			name:          "explicit DPO values",
+			objectiveYAML: "objective:\n  type: dpo\n  beta: 0.25\n  lossType: sigmoid\n  maxPromptLength: 128\n",
+			wantObjective: FineTuneObjectiveSpec{
+				Type: utils.ObjectiveDPO, Beta: 0.25, LossType: utils.DPOLossSigmoid, MaxPromptLength: 128,
+				betaConfigured: true, lossTypeConfigured: true, maxPromptLengthConfigured: true,
+			},
+			wantLearningRate:   defaultDPOLearningRate,
+			wantHasDPOSettings: true,
+		},
+		{
+			name:             "explicit DPO learning rate",
+			objectiveYAML:    "objective:\n  type: dpo\n",
+			learningRateYAML: "    learningRate: 0.00003\n",
+			wantObjective: FineTuneObjectiveSpec{
+				Type: utils.ObjectiveDPO, Beta: defaultDPOBeta, LossType: defaultDPOLossType, MaxPromptLength: defaultDPOMaxPromptLength,
+			},
+			wantLearningRate:   0.00003,
+			wantHasDPOSettings: true,
+		},
+		{
+			name:          "explicit invalid DPO zero values are preserved",
+			objectiveYAML: "objective:\n  type: dpo\n  beta: 0\n  lossType: \"\"\n  maxPromptLength: 0\n",
+			wantObjective: FineTuneObjectiveSpec{
+				Type: utils.ObjectiveDPO, betaConfigured: true, lossTypeConfigured: true, maxPromptLengthConfigured: true,
+			},
+			wantLearningRate:   defaultDPOLearningRate,
+			wantHasDPOSettings: true,
+		},
+		{
+			name:               "SFT DPO field presence is retained for validation",
+			objectiveYAML:      "objective:\n  type: sft\n  beta: 0\n",
+			wantObjective:      FineTuneObjectiveSpec{Type: utils.ObjectiveSFT, betaConfigured: true},
+			wantLearningRate:   defaultSFTLearningRate,
+			wantHasDPOSettings: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "apiVersion: v1alpha1\n" +
+				"baseModel: test-model\n" +
+				tt.objectiveYAML +
+				"datasets:\n" +
+				"  - source: test-dataset\n" +
+				"    type: alpaca\n" +
+				"config:\n" +
+				"  unsloth:\n" +
+				tt.learningRateYAML
+			_, fineTuneConfig, err := NewFromBytes([]byte(input))
+			if err != nil {
+				t.Fatalf("NewFromBytes() error = %v", err)
+			}
+			if fineTuneConfig.Objective != tt.wantObjective {
+				t.Errorf("objective = %#v, want %#v", fineTuneConfig.Objective, tt.wantObjective)
+			}
+			if got := fineTuneConfig.Config.Unsloth.LearningRate; got != tt.wantLearningRate {
+				t.Errorf("learning rate = %g, want %g", got, tt.wantLearningRate)
+			}
+			if got := fineTuneConfig.Objective.HasDPOSettings(); got != tt.wantHasDPOSettings {
+				t.Errorf("HasDPOSettings() = %t, want %t", got, tt.wantHasDPOSettings)
 			}
 		})
 	}

--- a/pkg/aikit2llb/finetune/convert.go
+++ b/pkg/aikit2llb/finetune/convert.go
@@ -36,9 +36,10 @@ const (
 var immutableNVIDIACDIDevicePattern = regexp.MustCompile(`^nvidia\.com/gpu=(?:GPU|MIG)-[A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}$`)
 
 type unslothTrainingConfig struct {
-	BaseModel string                    `yaml:"baseModel"`
-	Datasets  []config.Dataset          `yaml:"datasets"`
-	Config    config.FineTuneConfigSpec `yaml:"config"`
+	BaseModel string                        `yaml:"baseModel"`
+	Objective *config.FineTuneObjectiveSpec `yaml:"objective,omitempty"`
+	Datasets  []config.Dataset              `yaml:"datasets"`
+	Config    config.FineTuneConfigSpec     `yaml:"config"`
 }
 
 type unslothExportConfig struct {
@@ -114,6 +115,7 @@ func Aikit2LLB(c *config.FineTuneConfig, opts Options) (llb.State, error) {
 	scriptState := llb.Scratch().File(llb.Mkfile("/target_unsloth.py", 0o755, finetunescript.TargetUnsloth))
 	trainingConfig := unslothTrainingConfig{
 		BaseModel: c.BaseModel,
+		Objective: trainingObjective(c.Objective),
 		Datasets:  c.Datasets,
 		Config:    c.Config,
 	}
@@ -132,6 +134,13 @@ func Aikit2LLB(c *config.FineTuneConfig, opts Options) (llb.State, error) {
 	copyOpts := []llb.CopyOption{&llb.CopyInfo{AllowWildcard: true}}
 	outputFile := fmt.Sprintf("%s-%s.gguf", c.Output.Name, c.Output.Quantize)
 	return llb.Scratch().File(llb.Copy(state, inputFile, outputFile, copyOpts...)), nil
+}
+
+func trainingObjective(objective config.FineTuneObjectiveSpec) *config.FineTuneObjectiveSpec {
+	if objective.Type != utils.ObjectiveDPO {
+		return nil
+	}
+	return &objective
 }
 
 func gpuCacheKey(opts Options) string {

--- a/pkg/aikit2llb/finetune/convert_test.go
+++ b/pkg/aikit2llb/finetune/convert_test.go
@@ -570,6 +570,7 @@ func fineTuneTestConfig() *config.FineTuneConfig {
 		APIVersion: utils.APIv1alpha1,
 		Target:     utils.TargetUnsloth,
 		BaseModel:  "base-model",
+		Objective:  config.FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
 		Config: config.FineTuneConfigSpec{
 			Unsloth: config.FineTuneConfigUnslothSpec{
 				MaxSeqLength:              2048,
@@ -583,6 +584,22 @@ func fineTuneTestConfig() *config.FineTuneConfig {
 		},
 		Output: config.FineTuneOutputSpec{Name: "output", Quantize: "q4_k_m"},
 	}
+}
+
+func fineTuneDPOTestConfig() *config.FineTuneConfig {
+	cfg := fineTuneTestConfig()
+	cfg.Objective = config.FineTuneObjectiveSpec{
+		Type:            utils.ObjectiveDPO,
+		Beta:            0.1,
+		LossType:        utils.DPOLossSigmoid,
+		MaxPromptLength: 512,
+	}
+	cfg.Datasets = []config.Dataset{{
+		Source: "organization/preferences",
+		Type:   utils.DatasetPreference,
+	}}
+	cfg.Config.Unsloth.LearningRate = 0.000001
+	return cfg
 }
 
 func marshalFineTuneDefinition(t *testing.T, cfg *config.FineTuneConfig) *llb.Definition {
@@ -705,6 +722,116 @@ func cloneFineTuneDefinition(definition [][]byte) [][]byte {
 		cloned[i] = slices.Clone(data)
 	}
 	return cloned
+}
+
+func TestAikit2LLBPropagatesDPOObjective(t *testing.T) {
+	cfg := fineTuneDPOTestConfig()
+	ops := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, cfg))
+	_, trainingConfigFile := findFineTuneFile(t, ops, "/train-config.yaml")
+	wantTrainingConfig := mustMarshalYAML(unslothTrainingConfig{
+		BaseModel: cfg.BaseModel,
+		Objective: trainingObjective(cfg.Objective),
+		Datasets:  cfg.Datasets,
+		Config:    cfg.Config,
+	})
+	if !slices.Equal(trainingConfigFile.Data, wantTrainingConfig) {
+		t.Fatalf("training config = %q, want %q", string(trainingConfigFile.Data), string(wantTrainingConfig))
+	}
+	for _, fragment := range []string{
+		"objective:\n",
+		"  type: dpo\n",
+		"  beta: 0.1\n",
+		"  lossType: sigmoid\n",
+		"  maxPromptLength: 512\n",
+		"  type: preference\n",
+		"    learningRate: 1e-06\n",
+	} {
+		if !strings.Contains(string(trainingConfigFile.Data), fragment) {
+			t.Errorf("training config does not contain %q: %q", fragment, trainingConfigFile.Data)
+		}
+	}
+
+	_, exportConfigFile := findFineTuneFile(t, ops, "/export-config.yaml")
+	if strings.Contains(string(exportConfigFile.Data), "objective:") || strings.Contains(string(exportConfigFile.Data), "beta:") {
+		t.Fatalf("export config unexpectedly contains DPO objective settings: %q", exportConfigFile.Data)
+	}
+}
+
+func TestAikit2LLBDPOObjectiveChangesInvalidateTrainingOnlyAfterDependencies(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*config.FineTuneConfig)
+	}{
+		{
+			name: "type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective = config.FineTuneObjectiveSpec{Type: utils.ObjectiveSFT}
+			},
+		},
+		{
+			name: "beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = 0.2
+			},
+		},
+		{
+			name: "loss type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.LossType = "future-loss"
+			},
+		},
+		{
+			name: "max prompt length",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.MaxPromptLength = 256
+			},
+		},
+	}
+
+	baseCfg := fineTuneDPOTestConfig()
+	baseOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, baseCfg))
+	baseDependency := findFineTuneExec(t, baseOps, "uv pip sync")
+	baseTraining := findFineTuneExec(t, baseOps, "target_unsloth.py train")
+	baseExport := findFineTuneExec(t, baseOps, "target_unsloth.py export")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changedCfg := fineTuneDPOTestConfig()
+			tt.mutate(changedCfg)
+			changedOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, changedCfg))
+			if got := findFineTuneExec(t, changedOps, "uv pip sync").digest; got != baseDependency.digest {
+				t.Fatalf("objective change invalidated dependency installation: got %s, want %s", got, baseDependency.digest)
+			}
+			if got := findFineTuneExec(t, changedOps, "target_unsloth.py train").digest; got == baseTraining.digest {
+				t.Fatalf("objective change did not invalidate training: %s", got)
+			}
+			if got := findFineTuneExec(t, changedOps, "target_unsloth.py export").digest; got == baseExport.digest {
+				t.Fatalf("objective change did not invalidate export: %s", got)
+			}
+		})
+	}
+}
+
+func TestAikit2LLBOmittedAndExplicitSFTObjectivesShareCacheDefinition(t *testing.T) {
+	explicitCfg := fineTuneTestConfig()
+	omittedCfg := fineTuneTestConfig()
+	omittedCfg.Objective = config.FineTuneObjectiveSpec{}
+
+	explicitOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, explicitCfg))
+	omittedOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, omittedCfg))
+	_, explicitTrainingConfig := findFineTuneFile(t, explicitOps, "/train-config.yaml")
+	_, omittedTrainingConfig := findFineTuneFile(t, omittedOps, "/train-config.yaml")
+	if !slices.Equal(explicitTrainingConfig.Data, omittedTrainingConfig.Data) {
+		t.Fatalf("omitted and explicit SFT training configs differ: %q != %q", omittedTrainingConfig.Data, explicitTrainingConfig.Data)
+	}
+	if strings.Contains(string(explicitTrainingConfig.Data), "objective:") {
+		t.Fatalf("default SFT training config unexpectedly contains objective: %q", explicitTrainingConfig.Data)
+	}
+	for _, phase := range []string{"uv pip sync", "target_unsloth.py train", "target_unsloth.py export"} {
+		if got, want := findFineTuneExec(t, omittedOps, phase).digest, findFineTuneExec(t, explicitOps, phase).digest; got != want {
+			t.Fatalf("omitted and explicit SFT produced different %s digests: got %s, want %s", phase, got, want)
+		}
+	}
 }
 
 func TestAikit2LLBPropagatesDatasetLoader(t *testing.T) {

--- a/pkg/aikit2llb/finetune/convert_test.go
+++ b/pkg/aikit2llb/finetune/convert_test.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	testImmutableCDIDevice  = "nvidia.com/gpu=GPU-4f684ff2-f5d1-8b33-decf-42fac828778c"
-	testNVIDIADriverVersion = "590.48.01"
-	testSessionA            = "session-a"
-	testSessionB            = "session-b"
-	testDatasetSource       = "test-dataset"
-	testHubDatasetSource    = "organization/dataset"
-	testDatasetLoaderSplit  = "train"
+	testImmutableCDIDevice    = "nvidia.com/gpu=GPU-4f684ff2-f5d1-8b33-decf-42fac828778c"
+	testNVIDIADriverVersion   = "590.48.01"
+	testSessionA              = "session-a"
+	testSessionB              = "session-b"
+	testDatasetSource         = "test-dataset"
+	testHubDatasetSource      = "organization/dataset"
+	testDatasetLoaderSplit    = "train"
+	testDatasetLoaderSFTSplit = "train_sft"
 )
 
 type fineTuneDefinitionOp struct {
@@ -715,7 +716,7 @@ func TestAikit2LLBPropagatesDatasetLoader(t *testing.T) {
 		Loader: &config.DatasetLoaderSpec{
 			Type:     utils.DatasetLoaderHuggingFace,
 			Subset:   "default",
-			Split:    "train_sft",
+			Split:    testDatasetLoaderSFTSplit,
 			Revision: revision,
 		},
 	}}
@@ -840,6 +841,147 @@ func TestAikit2LLBDatasetLoaderChangesInvalidateTrainingOnlyAfterDependencies(t 
 				t.Fatalf("loader %s change did not invalidate export: %s", tt.name, got)
 			}
 		})
+	}
+}
+
+func TestAikit2LLBMultipleDatasetsPreserveOrderAndCacheIdentity(t *testing.T) {
+	const (
+		revisionA = "0123456789abcdef0123456789abcdef01234567"
+		revisionB = "89abcdef0123456789abcdef0123456789abcdef"
+	)
+
+	firstDataset := config.Dataset{
+		Source: "organization/first",
+		Type:   utils.DatasetText,
+		Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Split: "train", Revision: revisionA},
+	}
+	secondDataset := config.Dataset{
+		Source: "organization/second",
+		Type:   utils.DatasetMessages,
+		Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Subset: "default", Split: testDatasetLoaderSFTSplit, Revision: revisionA},
+	}
+
+	baseCfg := fineTuneTestConfig()
+	baseCfg.Datasets = []config.Dataset{firstDataset, secondDataset}
+	baseOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, baseCfg))
+	_, trainingConfigFile := findFineTuneFile(t, baseOps, "/train-config.yaml")
+	wantTrainingConfig := mustMarshalYAML(unslothTrainingConfig{
+		BaseModel: baseCfg.BaseModel,
+		Datasets:  baseCfg.Datasets,
+		Config:    baseCfg.Config,
+	})
+	if !slices.Equal(trainingConfigFile.Data, wantTrainingConfig) {
+		t.Fatalf("training config = %q, want %q", string(trainingConfigFile.Data), string(wantTrainingConfig))
+	}
+	trainingConfigText := string(trainingConfigFile.Data)
+	firstIndex := strings.Index(trainingConfigText, "source: organization/first")
+	secondIndex := strings.Index(trainingConfigText, "source: organization/second")
+	if firstIndex < 0 || secondIndex < 0 || firstIndex >= secondIndex {
+		t.Fatalf("training config did not preserve dataset order: %q", trainingConfigText)
+	}
+	for _, fragment := range []string{"subset: default", "split: train_sft", "revision: " + revisionA} {
+		if !strings.Contains(trainingConfigText, fragment) {
+			t.Fatalf("training config does not contain second dataset loader fragment %q: %q", fragment, trainingConfigText)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		datasets []config.Dataset
+	}{
+		{
+			name: "second source",
+			datasets: []config.Dataset{firstDataset, {
+				Source: "organization/changed",
+				Type:   secondDataset.Type,
+				Loader: secondDataset.Loader,
+			}},
+		},
+		{
+			name: "second type",
+			datasets: []config.Dataset{firstDataset, {
+				Source: secondDataset.Source,
+				Type:   utils.DatasetShareGPT,
+				Loader: secondDataset.Loader,
+			}},
+		},
+		{
+			name: "second split",
+			datasets: []config.Dataset{firstDataset, {
+				Source: secondDataset.Source,
+				Type:   secondDataset.Type,
+				Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Subset: "default", Split: "validation", Revision: revisionA},
+			}},
+		},
+		{
+			name: "second subset",
+			datasets: []config.Dataset{firstDataset, {
+				Source: secondDataset.Source,
+				Type:   secondDataset.Type,
+				Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Subset: "alternate", Split: testDatasetLoaderSFTSplit, Revision: revisionA},
+			}},
+		},
+		{
+			name: "second revision",
+			datasets: []config.Dataset{firstDataset, {
+				Source: secondDataset.Source,
+				Type:   secondDataset.Type,
+				Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Subset: "default", Split: testDatasetLoaderSFTSplit, Revision: revisionB},
+			}},
+		},
+		{
+			name:     "reordered",
+			datasets: []config.Dataset{secondDataset, firstDataset},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changedCfg := fineTuneTestConfig()
+			changedCfg.Datasets = tt.datasets
+			changedOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, changedCfg))
+			if got, want := findFineTuneExec(t, changedOps, "uv pip sync").digest, findFineTuneExec(t, baseOps, "uv pip sync").digest; got != want {
+				t.Fatalf("%s change invalidated dependency installation: got %s, want %s", tt.name, got, want)
+			}
+			if got, want := findFineTuneExec(t, changedOps, "target_unsloth.py train").digest, findFineTuneExec(t, baseOps, "target_unsloth.py train").digest; got == want {
+				t.Fatalf("%s change did not invalidate training: %s", tt.name, got)
+			}
+			if got, want := findFineTuneExec(t, changedOps, "target_unsloth.py export").digest, findFineTuneExec(t, baseOps, "target_unsloth.py export").digest; got == want {
+				t.Fatalf("%s change did not invalidate export: %s", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestAikit2LLBSecondDatasetChecksumChangesTrainingAfterDependencies(t *testing.T) {
+	const (
+		checksumA = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		checksumB = "sha256:89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+	)
+
+	makeConfig := func(checksum string) *config.FineTuneConfig {
+		cfg := fineTuneTestConfig()
+		cfg.Datasets = []config.Dataset{
+			{Source: "organization/first", Type: utils.DatasetPromptCompletion},
+			{
+				Source: "https://example.test/second.parquet",
+				Type:   utils.DatasetPromptCompletion,
+				Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderParquet, Split: "train", Checksum: checksum},
+			},
+		}
+		return cfg
+	}
+
+	beforeOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, makeConfig(checksumA)))
+	afterOps := decodeFineTuneDefinition(t, marshalFineTuneDefinition(t, makeConfig(checksumB)))
+	if got, want := findFineTuneExec(t, beforeOps, "uv pip sync").digest, findFineTuneExec(t, afterOps, "uv pip sync").digest; got != want {
+		t.Fatalf("second checksum change invalidated dependency installation: got %s, want %s", got, want)
+	}
+	if got, want := findFineTuneExec(t, beforeOps, "target_unsloth.py train").digest, findFineTuneExec(t, afterOps, "target_unsloth.py train").digest; got == want {
+		t.Fatalf("second checksum change did not invalidate training: %s", got)
+	}
+	if got, want := findFineTuneExec(t, beforeOps, "target_unsloth.py export").digest, findFineTuneExec(t, afterOps, "target_unsloth.py export").digest; got == want {
+		t.Fatalf("second checksum change did not invalidate export: %s", got)
 	}
 }
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -440,18 +440,14 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 		return errors.New("no datasets defined")
 	}
 
-	if len(c.Datasets) > 1 {
-		return errors.New("only one dataset is supported at this time")
-	}
-
 	for datasetIndex, dataset := range c.Datasets {
 		if strings.TrimSpace(dataset.Source) == "" {
-			return errors.New("dataset source is not defined")
+			return errors.Errorf("datasets[%d].source is not defined", datasetIndex)
 		}
 		switch dataset.Type {
 		case utils.DatasetAlpaca, utils.DatasetMessages, utils.DatasetPromptCompletion, utils.DatasetShareGPT, utils.DatasetText:
 		default:
-			return errors.Errorf("dataset type %s is not supported", dataset.Type)
+			return errors.Errorf("datasets[%d].type %s is not supported", datasetIndex, dataset.Type)
 		}
 		if err := validateDatasetLoader(datasetIndex, dataset); err != nil {
 			return err
@@ -465,15 +461,11 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 	if unsloth.Loss != utils.SFTLossAll && unsloth.Loss != utils.SFTLossResponse {
 		return errors.Errorf("config.unsloth.loss %s is not supported", unsloth.Loss)
 	}
-	if unsloth.Loss == utils.SFTLossResponse {
-		for _, dataset := range c.Datasets {
-			if dataset.Type != utils.DatasetMessages && dataset.Type != utils.DatasetShareGPT {
-				return errors.Errorf("config.unsloth.loss response is not supported for dataset type %s", dataset.Type)
-			}
-		}
-		if unsloth.Packing {
-			return errors.New("config.unsloth.loss response does not support packing because response masks must not cross conversation boundaries")
-		}
+	if err := validateSFTDatasetCompatibility(c.Datasets, unsloth.Loss); err != nil {
+		return err
+	}
+	if unsloth.Loss == utils.SFTLossResponse && unsloth.Packing {
+		return errors.New("config.unsloth.loss response does not support packing because response masks must not cross conversation boundaries")
 	}
 	if unsloth.MaxSeqLength <= 0 {
 		return errors.New("config.unsloth.maxSeqLength must be greater than zero")
@@ -528,6 +520,55 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 	}
 
 	return nil
+}
+
+type sftDatasetCompatibility string
+
+const (
+	sftCompatibilityFullSequence     sftDatasetCompatibility = "full-sequence"
+	sftCompatibilityPromptCompletion sftDatasetCompatibility = "completion-only"
+	sftCompatibilityResponseChat     sftDatasetCompatibility = "response-only chat"
+)
+
+func validateSFTDatasetCompatibility(datasets []config.Dataset, loss string) error {
+	firstCompatibility, err := sftDatasetCompatibilityFor(datasets[0].Type, loss)
+	if err != nil {
+		return errors.Errorf("datasets[0] type %s: %s", datasets[0].Type, err)
+	}
+
+	for datasetIndex := 1; datasetIndex < len(datasets); datasetIndex++ {
+		dataset := datasets[datasetIndex]
+		compatibility, compatibilityErr := sftDatasetCompatibilityFor(dataset.Type, loss)
+		if compatibilityErr != nil {
+			return errors.Errorf("datasets[%d] type %s: %s", datasetIndex, dataset.Type, compatibilityErr)
+		}
+		if compatibility != firstCompatibility {
+			return errors.Errorf(
+				"datasets[%d] type %s is incompatible with datasets[0] type %s: %s and %s datasets cannot be combined",
+				datasetIndex,
+				dataset.Type,
+				datasets[0].Type,
+				compatibility,
+				firstCompatibility,
+			)
+		}
+	}
+
+	return nil
+}
+
+func sftDatasetCompatibilityFor(datasetType, loss string) (sftDatasetCompatibility, error) {
+	if loss == utils.SFTLossResponse {
+		if datasetType != utils.DatasetMessages && datasetType != utils.DatasetShareGPT {
+			return "", errors.New("config.unsloth.loss response is supported only for messages and sharegpt datasets")
+		}
+		return sftCompatibilityResponseChat, nil
+	}
+
+	if datasetType == utils.DatasetPromptCompletion {
+		return sftCompatibilityPromptCompletion, nil
+	}
+	return sftCompatibilityFullSequence, nil
 }
 
 func validateDatasetLoader(datasetIndex int, dataset config.Dataset) error {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -436,6 +436,13 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 		return errors.New("baseModel is not defined")
 	}
 
+	if strings.TrimSpace(c.Objective.Type) == "" {
+		return errors.New("objective.type is not defined")
+	}
+	if c.Objective.Type != utils.ObjectiveSFT && c.Objective.Type != utils.ObjectiveDPO {
+		return errors.Errorf("objective.type %s is not supported", c.Objective.Type)
+	}
+
 	if len(c.Datasets) == 0 {
 		return errors.New("no datasets defined")
 	}
@@ -445,7 +452,7 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 			return errors.Errorf("datasets[%d].source is not defined", datasetIndex)
 		}
 		switch dataset.Type {
-		case utils.DatasetAlpaca, utils.DatasetMessages, utils.DatasetPromptCompletion, utils.DatasetShareGPT, utils.DatasetText:
+		case utils.DatasetAlpaca, utils.DatasetMessages, utils.DatasetPreference, utils.DatasetPromptCompletion, utils.DatasetShareGPT, utils.DatasetText:
 		default:
 			return errors.Errorf("datasets[%d].type %s is not supported", datasetIndex, dataset.Type)
 		}
@@ -461,15 +468,64 @@ func validateFinetuneConfig(c *config.FineTuneConfig) error {
 	if unsloth.Loss != utils.SFTLossAll && unsloth.Loss != utils.SFTLossResponse {
 		return errors.Errorf("config.unsloth.loss %s is not supported", unsloth.Loss)
 	}
-	if err := validateSFTDatasetCompatibility(c.Datasets, unsloth.Loss); err != nil {
-		return err
-	}
-	if unsloth.Loss == utils.SFTLossResponse && unsloth.Packing {
-		return errors.New("config.unsloth.loss response does not support packing because response masks must not cross conversation boundaries")
-	}
 	if unsloth.MaxSeqLength <= 0 {
 		return errors.New("config.unsloth.maxSeqLength must be greater than zero")
 	}
+
+	switch c.Objective.Type {
+	case utils.ObjectiveSFT:
+		if c.Objective.HasDPOSettings() {
+			return errors.New("objective beta, lossType, and maxPromptLength are supported only for objective type dpo")
+		}
+		for datasetIndex, dataset := range c.Datasets {
+			if dataset.Type != utils.DatasetPreference {
+				continue
+			}
+			if datasetIndex == 0 {
+				return errors.New("dataset type preference is supported only for objective type dpo")
+			}
+			return errors.Errorf("datasets[%d].type preference is not supported", datasetIndex)
+		}
+		if err := validateSFTDatasetCompatibility(c.Datasets, unsloth.Loss); err != nil {
+			return err
+		}
+		if unsloth.Loss == utils.SFTLossResponse && unsloth.Packing {
+			return errors.New("config.unsloth.loss response does not support packing because response masks must not cross conversation boundaries")
+		}
+	case utils.ObjectiveDPO:
+		if len(c.Datasets) != 1 {
+			return errors.New("objective type dpo requires exactly one dataset")
+		}
+		dataset := c.Datasets[0]
+		if dataset.Type != utils.DatasetPreference {
+			return errors.Errorf("objective type dpo requires dataset type preference, got %s", dataset.Type)
+		}
+		if dataset.Loader != nil && dataset.Loader.Type == utils.DatasetLoaderText {
+			return errors.New("dataset type preference does not support loader type text because DPO requires prompt, chosen, and rejected columns")
+		}
+		if unsloth.Loss == utils.SFTLossResponse {
+			return errors.New("config.unsloth.loss response is an SFT-only setting and is not supported for objective type dpo")
+		}
+		if unsloth.Packing {
+			return errors.New("objective type dpo does not support config.unsloth.packing")
+		}
+		if c.Objective.Beta <= 0 || math.IsNaN(c.Objective.Beta) || math.IsInf(c.Objective.Beta, 0) {
+			return errors.New("objective.beta must be a finite value greater than zero")
+		}
+		if strings.TrimSpace(c.Objective.LossType) == "" {
+			return errors.New("objective.lossType is not defined")
+		}
+		if c.Objective.LossType != utils.DPOLossSigmoid {
+			return errors.Errorf("objective.lossType %s is not supported", c.Objective.LossType)
+		}
+		if c.Objective.MaxPromptLength <= 0 {
+			return errors.New("objective.maxPromptLength must be greater than zero")
+		}
+		if c.Objective.MaxPromptLength > unsloth.MaxSeqLength {
+			return errors.New("objective.maxPromptLength must not exceed config.unsloth.maxSeqLength")
+		}
+	}
+
 	if unsloth.BatchSize <= 0 {
 		return errors.New("config.unsloth.batchSize must be greater than zero")
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -11,6 +11,14 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	testHTTPSPrefix       = "https://"
+	testMutableHubWarning = "datasets[0] Hugging Face dataset has no revision; its content is not reproducibly pinned"
+	testURLFragment       = "fragment"
+	testURLToken          = "token"
+	testURLValue          = "value"
+)
+
 func Test_validateConfig(t *testing.T) {
 	type args struct {
 		c *config.InferenceConfig
@@ -292,7 +300,11 @@ func Test_validateBackendPlatformCompatibility(t *testing.T) {
 }
 
 func Test_validateFineTuneConfig(t *testing.T) {
-	const invalidOutputNameError = "output name must be a safe filename containing only letters, numbers, dots, hyphens, or underscores"
+	const (
+		invalidOutputNameError = "output name must be a safe filename containing only letters, numbers, dots, hyphens, or underscores"
+		testMessagesSource     = "messages"
+		testTextSource         = "text"
+	)
 
 	tests := []struct {
 		name      string
@@ -376,25 +388,90 @@ func Test_validateFineTuneConfig(t *testing.T) {
 			wantErr: "no datasets defined",
 		},
 		{
-			name: "multiple datasets",
+			name: "valid multiple full-sequence datasets",
 			mutate: func(c *config.FineTuneConfig) {
-				c.Datasets = append(c.Datasets, config.Dataset{Source: "other", Type: "alpaca"})
+				c.Datasets = []config.Dataset{
+					{Source: "alpaca", Type: utils.DatasetAlpaca},
+					{Source: testTextSource, Type: utils.DatasetText},
+					{Source: testMessagesSource, Type: utils.DatasetMessages},
+					{Source: "sharegpt", Type: utils.DatasetShareGPT},
+				}
 			},
-			wantErr: "only one dataset is supported at this time",
+		},
+		{
+			name: "valid multiple prompt-completion datasets",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = []config.Dataset{
+					{Source: "first", Type: utils.DatasetPromptCompletion},
+					{Source: "second", Type: utils.DatasetPromptCompletion},
+				}
+			},
+		},
+		{
+			name: "valid multiple response-only chat datasets",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = []config.Dataset{
+					{Source: testMessagesSource, Type: utils.DatasetMessages},
+					{Source: "sharegpt", Type: utils.DatasetShareGPT},
+				}
+				c.Config.Unsloth.Loss = utils.SFTLossResponse
+			},
+		},
+		{
+			name: "incompatible later prompt-completion dataset",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = append(c.Datasets, config.Dataset{Source: "other", Type: utils.DatasetPromptCompletion})
+			},
+			wantErr: "datasets[1] type prompt-completion is incompatible with datasets[0] type alpaca: completion-only and full-sequence datasets cannot be combined",
+		},
+		{
+			name: "incompatible later full-sequence dataset",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = []config.Dataset{
+					{Source: "first", Type: utils.DatasetPromptCompletion},
+					{Source: "second", Type: utils.DatasetText},
+				}
+			},
+			wantErr: "datasets[1] type text is incompatible with datasets[0] type prompt-completion: full-sequence and completion-only datasets cannot be combined",
 		},
 		{
 			name: "missing dataset source",
 			mutate: func(c *config.FineTuneConfig) {
 				c.Datasets[0].Source = "\t"
 			},
-			wantErr: "dataset source is not defined",
+			wantErr: "datasets[0].source is not defined",
+		},
+		{
+			name: "missing later dataset source",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = append(c.Datasets, config.Dataset{Source: " ", Type: utils.DatasetText})
+			},
+			wantErr: "datasets[1].source is not defined",
 		},
 		{
 			name: "unsupported dataset type",
 			mutate: func(c *config.FineTuneConfig) {
 				c.Datasets[0].Type = "other"
 			},
-			wantErr: "dataset type other is not supported",
+			wantErr: "datasets[0].type other is not supported",
+		},
+		{
+			name: "unsupported later dataset type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = append(c.Datasets, config.Dataset{Source: "other", Type: "preference"})
+			},
+			wantErr: "datasets[1].type preference is not supported",
+		},
+		{
+			name: "invalid later dataset loader",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = append(c.Datasets, config.Dataset{
+					Source: "organization/text",
+					Type:   utils.DatasetText,
+					Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace},
+				})
+			},
+			wantErr: "datasets[1].loader.split is not defined",
 		},
 		{
 			name: "missing loss",
@@ -422,7 +499,7 @@ func Test_validateFineTuneConfig(t *testing.T) {
 			mutate: func(c *config.FineTuneConfig) {
 				c.Config.Unsloth.Loss = utils.SFTLossResponse
 			},
-			wantErr: "config.unsloth.loss response is not supported for dataset type alpaca",
+			wantErr: "datasets[0] type alpaca: config.unsloth.loss response is supported only for messages and sharegpt datasets",
 		},
 		{
 			name: "response loss with prompt-completion dataset",
@@ -430,7 +507,7 @@ func Test_validateFineTuneConfig(t *testing.T) {
 				c.Datasets[0].Type = utils.DatasetPromptCompletion
 				c.Config.Unsloth.Loss = utils.SFTLossResponse
 			},
-			wantErr: "config.unsloth.loss response is not supported for dataset type prompt-completion",
+			wantErr: "datasets[0] type prompt-completion: config.unsloth.loss response is supported only for messages and sharegpt datasets",
 		},
 		{
 			name: "response loss with text dataset",
@@ -438,7 +515,18 @@ func Test_validateFineTuneConfig(t *testing.T) {
 				c.Datasets[0].Type = utils.DatasetText
 				c.Config.Unsloth.Loss = utils.SFTLossResponse
 			},
-			wantErr: "config.unsloth.loss response is not supported for dataset type text",
+			wantErr: "datasets[0] type text: config.unsloth.loss response is supported only for messages and sharegpt datasets",
+		},
+		{
+			name: "response loss with later non-chat dataset",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = []config.Dataset{
+					{Source: testMessagesSource, Type: utils.DatasetMessages},
+					{Source: testTextSource, Type: utils.DatasetText},
+				}
+				c.Config.Unsloth.Loss = utils.SFTLossResponse
+			},
+			wantErr: "datasets[1] type text: config.unsloth.loss response is supported only for messages and sharegpt datasets",
 		},
 		{
 			name: "response loss with packing",
@@ -913,7 +1001,7 @@ func Test_validateDatasetLoader(t *testing.T) {
 			loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Split: testLoaderSplit, Subset: " \t"}, wantErr: "datasets[0].loader.subset must not be empty",
 		},
 		{
-			name: "huggingface URL", source: strings.Join([]string{"https://", "user-one", ":", "credential-one", "@example.test/data?token=", "value", "#fragment"}, ""),
+			name: "huggingface URL", source: strings.Join([]string{testHTTPSPrefix, "user-one", ":", "credential-one", "@example.test/data?token=", testURLValue, "#" + testURLFragment}, ""),
 			loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Split: testLoaderSplit}, wantErr: "type huggingface does not support an HTTP(S) source",
 		},
 		{
@@ -980,7 +1068,7 @@ func Test_validateDatasetLoader(t *testing.T) {
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("validateFinetuneConfig() error = %q, want substring %q", err, tt.wantErr)
 			}
-			for _, secret := range []string{"user-one", "credential-one", "token", "value", "fragment"} {
+			for _, secret := range []string{"user-one", "credential-one", testURLToken, testURLValue, testURLFragment} {
 				if strings.Contains(err.Error(), secret) {
 					t.Fatalf("validation error leaked URL detail %q: %q", secret, err)
 				}
@@ -996,7 +1084,7 @@ func Test_datasetReproducibilityWarnings(t *testing.T) {
 		revision             = "0123456789abcdef0123456789abcdef01234567"
 		checksum             = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	)
-	secretURL := strings.Join([]string{"https://", "user-two", ":", "credential-two", "@example.test/train.parquet?token=", "private-value", "#fragment"}, "")
+	secretURL := strings.Join([]string{testHTTPSPrefix, "user-two", ":", "credential-two", "@example.test/train.parquet?token=", "private-value", "#" + testURLFragment}, "")
 
 	tests := []struct {
 		name         string
@@ -1006,7 +1094,7 @@ func Test_datasetReproducibilityWarnings(t *testing.T) {
 		{
 			name:         "legacy hub",
 			dataset:      config.Dataset{Source: privateDatasetSource, Type: utils.DatasetAlpaca},
-			wantWarnings: []string{"datasets[0] Hugging Face dataset has no revision; its content is not reproducibly pinned"},
+			wantWarnings: []string{testMutableHubWarning},
 		},
 		{
 			name:         "legacy URL",
@@ -1016,7 +1104,7 @@ func Test_datasetReproducibilityWarnings(t *testing.T) {
 		{
 			name:         "mutable hub loader",
 			dataset:      config.Dataset{Source: privateDatasetSource, Type: utils.DatasetMessages, Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Split: testLoaderSplit}},
-			wantWarnings: []string{"datasets[0] Hugging Face dataset has no revision; its content is not reproducibly pinned"},
+			wantWarnings: []string{testMutableHubWarning},
 		},
 		{
 			name:         "mutable remote loader",
@@ -1044,12 +1132,45 @@ func Test_datasetReproducibilityWarnings(t *testing.T) {
 				t.Fatalf("warnings = %#v, want %#v", warnings, tt.wantWarnings)
 			}
 			for _, warning := range warnings {
-				for _, secret := range []string{privateDatasetSource, "example.test", "user-two", "credential-two", "token", "private-value", "fragment"} {
+				for _, secret := range []string{privateDatasetSource, "example.test", "user-two", "credential-two", testURLToken, "private-value", testURLFragment} {
 					if strings.Contains(warning, secret) {
 						t.Fatalf("warning leaked source detail %q: %q", secret, warning)
 					}
 				}
 			}
 		})
+	}
+}
+
+func Test_datasetReproducibilityWarningsCoverEveryDataset(t *testing.T) {
+	secretURL := strings.Join([]string{testHTTPSPrefix, "user", ":", "credential", "@example.test/second.json?token=", testURLValue, "#" + testURLFragment}, "")
+	fineTuneConfig := validFineTuneConfig()
+	fineTuneConfig.Datasets = []config.Dataset{
+		{
+			Source: "organization/first",
+			Type:   utils.DatasetText,
+			Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderHuggingFace, Split: "train"},
+		},
+		{
+			Source: secretURL,
+			Type:   utils.DatasetText,
+			Loader: &config.DatasetLoaderSpec{Type: utils.DatasetLoaderJSON, Split: "train"},
+		},
+	}
+
+	want := []string{
+		testMutableHubWarning,
+		"datasets[1] remote json dataset has no checksum; its content is not reproducibly pinned",
+	}
+	warnings := datasetReproducibilityWarnings(fineTuneConfig)
+	if !reflect.DeepEqual(warnings, want) {
+		t.Fatalf("warnings = %#v, want %#v", warnings, want)
+	}
+	for _, warning := range warnings {
+		for _, secret := range []string{"organization/first", "example.test", "user", "credential", testURLToken, testURLValue, testURLFragment} {
+			if strings.Contains(warning, secret) {
+				t.Fatalf("warning leaked source detail %q: %q", secret, warning)
+			}
+		}
 	}
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -736,6 +736,232 @@ func Test_validateFineTuneConfig(t *testing.T) {
 	}
 }
 
+func Test_validateDPOFineTuneConfig(t *testing.T) {
+	const (
+		revision       = "0123456789abcdef0123456789abcdef01234567"
+		checksum       = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		dpoLoaderSplit = "train"
+		betaError      = "objective.beta must be a finite value greater than zero"
+	)
+
+	tests := []struct {
+		name    string
+		mutate  func(*config.FineTuneConfig)
+		wantErr string
+	}{
+		{name: "valid defaults"},
+		{
+			name: "DPO rejects multiple preference datasets",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets = append(c.Datasets, c.Datasets[0])
+			},
+			wantErr: "objective type dpo requires exactly one dataset",
+		},
+		{
+			name: "valid pinned Hugging Face loader",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Loader = &config.DatasetLoaderSpec{
+					Type: utils.DatasetLoaderHuggingFace, Split: dpoLoaderSplit, Revision: revision,
+				}
+			},
+		},
+		{
+			name: "valid checksummed JSON loader",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Source = "https://example.test/preferences.jsonl"
+				c.Datasets[0].Loader = &config.DatasetLoaderSpec{
+					Type: utils.DatasetLoaderJSON, Split: dpoLoaderSplit, Checksum: checksum,
+				}
+			},
+		},
+		{
+			name: "missing objective type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Type = ""
+			},
+			wantErr: "objective.type is not defined",
+		},
+		{
+			name: "whitespace objective type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Type = " \t"
+			},
+			wantErr: "objective.type is not defined",
+		},
+		{
+			name: "unsupported objective type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Type = "orpo"
+			},
+			wantErr: "objective.type orpo is not supported",
+		},
+		{
+			name: "SFT rejects preference",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective = config.FineTuneObjectiveSpec{Type: utils.ObjectiveSFT}
+			},
+			wantErr: "dataset type preference is supported only for objective type dpo",
+		},
+		{
+			name: "SFT rejects DPO settings",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective = config.FineTuneObjectiveSpec{Type: utils.ObjectiveSFT, Beta: 0.1}
+				c.Datasets[0].Type = utils.DatasetAlpaca
+			},
+			wantErr: "objective beta, lossType, and maxPromptLength are supported only for objective type dpo",
+		},
+		{
+			name: "DPO rejects Alpaca",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Type = utils.DatasetAlpaca
+			},
+			wantErr: "objective type dpo requires dataset type preference, got alpaca",
+		},
+		{
+			name: "DPO rejects messages",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Type = utils.DatasetMessages
+			},
+			wantErr: "objective type dpo requires dataset type preference, got messages",
+		},
+		{
+			name: "DPO rejects ShareGPT",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Type = utils.DatasetShareGPT
+			},
+			wantErr: "objective type dpo requires dataset type preference, got sharegpt",
+		},
+		{
+			name: "DPO rejects prompt-completion",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Type = utils.DatasetPromptCompletion
+			},
+			wantErr: "objective type dpo requires dataset type preference, got prompt-completion",
+		},
+		{
+			name: "DPO rejects text",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Type = utils.DatasetText
+			},
+			wantErr: "objective type dpo requires dataset type preference, got text",
+		},
+		{
+			name: "DPO rejects text loader",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Datasets[0].Source = "https://example.test/preferences.txt"
+				c.Datasets[0].Loader = &config.DatasetLoaderSpec{Type: utils.DatasetLoaderText, Split: "train"}
+			},
+			wantErr: "dataset type preference does not support loader type text",
+		},
+		{
+			name: "DPO rejects response loss",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Config.Unsloth.Loss = utils.SFTLossResponse
+			},
+			wantErr: "config.unsloth.loss response is an SFT-only setting and is not supported for objective type dpo",
+		},
+		{
+			name: "DPO rejects packing",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Config.Unsloth.Packing = true
+			},
+			wantErr: "objective type dpo does not support config.unsloth.packing",
+		},
+		{
+			name: "zero beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = 0
+			},
+			wantErr: betaError,
+		},
+		{
+			name: "negative beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = -0.1
+			},
+			wantErr: betaError,
+		},
+		{
+			name: "NaN beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = math.NaN()
+			},
+			wantErr: betaError,
+		},
+		{
+			name: "positive infinity beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = math.Inf(1)
+			},
+			wantErr: betaError,
+		},
+		{
+			name: "negative infinity beta",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.Beta = math.Inf(-1)
+			},
+			wantErr: betaError,
+		},
+		{
+			name: "missing loss type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.LossType = ""
+			},
+			wantErr: "objective.lossType is not defined",
+		},
+		{
+			name: "unsupported loss type",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.LossType = "hinge"
+			},
+			wantErr: "objective.lossType hinge is not supported",
+		},
+		{
+			name: "zero max prompt length",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.MaxPromptLength = 0
+			},
+			wantErr: "objective.maxPromptLength must be greater than zero",
+		},
+		{
+			name: "negative max prompt length",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.MaxPromptLength = -1
+			},
+			wantErr: "objective.maxPromptLength must be greater than zero",
+		},
+		{
+			name: "max prompt length exceeds sequence length",
+			mutate: func(c *config.FineTuneConfig) {
+				c.Objective.MaxPromptLength = c.Config.Unsloth.MaxSeqLength + 1
+			},
+			wantErr: "objective.maxPromptLength must not exceed config.unsloth.maxSeqLength",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fineTuneConfig := validDPOFineTuneConfig()
+			if tt.mutate != nil {
+				tt.mutate(fineTuneConfig)
+			}
+			err := validateFinetuneConfig(fineTuneConfig)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateFinetuneConfig() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateFinetuneConfig() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateFinetuneConfig() error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_validateNormalizedFineTuneConfig(t *testing.T) {
 	datasetTypes := []string{utils.DatasetAlpaca, utils.DatasetMessages, utils.DatasetPromptCompletion, utils.DatasetShareGPT, utils.DatasetText}
 	for _, datasetType := range datasetTypes {
@@ -764,6 +990,43 @@ datasets:
 				t.Fatalf("validateFinetuneConfig() error = %v", err)
 			}
 		})
+	}
+}
+
+func Test_validateNormalizedDPOFineTuneConfig(t *testing.T) {
+	_, fineTuneConfig, err := config.NewFromBytes([]byte(`
+apiVersion: v1alpha1
+baseModel: unsloth/test-model
+objective:
+  type: dpo
+datasets:
+  - source: organization/preferences
+    type: preference
+config:
+  unsloth:
+    packing: false
+`))
+	if err != nil {
+		t.Fatalf("config.NewFromBytes() error = %v", err)
+	}
+	if fineTuneConfig == nil {
+		t.Fatal("config.NewFromBytes() returned no fine-tune config")
+	}
+	fineTuneConfig.Target = utils.TargetUnsloth
+
+	if got := fineTuneConfig.Objective; got != (config.FineTuneObjectiveSpec{
+		Type:            utils.ObjectiveDPO,
+		Beta:            0.1,
+		LossType:        utils.DPOLossSigmoid,
+		MaxPromptLength: 512,
+	}) {
+		t.Fatalf("objective = %#v, want normalized DPO defaults", got)
+	}
+	if got := fineTuneConfig.Config.Unsloth.LearningRate; got != 0.000001 {
+		t.Fatalf("learning rate = %g, want DPO default 0.000001", got)
+	}
+	if err := validateFinetuneConfig(fineTuneConfig); err != nil {
+		t.Fatalf("validateFinetuneConfig() error = %v", err)
 	}
 }
 
@@ -858,6 +1121,7 @@ func validFineTuneConfig() *config.FineTuneConfig {
 		APIVersion: "v1alpha1",
 		Target:     "unsloth",
 		BaseModel:  "unsloth/test-model",
+		Objective:  config.FineTuneObjectiveSpec{Type: utils.ObjectiveSFT},
 		Datasets: []config.Dataset{
 			{Source: "test-dataset", Type: "alpaca"},
 		},
@@ -883,6 +1147,19 @@ func validFineTuneConfig() *config.FineTuneConfig {
 			Name:     "aikit-model",
 		},
 	}
+}
+
+func validDPOFineTuneConfig() *config.FineTuneConfig {
+	c := validFineTuneConfig()
+	c.Objective = config.FineTuneObjectiveSpec{
+		Type:            utils.ObjectiveDPO,
+		Beta:            0.1,
+		LossType:        utils.DPOLossSigmoid,
+		MaxPromptLength: 512,
+	}
+	c.Datasets[0].Type = utils.DatasetPreference
+	c.Config.Unsloth.LearningRate = 0.000001
+	return c
 }
 
 func Test_parseFineTuneBuildOptions(t *testing.T) {

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -3089,10 +3089,15 @@ def validate_prompt_completion_tokenization(
     prompts: list[str] = []
     prompt_completions: list[str] = []
     effective_add_special_tokens = add_special_tokens
+    source_add_special_tokens = None
     fingerprint = empty_prompt_prefix_fingerprint()
 
     def validate_batch() -> None:
         nonlocal fingerprint
+        if source_add_special_tokens is None:
+            raise RuntimeError(
+                "prompt-completion validation did not derive a source tokenization policy"
+            )
         token_rows = tokenize_verification_texts(
             processing_class,
             prompts + prompt_completions,
@@ -3104,12 +3109,60 @@ def validate_prompt_completion_tokenization(
         )
         prompt_token_rows = token_rows[: len(prompts)]
         prompt_completion_token_rows = token_rows[len(prompts) :]
-        for batch_index, (prompt_ids, input_ids) in enumerate(
-            zip(prompt_token_rows, prompt_completion_token_rows)
+        source_prompt_token_rows = prompt_token_rows
+        source_prompt_completion_token_rows = prompt_completion_token_rows
+        if source_add_special_tokens != effective_add_special_tokens:
+            source_token_rows = tokenize_verification_texts(
+                processing_class,
+                prompts + prompt_completions,
+                add_special_tokens=source_add_special_tokens,
+                description=(
+                    f"source-policy records {batch_start}-"
+                    f"{batch_start + len(prompts) - 1} prompts and prompt-completions"
+                ),
+            )
+            source_prompt_token_rows = source_token_rows[: len(prompts)]
+            source_prompt_completion_token_rows = source_token_rows[len(prompts) :]
+        for batch_index, (
+            prompt_ids,
+            input_ids,
+            source_prompt_ids,
+            source_input_ids,
+        ) in enumerate(
+            zip(
+                prompt_token_rows,
+                prompt_completion_token_rows,
+                source_prompt_token_rows,
+                source_prompt_completion_token_rows,
+            )
         ):
             record_index = batch_start + batch_index
             input_ids = input_ids[:max_seq_length]
             prompt_length = min(len(prompt_ids), len(input_ids))
+            source_input_ids = source_input_ids[:max_seq_length]
+            source_prompt_length = min(
+                len(source_prompt_ids),
+                len(source_input_ids),
+            )
+            completion_mask = [0] * prompt_length + [1] * (
+                len(input_ids) - prompt_length
+            )
+            source_completion_mask = [0] * source_prompt_length + [1] * (
+                len(source_input_ids) - source_prompt_length
+            )
+            if (
+                input_ids != source_input_ids
+                or completion_mask != source_completion_mask
+            ):
+                raise ValueError(
+                    f"prompt-completion preprocessing record {record_index} "
+                    "tokenizes differently with its source "
+                    f"add_special_tokens={source_add_special_tokens} policy and "
+                    "the combined dataset "
+                    f"add_special_tokens={effective_add_special_tokens} policy; "
+                    "combining these records would change token or completion-mask "
+                    "boundaries"
+                )
             if len(input_ids) <= prompt_length:
                 raise RuntimeError(
                     f"prompt-completion preprocessing record {record_index} retains no completion tokens after truncation to maxSeqLength {max_seq_length}"
@@ -3125,11 +3178,13 @@ def validate_prompt_completion_tokenization(
             )
 
     for record in dataset:
-        if effective_add_special_tokens is None:
-            effective_add_special_tokens = prompt_completion_add_special_tokens(
+        if source_add_special_tokens is None:
+            source_add_special_tokens = prompt_completion_add_special_tokens(
                 processing_class,
                 record["prompt"],
             )
+        if effective_add_special_tokens is None:
+            effective_add_special_tokens = source_add_special_tokens
 
         completion = record["completion"]
         if not completion.endswith(eos_token):

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -106,6 +106,9 @@ CHAT_DATASET_TYPES = frozenset((DATASET_TYPE_MESSAGES, DATASET_TYPE_SHAREGPT))
 LOSS_ALL = "all"
 LOSS_RESPONSE = "response"
 SUPPORTED_LOSSES = frozenset((LOSS_ALL, LOSS_RESPONSE))
+DATASET_COMPATIBILITY_FULL_SEQUENCE = "full-sequence"
+DATASET_COMPATIBILITY_PROMPT_COMPLETION = "completion-only"
+DATASET_COMPATIBILITY_RESPONSE_CHAT = "response-only chat"
 UNSUPPORTED_MESSAGES_TOP_LEVEL_FIELDS = frozenset(
     (
         "add_generation_prompt",
@@ -193,6 +196,7 @@ class TrainingDatasetSpec(NamedTuple):
     source: str
     dataset_type: str
     loader: DatasetLoaderSpec
+    index: int | None = None
 
 
 class PromptPrefixFingerprint(NamedTuple):
@@ -243,6 +247,7 @@ class TrainDependencies(NamedTuple):
     sft_trainer: Callable[..., Any]
     get_chat_template_parts: Callable[..., tuple[str, str]]
     train_on_responses_only: Callable[..., Any]
+    concatenate_datasets: Callable[[list[Any]], Any] | None = None
 
 
 class ExportDependencies(NamedTuple):
@@ -387,7 +392,13 @@ def parse_dataset_loader_spec(
     dataset: Mapping[str, Any],
     *,
     source: str,
+    dataset_index: int | None = None,
 ) -> DatasetLoaderSpec:
+    path = (
+        "training dataset loader"
+        if dataset_index is None
+        else f"datasets[{dataset_index}].loader"
+    )
     if "loader" not in dataset:
         return DatasetLoaderSpec(
             loader_type=None,
@@ -399,9 +410,9 @@ def parse_dataset_loader_spec(
 
     loader = dataset["loader"]
     if not isinstance(loader, Mapping):
-        raise ValueError("training dataset loader must be a mapping")
+        raise ValueError(f"{path} must be a mapping")
     if any(not isinstance(field, str) for field in loader):
-        raise ValueError("training dataset loader field names must be strings")
+        raise ValueError(f"{path} field names must be strings")
 
     allowed_fields = frozenset(
         ("type", "subset", "split", "revision", "checksum")
@@ -410,29 +421,31 @@ def parse_dataset_loader_spec(
     if unknown_fields:
         quoted_fields = ", ".join(repr(field) for field in unknown_fields)
         raise ValueError(
-            f"training dataset loader contains unknown fields: {quoted_fields}"
+            f"{path} contains unknown fields: {quoted_fields}"
         )
 
     for field, value in loader.items():
         if not isinstance(value, str):
             raise ValueError(
-                f"training dataset loader field {field!r} must be a string"
+                f"{path} field {field!r} must be a string"
             )
         if field in {"subset", "revision", "checksum"} and not value.strip():
             raise ValueError(
-                f"training dataset loader field {field!r} must not be empty"
+                f"{path} field {field!r} must not be empty"
             )
 
     loader_type = loader.get("type")
     if not isinstance(loader_type, str) or not loader_type.strip():
-        raise ValueError("training dataset loader type must be a non-empty string")
+        raise ValueError(f"{path} type must be a non-empty string")
     if loader_type not in SUPPORTED_DATASET_LOADERS:
-        raise ValueError(f"unsupported training dataset loader {loader_type!r}")
+        raise ValueError(
+            f"{path}: unsupported training dataset loader {loader_type!r}"
+        )
 
     split = loader.get("split", DEFAULT_DATASET_SPLIT)
     if not isinstance(split, str) or not DATASET_SPLIT_PATTERN.fullmatch(split):
         raise ValueError(
-            "training dataset loader split must be a named split containing "
+            f"{path} split must be a named split containing "
             "letters, numbers, or underscores in dot-separated segments"
         )
 
@@ -442,38 +455,38 @@ def parse_dataset_loader_spec(
     if loader_type == DATASET_LOADER_HUGGINGFACE:
         if is_http_dataset_source(source):
             raise ValueError(
-                "huggingface dataset loader does not support an HTTP(S) source"
+                f"{path}: huggingface dataset loader does not support an HTTP(S) source"
             )
         if checksum is not None:
             raise ValueError(
-                "huggingface dataset loader does not support checksum"
+                f"{path}: huggingface dataset loader does not support checksum"
             )
         if revision is not None and not HF_COMMIT_HASH_PATTERN.fullmatch(
             revision
         ):
             raise ValueError(
-                "huggingface dataset loader revision must be a lowercase "
+                f"{path} revision must be a lowercase "
                 "40-character commit hash"
             )
     else:
         if not is_http_dataset_source(source):
             raise ValueError(
-                f"{loader_type} dataset loader requires an absolute HTTP(S) "
+                f"{path}: {loader_type} dataset loader requires an absolute HTTP(S) "
                 "source"
             )
         if subset is not None:
             raise ValueError(
-                "remote-file dataset loaders do not support subset"
+                f"{path}: remote-file dataset loaders do not support subset"
             )
         if revision is not None:
             raise ValueError(
-                "remote-file dataset loaders do not support revision"
+                f"{path}: remote-file dataset loaders do not support revision"
             )
         if checksum is not None and not DATASET_CHECKSUM_PATTERN.fullmatch(
             checksum
         ):
             raise ValueError(
-                "remote-file dataset loader checksum must use lowercase "
+                f"{path}: remote-file dataset loader checksum must use lowercase "
                 "sha256:<64 hex> format"
             )
 
@@ -547,41 +560,63 @@ def dataset_source_description(
     return f"source {source!r}"
 
 
-def training_dataset_spec(
+def training_dataset_specs(
     train_config: Mapping[str, Any],
-) -> TrainingDatasetSpec:
+) -> tuple[TrainingDatasetSpec, ...]:
     datasets = train_config.get("datasets")
     if (
         not isinstance(datasets, Sequence)
         or isinstance(datasets, (str, bytes))
-        or len(datasets) != 1
+        or len(datasets) == 0
     ):
-        raise ValueError("training configuration must define exactly one dataset")
+        raise ValueError("training configuration must define at least one dataset")
 
-    dataset = datasets[0]
-    if not isinstance(dataset, Mapping):
-        raise ValueError("training dataset configuration must be a mapping")
+    specs = []
+    for dataset_index, dataset in enumerate(datasets):
+        path = f"datasets[{dataset_index}]"
+        if not isinstance(dataset, Mapping):
+            raise ValueError(f"{path} must be a mapping")
 
-    dataset_type = dataset.get("type")
-    if (
-        not isinstance(dataset_type, str)
-        or dataset_type not in SUPPORTED_DATASET_TYPES
-    ):
-        raise ValueError(f"unsupported dataset type {dataset_type!r}")
+        dataset_type = dataset.get("type")
+        if (
+            not isinstance(dataset_type, str)
+            or dataset_type not in SUPPORTED_DATASET_TYPES
+        ):
+            raise ValueError(
+                f"{path}.type has unsupported dataset type {dataset_type!r}"
+            )
 
-    source = dataset.get("source")
-    if not isinstance(source, str) or not source.strip():
-        raise ValueError("training dataset source must be a non-empty string")
-    if has_http_dataset_scheme(source) and not is_http_dataset_source(source):
-        raise ValueError(
-            "training dataset HTTP(S) source must be an absolute URL with a host"
+        source = dataset.get("source")
+        if not isinstance(source, str) or not source.strip():
+            raise ValueError(f"{path}.source must be a non-empty string")
+        if has_http_dataset_scheme(source) and not is_http_dataset_source(source):
+            raise ValueError(
+                f"{path} HTTP(S) source must be an absolute URL with a host"
+            )
+
+        specs.append(
+            TrainingDatasetSpec(
+                source=source,
+                dataset_type=dataset_type,
+                loader=parse_dataset_loader_spec(
+                    dataset,
+                    source=source,
+                    dataset_index=dataset_index,
+                ),
+                index=dataset_index,
+            )
         )
 
-    return TrainingDatasetSpec(
-        source=source,
-        dataset_type=dataset_type,
-        loader=parse_dataset_loader_spec(dataset, source=source),
-    )
+    return tuple(specs)
+
+
+def training_dataset_spec(
+    train_config: Mapping[str, Any],
+) -> TrainingDatasetSpec:
+    specs = training_dataset_specs(train_config)
+    if len(specs) != 1:
+        raise ValueError("training configuration must define exactly one dataset")
+    return specs[0]
 
 
 def dataset_cache_directory() -> Path:
@@ -1012,29 +1047,107 @@ def load_training_dataset(
         try:
             return load_dataset(load_spec.path, **load_spec.kwargs)
         except Exception:
-            if is_remote or dataset_spec.dataset_type in (
-                *CHAT_DATASET_TYPES,
-                DATASET_TYPE_TEXT,
-            ):
-                subject = dataset_error_subject(
-                    dataset_spec.dataset_type,
-                    source=dataset_spec.source,
-                    loader_type=loader_type,
-                )
-                raise RuntimeError(f"{subject} could not be loaded") from None
+            subject = dataset_error_subject(
+                dataset_spec.dataset_type,
+                source=dataset_spec.source,
+                loader_type=loader_type,
+                dataset_index=dataset_spec.index,
+            )
+            raise RuntimeError(f"{subject} could not be loaded") from None
+
+    try:
+        if not is_remote:
+            return load_materialized_dataset()
+
+        effective_loader = loader_type or DATASET_LOADER_JSON
+        with materialize_remote_dataset_file(
+            dataset_spec.source,
+            loader_type=effective_loader,
+            checksum=dataset_spec.loader.checksum,
+            cache_directory=cache_directory,
+        ) as local_file:
+            return load_materialized_dataset(local_file)
+    except (OSError, RuntimeError, ValueError) as error:
+        if dataset_spec.index is None or str(error).startswith(
+            f"datasets[{dataset_spec.index}] "
+        ):
             raise
+        raise type(error)(
+            f"datasets[{dataset_spec.index}] {error}"
+        ) from None
 
-    if not is_remote:
-        return load_materialized_dataset()
 
-    effective_loader = loader_type or DATASET_LOADER_JSON
-    with materialize_remote_dataset_file(
-        dataset_spec.source,
-        loader_type=effective_loader,
-        checksum=dataset_spec.loader.checksum,
-        cache_directory=cache_directory,
-    ) as local_file:
-        return load_materialized_dataset(local_file)
+def configured_training_loss(train_config: Mapping[str, Any]) -> str:
+    cfg = unsloth_config(train_config)
+    configured_loss = cfg.get("loss", LOSS_ALL)
+    loss = LOSS_ALL if configured_loss is None else configured_loss
+    if not isinstance(loss, str) or loss not in SUPPORTED_LOSSES:
+        raise ValueError(f"unsupported SFT loss {loss!r}")
+    return loss
+
+
+def dataset_compatibility_group(dataset_type: str, *, loss: str) -> str:
+    if loss == LOSS_RESPONSE and dataset_type not in CHAT_DATASET_TYPES:
+        raise ValueError(
+            "response SFT loss is supported only for messages and sharegpt datasets"
+        )
+    if loss == LOSS_RESPONSE:
+        return DATASET_COMPATIBILITY_RESPONSE_CHAT
+    if dataset_type == DATASET_TYPE_PROMPT_COMPLETION:
+        return DATASET_COMPATIBILITY_PROMPT_COMPLETION
+    return DATASET_COMPATIBILITY_FULL_SEQUENCE
+
+
+def training_dataset_compatibility(
+    dataset_specs: Sequence[TrainingDatasetSpec],
+    *,
+    loss: str,
+) -> str:
+    if not dataset_specs:
+        raise ValueError("training configuration must define at least one dataset")
+
+    first_spec = dataset_specs[0]
+    try:
+        first_group = dataset_compatibility_group(
+            first_spec.dataset_type,
+            loss=loss,
+        )
+    except ValueError as error:
+        raise ValueError(
+            f"datasets[0] type {first_spec.dataset_type}: {error}"
+        ) from None
+
+    for dataset_index, dataset_spec in enumerate(dataset_specs[1:], start=1):
+        try:
+            group = dataset_compatibility_group(
+                dataset_spec.dataset_type,
+                loss=loss,
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"datasets[{dataset_index}] type {dataset_spec.dataset_type}: {error}"
+            ) from None
+        if group != first_group:
+            raise ValueError(
+                f"datasets[{dataset_index}] type {dataset_spec.dataset_type} is "
+                f"incompatible with datasets[0] type {first_spec.dataset_type}: "
+                f"{group} and {first_group} datasets cannot be combined"
+            )
+    return first_group
+
+
+def validate_response_packing(
+    train_config: Mapping[str, Any],
+    *,
+    loss: str,
+) -> None:
+    cfg = unsloth_config(train_config)
+    if loss == LOSS_RESPONSE and bool(cfg.get("packing", False)):
+        raise ValueError(
+            "response SFT loss does not support packing because response masks "
+            "must not cross conversation boundaries; set config.unsloth.packing "
+            "to false"
+        )
 
 
 def training_loss(
@@ -1042,21 +1155,9 @@ def training_loss(
     *,
     dataset_type: str,
 ) -> str:
-    cfg = unsloth_config(train_config)
-    configured_loss = cfg.get("loss", LOSS_ALL)
-    loss = LOSS_ALL if configured_loss is None else configured_loss
-    if not isinstance(loss, str) or loss not in SUPPORTED_LOSSES:
-        raise ValueError(f"unsupported SFT loss {loss!r}")
-    if loss == LOSS_RESPONSE and dataset_type not in CHAT_DATASET_TYPES:
-        raise ValueError(
-            "response SFT loss is supported only for messages and sharegpt datasets"
-        )
-    if loss == LOSS_RESPONSE and bool(cfg.get("packing", False)):
-        raise ValueError(
-            "response SFT loss does not support packing because response masks "
-            "must not cross conversation boundaries; set config.unsloth.packing "
-            "to false"
-        )
+    loss = configured_training_loss(train_config)
+    dataset_compatibility_group(dataset_type, loss=loss)
+    validate_response_packing(train_config, loss=loss)
     return loss
 
 
@@ -1066,20 +1167,33 @@ def dataset_error_subject(
     source: str | None = None,
     record_index: int | None = None,
     loader_type: str | None = None,
+    dataset_index: int | None = None,
 ) -> str:
     if source is None:
         subject = f"{dataset_type} dataset"
         if record_index is not None:
             subject += f" record {record_index}"
-        return subject
-
-    subject = (
-        f"{dataset_type} dataset "
-        f"{dataset_source_description(source, loader_type=loader_type)}"
-    )
-    if record_index is not None:
-        subject += f" row {record_index}"
+    else:
+        subject = (
+            f"{dataset_type} dataset "
+            f"{dataset_source_description(source, loader_type=loader_type)}"
+        )
+        if record_index is not None:
+            subject += f" row {record_index}"
+    if dataset_index is not None:
+        subject = f"datasets[{dataset_index}] {subject}"
     return subject
+
+
+@contextmanager
+def indexed_dataset_errors(dataset_index: int) -> Iterator[None]:
+    try:
+        yield
+    except (RuntimeError, ValueError) as error:
+        prefix = f"datasets[{dataset_index}] "
+        if str(error).startswith(prefix):
+            raise
+        raise type(error)(f"{prefix}{error}") from None
 
 
 def validate_messages_value(
@@ -1580,6 +1694,21 @@ def messages_rendered_token_id_rows(
 
 def empty_messages_token_fingerprint() -> MessagesTokenFingerprint:
     return MessagesTokenFingerprint(0, 0, 0)
+
+
+def merge_messages_token_fingerprints(
+    fingerprints: Sequence[MessagesTokenFingerprint],
+) -> MessagesTokenFingerprint:
+    merged = empty_messages_token_fingerprint()
+    for fingerprint in fingerprints:
+        merged = MessagesTokenFingerprint(
+            merged.sequence_count + fingerprint.sequence_count,
+            (merged.first_digest_sum + fingerprint.first_digest_sum)
+            & MESSAGES_TOKEN_FINGERPRINT_MASK,
+            (merged.second_digest_sum + fingerprint.second_digest_sum)
+            & MESSAGES_TOKEN_FINGERPRINT_MASK,
+        )
+    return merged
 
 
 def extend_messages_token_fingerprint(
@@ -2207,6 +2336,164 @@ def prepare_training_dataset(
     raise ValueError(f"unsupported dataset type {dataset_type!r}")
 
 
+def canonical_string_examples(
+    examples: Mapping[str, Sequence[str]],
+    *,
+    fields: Sequence[str],
+) -> dict[str, list[str]]:
+    return {field: list(examples[field]) for field in fields}
+
+
+def normalize_canonical_string_dataset(
+    dataset: Any,
+    *,
+    fields: Sequence[str],
+    dataset_type: str,
+    source: str,
+    dataset_index: int,
+) -> Any:
+    subject = dataset_error_subject(
+        dataset_type,
+        source=source,
+        dataset_index=dataset_index,
+    )
+    canonical_fields = tuple(fields)
+    map_kwargs: dict[str, Any] = {}
+    canonical_features = None
+    if getattr(dataset, "features", None) is not None:
+        try:
+            from datasets import Features, Value
+
+            canonical_features = Features(
+                {field: Value("string") for field in canonical_fields}
+            )
+            map_kwargs["features"] = canonical_features
+        except Exception:
+            raise RuntimeError(
+                f"{subject} could not construct canonical string features"
+            ) from None
+
+    try:
+        normalized = dataset.map(
+            partial(canonical_string_examples, fields=canonical_fields),
+            batched=True,
+            remove_columns=list(dataset.column_names),
+            **map_kwargs,
+        )
+    except Exception:
+        raise RuntimeError(
+            f"{subject} could not be normalized to canonical string features"
+        ) from None
+
+    if list(getattr(normalized, "column_names", ())) != list(canonical_fields):
+        raise RuntimeError(
+            f"{subject} did not normalize to the canonical columns "
+            f"{list(canonical_fields)!r}"
+        )
+    if (
+        canonical_features is not None
+        and getattr(normalized, "features", None) != canonical_features
+    ):
+        raise RuntimeError(
+            f"{subject} did not normalize to canonical string features"
+        )
+    return normalized
+
+
+def validate_full_sequence_text_tokenization(
+    dataset: Any,
+    *,
+    processing_class: Any,
+    max_seq_length: int,
+    dataset_type: str,
+    source: str,
+    dataset_index: int,
+    add_special_tokens: bool | None = None,
+    batch_size: int = TEXT_VALIDATION_BATCH_SIZE,
+) -> MessagesTokenFingerprint:
+    if (
+        isinstance(batch_size, bool)
+        or not isinstance(batch_size, int)
+        or batch_size <= 0
+    ):
+        raise ValueError("full-sequence validation batch size must be positive")
+    if (
+        isinstance(max_seq_length, bool)
+        or not isinstance(max_seq_length, int)
+        or max_seq_length <= 0
+    ):
+        raise ValueError("full-sequence max sequence length must be positive")
+
+    effective_batch_size = min(
+        batch_size,
+        max(1, TEXT_VALIDATION_TOKEN_BUDGET // max_seq_length),
+    )
+    fingerprint = empty_messages_token_fingerprint()
+    texts: list[str] = []
+    batch_start = 0
+    record_count = 0
+    unsloth_tokenizer = getattr(
+        processing_class,
+        "tokenizer",
+        processing_class,
+    )
+
+    def validate_batch() -> None:
+        nonlocal fingerprint
+        subject = dataset_error_subject(
+            dataset_type,
+            source=source,
+            dataset_index=dataset_index,
+        )
+        input_id_rows = text_token_id_rows(
+            unsloth_tokenizer,
+            texts,
+            add_special_tokens=bool(add_special_tokens),
+            max_length=max_seq_length,
+            description=(
+                f"{subject} rows {batch_start}-{batch_start + len(texts) - 1}"
+            ),
+        )
+        for batch_index, input_ids in enumerate(input_id_rows):
+            record_index = batch_start + batch_index
+            if not input_ids:
+                raise RuntimeError(
+                    f"{subject} row {record_index} produced no training tokens"
+                )
+            fingerprint = extend_messages_token_fingerprint(
+                fingerprint,
+                input_ids,
+                description=(
+                    f"datasets[{dataset_index}] source record {record_index}"
+                ),
+            )
+
+    for record in dataset:
+        text = record["text"]
+        if add_special_tokens is None:
+            add_special_tokens = messages_unsloth_add_special_tokens(
+                processing_class,
+                text,
+            )
+        texts.append(text)
+        record_count += 1
+        if len(texts) == effective_batch_size:
+            validate_batch()
+            texts.clear()
+            batch_start = record_count
+
+    if texts:
+        validate_batch()
+    if record_count == 0:
+        subject = dataset_error_subject(
+            dataset_type,
+            source=source,
+            dataset_index=dataset_index,
+        )
+        raise RuntimeError(f"{subject} produced no canonical records")
+    return fingerprint
+
+
 def sequence_values(
     value: Any,
     *,
@@ -2666,6 +2953,21 @@ def empty_prompt_prefix_fingerprint() -> PromptPrefixFingerprint:
     return PromptPrefixFingerprint(0, 0, 0)
 
 
+def merge_prompt_prefix_fingerprints(
+    fingerprints: Sequence[PromptPrefixFingerprint],
+) -> PromptPrefixFingerprint:
+    merged = empty_prompt_prefix_fingerprint()
+    for fingerprint in fingerprints:
+        merged = PromptPrefixFingerprint(
+            merged.sequence_count + fingerprint.sequence_count,
+            (merged.first_digest_sum + fingerprint.first_digest_sum)
+            & PROMPT_PREFIX_FINGERPRINT_MASK,
+            (merged.second_digest_sum + fingerprint.second_digest_sum)
+            & PROMPT_PREFIX_FINGERPRINT_MASK,
+        )
+    return merged
+
+
 def extend_prompt_prefix_fingerprint(
     fingerprint: PromptPrefixFingerprint,
     token_ids: Sequence[Any],
@@ -2707,6 +3009,7 @@ def validate_prompt_completion_tokenization(
     *,
     processing_class: Any,
     max_seq_length: int,
+    add_special_tokens: bool | None = None,
     batch_size: int = PROMPT_COMPLETION_VALIDATION_BATCH_SIZE,
 ) -> PromptPrefixFingerprint:
     """Validate source token boundaries in bounded tokenizer batches."""
@@ -2748,7 +3051,7 @@ def validate_prompt_completion_tokenization(
     batch_start = 0
     prompts: list[str] = []
     prompt_completions: list[str] = []
-    add_special_tokens: bool | None = None
+    effective_add_special_tokens = add_special_tokens
     fingerprint = empty_prompt_prefix_fingerprint()
 
     def validate_batch() -> None:
@@ -2756,7 +3059,7 @@ def validate_prompt_completion_tokenization(
         token_rows = tokenize_verification_texts(
             processing_class,
             prompts + prompt_completions,
-            add_special_tokens=add_special_tokens,
+            add_special_tokens=effective_add_special_tokens,
             description=(
                 f"records {batch_start}-{batch_start + len(prompts) - 1} "
                 "prompts and prompt-completions"
@@ -2785,8 +3088,8 @@ def validate_prompt_completion_tokenization(
             )
 
     for record in dataset:
-        if add_special_tokens is None:
-            add_special_tokens = prompt_completion_add_special_tokens(
+        if effective_add_special_tokens is None:
+            effective_add_special_tokens = prompt_completion_add_special_tokens(
                 processing_class,
                 record["prompt"],
             )
@@ -3599,7 +3902,7 @@ def load_train_dependencies() -> TrainDependencies:
     from unsloth.chat_templates import train_on_responses_only
     from unsloth.models.loader_utils import get_model_name
     from unsloth_zoo.dataset_utils import get_chat_template_parts
-    from datasets import Dataset, load_dataset
+    from datasets import Dataset, concatenate_datasets, load_dataset
     from huggingface_hub import model_info
     from trl import SFTConfig, SFTTrainer
 
@@ -3614,6 +3917,7 @@ def load_train_dependencies() -> TrainDependencies:
         sft_trainer=SFTTrainer,
         get_chat_template_parts=get_chat_template_parts,
         train_on_responses_only=train_on_responses_only,
+        concatenate_datasets=concatenate_datasets,
     )
 
 
@@ -3633,8 +3937,13 @@ def train_model(
     trained_model_directory: Path | str = TRAINED_MODEL_DIRECTORY,
     dependencies: TrainDependencies | None = None,
 ) -> Path:
-    dataset_spec = training_dataset_spec(train_config)
-    loss = training_loss(train_config, dataset_type=dataset_spec.dataset_type)
+    dataset_specs = training_dataset_specs(train_config)
+    loss = configured_training_loss(train_config)
+    compatibility = training_dataset_compatibility(
+        dataset_specs,
+        loss=loss,
+    )
+    validate_response_packing(train_config, loss=loss)
 
     if dependencies is None:
         dependencies = load_train_dependencies()
@@ -3642,37 +3951,47 @@ def train_model(
     cfg = unsloth_config(train_config)
     max_seq_length = cfg["maxSeqLength"]
 
-    dataset = load_training_dataset(
-        dataset_spec,
-        load_dataset=dependencies.load_dataset,
-    )
-    validation_source = None
-    if (
-        dataset_spec.dataset_type in CHAT_DATASET_TYPES
-        or dataset_spec.dataset_type == DATASET_TYPE_TEXT
-    ):
-        validation_source = dataset_spec.source
-    dataset = project_training_dataset(
-        dataset,
-        dataset_type=dataset_spec.dataset_type,
-        source=validation_source,
-    )
-    validate_training_dataset(
-        dataset,
-        dataset_type=dataset_spec.dataset_type,
-        source=validation_source,
-    )
-    if dataset_spec.dataset_type == DATASET_TYPE_SHAREGPT:
-        dataset = normalize_sharegpt_dataset(
-            dataset,
-            source=dataset_spec.source,
-        )
-    if dataset_spec.dataset_type in CHAT_DATASET_TYPES and loss == LOSS_RESPONSE:
-        validate_response_training_dataset(
-            dataset,
-            dataset_type=dataset_spec.dataset_type,
-            source=dataset_spec.source,
-        )
+    source_datasets = []
+    for dataset_spec in dataset_specs:
+        dataset_index = dataset_spec.index
+        if dataset_index is None:
+            raise RuntimeError("parsed training dataset is missing its index")
+        with indexed_dataset_errors(dataset_index):
+            source_dataset = load_training_dataset(
+                dataset_spec,
+                load_dataset=dependencies.load_dataset,
+            )
+            validation_source = None
+            if (
+                dataset_spec.dataset_type in CHAT_DATASET_TYPES
+                or dataset_spec.dataset_type == DATASET_TYPE_TEXT
+            ):
+                validation_source = dataset_spec.source
+            source_dataset = project_training_dataset(
+                source_dataset,
+                dataset_type=dataset_spec.dataset_type,
+                source=validation_source,
+            )
+            validate_training_dataset(
+                source_dataset,
+                dataset_type=dataset_spec.dataset_type,
+                source=validation_source,
+            )
+            if dataset_spec.dataset_type == DATASET_TYPE_SHAREGPT:
+                source_dataset = normalize_sharegpt_dataset(
+                    source_dataset,
+                    source=dataset_spec.source,
+                )
+            if (
+                dataset_spec.dataset_type in CHAT_DATASET_TYPES
+                and loss == LOSS_RESPONSE
+            ):
+                validate_response_training_dataset(
+                    source_dataset,
+                    dataset_type=dataset_spec.dataset_type,
+                    source=dataset_spec.source,
+                )
+            source_datasets.append(source_dataset)
 
     model, tokenizer = dependencies.fast_language_model.from_pretrained(
         model_name=train_config["baseModel"],
@@ -3680,50 +3999,95 @@ def train_model(
         dtype=None,
         load_in_4bit=cfg["loadIn4bit"],
     )
-    messages_token_fingerprint = None
+
+    has_chat_dataset = any(
+        dataset_spec.dataset_type in CHAT_DATASET_TYPES
+        for dataset_spec in dataset_specs
+    )
+    has_text_dataset = any(
+        dataset_spec.dataset_type == DATASET_TYPE_TEXT
+        for dataset_spec in dataset_specs
+    )
+    response_only = compatibility == DATASET_COMPATIBILITY_RESPONSE_CHAT
+    completion_only = (
+        compatibility == DATASET_COMPATIBILITY_PROMPT_COMPLETION
+    )
+    validate_all_full_sequence_records = (
+        compatibility == DATASET_COMPATIBILITY_FULL_SEQUENCE
+        and (len(dataset_specs) > 1 or has_chat_dataset)
+    )
+
     response_markers = None
-    if dataset_spec.dataset_type in CHAT_DATASET_TYPES:
+    if has_chat_dataset:
         require_messages_chat_template(tokenizer)
-        if loss == LOSS_RESPONSE:
+        if response_only:
             response_markers = derive_response_markers(
                 tokenizer,
                 get_chat_template_parts=dependencies.get_chat_template_parts,
             )
-        messages_source_dataset = dataset
-        dataset = render_messages_dataset(
-            messages_source_dataset,
-            processing_class=tokenizer,
-            source=dataset_spec.source,
-            dataset_type=dataset_spec.dataset_type,
-        )
-        messages_token_fingerprint = validate_messages_tokenization(
-            messages_source_dataset,
-            dataset,
-            processing_class=tokenizer,
-            max_seq_length=max_seq_length,
-            source=dataset_spec.source,
-            dataset_type=dataset_spec.dataset_type,
-            response_markers=response_markers,
-        )
-
-    prompt_prefix_fingerprint = None
-    if dataset_spec.dataset_type == DATASET_TYPE_PROMPT_COMPLETION:
-        prompt_prefix_fingerprint = validate_prompt_completion_tokenization(
-            dataset,
-            processing_class=tokenizer,
-            max_seq_length=max_seq_length,
-        )
 
     text_policy = None
-    if dataset_spec.dataset_type == DATASET_TYPE_TEXT:
+    if has_text_dataset:
         text_policy = text_boundary_policy(tokenizer)
-        validate_text_sequence_lengths(
-            dataset,
-            processing_class=tokenizer,
-            policy=text_policy,
-            max_seq_length=max_seq_length,
-            source=dataset_spec.source,
+
+    prompt_add_special_tokens = None
+    if completion_only:
+        first_prompt_record = next(iter(source_datasets[0]))
+        prompt_add_special_tokens = prompt_completion_add_special_tokens(
+            tokenizer,
+            first_prompt_record["prompt"],
         )
+
+    rendered_source_datasets = []
+    canonical_chat_fingerprints = []
+    prompt_prefix_fingerprints = []
+    for dataset_spec, source_dataset in zip(dataset_specs, source_datasets):
+        dataset_index = dataset_spec.index
+        if dataset_index is None:
+            raise RuntimeError("parsed training dataset is missing its index")
+        with indexed_dataset_errors(dataset_index):
+            if dataset_spec.dataset_type in CHAT_DATASET_TYPES:
+                messages_source_dataset = source_dataset
+                source_dataset = render_messages_dataset(
+                    messages_source_dataset,
+                    processing_class=tokenizer,
+                    source=dataset_spec.source,
+                    dataset_type=dataset_spec.dataset_type,
+                )
+                canonical_chat_fingerprints.append(
+                    validate_messages_tokenization(
+                        messages_source_dataset,
+                        source_dataset,
+                        processing_class=tokenizer,
+                        max_seq_length=max_seq_length,
+                        source=dataset_spec.source,
+                        dataset_type=dataset_spec.dataset_type,
+                        response_markers=response_markers,
+                    )
+                )
+            elif dataset_spec.dataset_type == DATASET_TYPE_PROMPT_COMPLETION:
+                prompt_prefix_fingerprints.append(
+                    validate_prompt_completion_tokenization(
+                        source_dataset,
+                        processing_class=tokenizer,
+                        max_seq_length=max_seq_length,
+                        add_special_tokens=prompt_add_special_tokens,
+                    )
+                )
+            elif dataset_spec.dataset_type == DATASET_TYPE_TEXT:
+                if text_policy is None:
+                    raise RuntimeError(
+                        "text preprocessing did not produce a boundary policy"
+                    )
+                validate_text_sequence_lengths(
+                    source_dataset,
+                    processing_class=tokenizer,
+                    policy=text_policy,
+                    max_seq_length=max_seq_length,
+                    source=dataset_spec.source,
+                )
+            rendered_source_datasets.append(source_dataset)
+
     base_model_name, base_model_revision = resolve_export_base_model(
         train_config["baseModel"],
         model_info=dependencies.model_info,
@@ -3758,12 +4122,94 @@ def train_model(
         revision=base_model_revision,
     )
 
-    dataset = prepare_training_dataset(
-        dataset,
-        dataset_type=dataset_spec.dataset_type,
-        end_of_sequence=tokenizer.eos_token,
-        text_policy=text_policy,
-    )
+    canonical_datasets = []
+    for dataset_spec, source_dataset in zip(
+        dataset_specs,
+        rendered_source_datasets,
+    ):
+        dataset_index = dataset_spec.index
+        if dataset_index is None:
+            raise RuntimeError("parsed training dataset is missing its index")
+        with indexed_dataset_errors(dataset_index):
+            source_dataset = prepare_training_dataset(
+                source_dataset,
+                dataset_type=dataset_spec.dataset_type,
+                end_of_sequence=tokenizer.eos_token,
+                text_policy=text_policy,
+            )
+
+            if len(dataset_specs) > 1:
+                canonical_fields = (
+                    DATASET_REQUIRED_FIELDS[DATASET_TYPE_PROMPT_COMPLETION]
+                    if completion_only
+                    else DATASET_REQUIRED_FIELDS[DATASET_TYPE_TEXT]
+                )
+                source_dataset = normalize_canonical_string_dataset(
+                    source_dataset,
+                    fields=canonical_fields,
+                    dataset_type=dataset_spec.dataset_type,
+                    source=dataset_spec.source,
+                    dataset_index=dataset_index,
+                )
+
+            canonical_datasets.append(source_dataset)
+
+    messages_token_fingerprints = []
+    if response_only or validate_all_full_sequence_records:
+        if len(canonical_datasets) == 1 and has_chat_dataset:
+            messages_token_fingerprints = canonical_chat_fingerprints
+        else:
+            first_record = next(iter(canonical_datasets[0]))
+            full_sequence_add_special_tokens = (
+                messages_unsloth_add_special_tokens(
+                    tokenizer,
+                    first_record["text"],
+                )
+            )
+            for dataset_spec, canonical_dataset in zip(
+                dataset_specs,
+                canonical_datasets,
+            ):
+                dataset_index = dataset_spec.index
+                if dataset_index is None:
+                    raise RuntimeError(
+                        "parsed training dataset is missing its index"
+                    )
+                with indexed_dataset_errors(dataset_index):
+                    messages_token_fingerprints.append(
+                        validate_full_sequence_text_tokenization(
+                            canonical_dataset,
+                            processing_class=tokenizer,
+                            max_seq_length=max_seq_length,
+                            dataset_type=dataset_spec.dataset_type,
+                            source=dataset_spec.source,
+                            dataset_index=dataset_index,
+                            add_special_tokens=(
+                                full_sequence_add_special_tokens
+                            ),
+                        )
+                    )
+
+    if len(canonical_datasets) == 1:
+        dataset = canonical_datasets[0]
+    else:
+        if not callable(dependencies.concatenate_datasets):
+            raise RuntimeError(
+                "multiple training datasets require datasets.concatenate_datasets"
+            )
+        dataset = dependencies.concatenate_datasets(canonical_datasets)
+
+    messages_token_fingerprint = None
+    if response_only or validate_all_full_sequence_records:
+        messages_token_fingerprint = merge_messages_token_fingerprints(
+            messages_token_fingerprints
+        )
+    prompt_prefix_fingerprint = None
+    if completion_only:
+        prompt_prefix_fingerprint = merge_prompt_prefix_fingerprints(
+            prompt_prefix_fingerprints
+        )
+
     bfloat16_supported = dependencies.is_bfloat16_supported()
 
     trainer = dependencies.sft_trainer(
@@ -3775,9 +4221,7 @@ def train_model(
             dataset_text_field="text",
             dataset_num_proc=2,
             assistant_only_loss=False,
-            completion_only_loss=(
-                dataset_spec.dataset_type == DATASET_TYPE_PROMPT_COMPLETION
-            ),
+            completion_only_loss=completion_only,
             max_length=max_seq_length,
             packing=cfg["packing"],
             per_device_train_batch_size=cfg["batchSize"],
@@ -3796,7 +4240,7 @@ def train_model(
             report_to="none",
         ),
     )
-    if dataset_spec.dataset_type in CHAT_DATASET_TYPES and loss == LOSS_RESPONSE:
+    if response_only:
         if bool(getattr(trainer.args, "packing", False)):
             raise RuntimeError(
                 "response-only messages preprocessing does not support effective "
@@ -3821,7 +4265,7 @@ def train_model(
             raise RuntimeError(
                 "response-only messages preprocessing did not return a trainer"
             )
-    if dataset_spec.dataset_type == DATASET_TYPE_PROMPT_COMPLETION:
+    if completion_only:
         # This is exercised by the GPU smoke path against the exact locked,
         # Unsloth-patched TRL trainer before any training step can silently use
         # full-sequence loss or omit EOS supervision.
@@ -3839,7 +4283,7 @@ def train_model(
             expected_prompt_prefix_fingerprint=prompt_prefix_fingerprint,
         )
 
-    if dataset_spec.dataset_type in CHAT_DATASET_TYPES:
+    if response_only or validate_all_full_sequence_records:
         if messages_token_fingerprint is None:
             raise RuntimeError(
                 "messages preprocessing did not produce a source fingerprint"
@@ -3856,7 +4300,11 @@ def train_model(
             response_markers=response_markers,
         )
 
-    if dataset_spec.dataset_type == DATASET_TYPE_TEXT:
+    if has_text_dataset:
+        if text_policy is None:
+            raise RuntimeError(
+                "text preprocessing did not produce a boundary policy"
+            )
         verify_text_preprocessing(
             trainer,
             dataset_from_dict=dependencies.dataset_from_dict,

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -2432,6 +2432,8 @@ def validate_full_sequence_text_tokenization(
     texts: list[str] = []
     batch_start = 0
     record_count = 0
+    effective_add_special_tokens = add_special_tokens
+    source_add_special_tokens = None
     unsloth_tokenizer = getattr(
         processing_class,
         "tokenizer",
@@ -2440,6 +2442,10 @@ def validate_full_sequence_text_tokenization(
 
     def validate_batch() -> None:
         nonlocal fingerprint
+        if source_add_special_tokens is None:
+            raise RuntimeError(
+                "full-sequence validation did not derive a source tokenization policy"
+            )
         subject = dataset_error_subject(
             dataset_type,
             source=source,
@@ -2448,14 +2454,43 @@ def validate_full_sequence_text_tokenization(
         input_id_rows = text_token_id_rows(
             unsloth_tokenizer,
             texts,
-            add_special_tokens=bool(add_special_tokens),
+            add_special_tokens=bool(effective_add_special_tokens),
             max_length=max_seq_length,
             description=(
                 f"{subject} rows {batch_start}-{batch_start + len(texts) - 1}"
             ),
         )
-        for batch_index, input_ids in enumerate(input_id_rows):
+        source_input_id_rows = input_id_rows
+        if source_add_special_tokens != effective_add_special_tokens:
+            source_input_id_rows = text_token_id_rows(
+                unsloth_tokenizer,
+                texts,
+                add_special_tokens=source_add_special_tokens,
+                max_length=max_seq_length,
+                description=(
+                    f"{subject} source-policy rows {batch_start}-"
+                    f"{batch_start + len(texts) - 1}"
+                ),
+            )
+        for batch_index, (input_ids, source_input_ids) in enumerate(
+            zip(input_id_rows, source_input_id_rows)
+        ):
             record_index = batch_start + batch_index
+            if input_ids != source_input_ids:
+                row_subject = dataset_error_subject(
+                    dataset_type,
+                    source=source,
+                    record_index=record_index,
+                    dataset_index=dataset_index,
+                )
+                raise ValueError(
+                    f"{row_subject} tokenizes differently with its source "
+                    f"add_special_tokens={source_add_special_tokens} policy and "
+                    "the combined full-sequence "
+                    f"add_special_tokens={effective_add_special_tokens} policy "
+                    "derived from datasets[0]; combining these records would "
+                    "change tokenizer special-token boundaries"
+                )
             if not input_ids:
                 raise RuntimeError(
                     f"{subject} row {record_index} produced no training tokens"
@@ -2470,11 +2505,13 @@ def validate_full_sequence_text_tokenization(
 
     for record in dataset:
         text = record["text"]
-        if add_special_tokens is None:
-            add_special_tokens = messages_unsloth_add_special_tokens(
+        if source_add_special_tokens is None:
+            source_add_special_tokens = messages_unsloth_add_special_tokens(
                 processing_class,
                 text,
             )
+        if effective_add_special_tokens is None:
+            effective_add_special_tokens = source_add_special_tokens
         texts.append(text)
         record_count += 1
         if len(texts) == effective_batch_size:

--- a/pkg/finetune/target_unsloth.py
+++ b/pkg/finetune/target_unsloth.py
@@ -6,6 +6,7 @@ import errno
 import fcntl
 import hashlib
 import json
+import math
 import operator
 import os
 import re
@@ -31,6 +32,9 @@ ADAPTER_CONFIG_FILENAME = "adapter_config.json"
 HF_COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 DATASET_CHECKSUM_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 DATASET_SPLIT_PATTERN = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$")
+GO_YAML_SCIENTIFIC_FLOAT_PATTERN = re.compile(
+    r"^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)[eE][+-]?[0-9]+$"
+)
 DATASET_LOADER_HUGGINGFACE = "huggingface"
 DATASET_LOADER_JSON = "json"
 DATASET_LOADER_CSV = "csv"
@@ -73,6 +77,7 @@ REMOTE_DATASET_COMPRESSION_SUFFIXES = frozenset(
 REMOTE_DATASET_CHUNK_SIZE = 1024 * 1024
 DATASET_TYPE_ALPACA = "alpaca"
 DATASET_TYPE_MESSAGES = "messages"
+DATASET_TYPE_PREFERENCE = "preference"
 DATASET_TYPE_PROMPT_COMPLETION = "prompt-completion"
 DATASET_TYPE_SHAREGPT = "sharegpt"
 DATASET_TYPE_TEXT = "text"
@@ -80,6 +85,7 @@ SUPPORTED_DATASET_TYPES = frozenset(
     (
         DATASET_TYPE_ALPACA,
         DATASET_TYPE_MESSAGES,
+        DATASET_TYPE_PREFERENCE,
         DATASET_TYPE_PROMPT_COMPLETION,
         DATASET_TYPE_SHAREGPT,
         DATASET_TYPE_TEXT,
@@ -88,6 +94,7 @@ SUPPORTED_DATASET_TYPES = frozenset(
 DATASET_REQUIRED_FIELDS = {
     DATASET_TYPE_ALPACA: ("instruction", "input", "output"),
     DATASET_TYPE_MESSAGES: ("messages",),
+    DATASET_TYPE_PREFERENCE: ("prompt", "chosen", "rejected"),
     DATASET_TYPE_PROMPT_COMPLETION: ("prompt", "completion"),
     DATASET_TYPE_SHAREGPT: ("conversations",),
     DATASET_TYPE_TEXT: ("text",),
@@ -106,6 +113,13 @@ CHAT_DATASET_TYPES = frozenset((DATASET_TYPE_MESSAGES, DATASET_TYPE_SHAREGPT))
 LOSS_ALL = "all"
 LOSS_RESPONSE = "response"
 SUPPORTED_LOSSES = frozenset((LOSS_ALL, LOSS_RESPONSE))
+OBJECTIVE_TYPE_SFT = "sft"
+OBJECTIVE_TYPE_DPO = "dpo"
+SUPPORTED_OBJECTIVE_TYPES = frozenset((OBJECTIVE_TYPE_SFT, OBJECTIVE_TYPE_DPO))
+DPO_LOSS_SIGMOID = "sigmoid"
+DPO_TRUNCATION_KEEP_END = "keep_end"
+DEFAULT_DPO_BETA = 0.1
+DEFAULT_DPO_MAX_PROMPT_LENGTH = 512
 DATASET_COMPATIBILITY_FULL_SEQUENCE = "full-sequence"
 DATASET_COMPATIBILITY_PROMPT_COMPLETION = "completion-only"
 DATASET_COMPATIBILITY_RESPONSE_CHAT = "response-only chat"
@@ -199,6 +213,13 @@ class TrainingDatasetSpec(NamedTuple):
     index: int | None = None
 
 
+class TrainingObjectiveSpec(NamedTuple):
+    objective_type: str
+    beta: float | None
+    loss_type: str | None
+    max_prompt_length: int | None
+
+
 class PromptPrefixFingerprint(NamedTuple):
     sequence_count: int
     first_digest_sum: int
@@ -245,6 +266,8 @@ class TrainDependencies(NamedTuple):
     resolve_model_name: Callable[..., str]
     sft_config: Callable[..., Any]
     sft_trainer: Callable[..., Any]
+    dpo_config: Callable[..., Any]
+    dpo_trainer: Callable[..., Any]
     get_chat_template_parts: Callable[..., tuple[str, str]]
     train_on_responses_only: Callable[..., Any]
     concatenate_datasets: Callable[[list[Any]], Any] | None = None
@@ -289,6 +312,127 @@ def unsloth_config(train_config: Mapping[str, Any]) -> Mapping[str, Any]:
 
 def output_config(export_config: Mapping[str, Any]) -> Mapping[str, Any]:
     return export_config["output"]
+
+
+def normalize_go_yaml_float(
+    value: Any,
+    *,
+    description: str,
+    allow_zero: bool,
+) -> float:
+    """Normalize Go YAML scientific scalars and enforce their numeric range."""
+    requirement = "zero or greater" if allow_zero else "greater than zero"
+    error_message = f"{description} must be a finite value {requirement}"
+
+    if isinstance(value, str):
+        if GO_YAML_SCIENTIFIC_FLOAT_PATTERN.fullmatch(value) is None:
+            raise ValueError(error_message)
+        value = float(value)
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(error_message)
+
+    normalized = float(value)
+    if (
+        not math.isfinite(normalized)
+        or normalized < 0
+        or (not allow_zero and normalized == 0)
+    ):
+        raise ValueError(error_message)
+
+    return normalized
+
+
+def training_objective_spec(
+    train_config: Mapping[str, Any],
+) -> TrainingObjectiveSpec:
+    objective = train_config.get("objective")
+    if objective is None:
+        objective = {}
+    if not isinstance(objective, Mapping):
+        raise ValueError("training objective must be a mapping")
+    if any(not isinstance(field, str) for field in objective):
+        raise ValueError("training objective field names must be strings")
+
+    allowed_fields = frozenset(
+        ("type", "beta", "lossType", "maxPromptLength")
+    )
+    unknown_fields = sorted(set(objective) - allowed_fields)
+    if unknown_fields:
+        quoted_fields = ", ".join(repr(field) for field in unknown_fields)
+        raise ValueError(
+            f"training objective contains unknown fields: {quoted_fields}"
+        )
+
+    configured_type = objective.get("type", OBJECTIVE_TYPE_SFT)
+    objective_type = (
+        OBJECTIVE_TYPE_SFT if configured_type is None else configured_type
+    )
+    if (
+        not isinstance(objective_type, str)
+        or objective_type not in SUPPORTED_OBJECTIVE_TYPES
+    ):
+        raise ValueError(f"unsupported training objective {objective_type!r}")
+
+    if objective_type == OBJECTIVE_TYPE_SFT:
+        dpo_fields = sorted(
+            field
+            for field in ("beta", "lossType", "maxPromptLength")
+            if field in objective
+        )
+        if dpo_fields:
+            quoted_fields = ", ".join(repr(field) for field in dpo_fields)
+            raise ValueError(
+                "SFT objective does not support DPO fields: "
+                f"{quoted_fields}"
+            )
+        return TrainingObjectiveSpec(
+            objective_type=OBJECTIVE_TYPE_SFT,
+            beta=None,
+            loss_type=None,
+            max_prompt_length=None,
+        )
+
+    configured_beta = objective.get("beta", DEFAULT_DPO_BETA)
+    beta = normalize_go_yaml_float(
+        DEFAULT_DPO_BETA if configured_beta is None else configured_beta,
+        description="DPO objective beta",
+        allow_zero=False,
+    )
+
+    configured_loss_type = objective.get("lossType", DPO_LOSS_SIGMOID)
+    loss_type = (
+        DPO_LOSS_SIGMOID
+        if configured_loss_type is None
+        else configured_loss_type
+    )
+    if not isinstance(loss_type, str) or loss_type != DPO_LOSS_SIGMOID:
+        raise ValueError(f"unsupported DPO objective loss type {loss_type!r}")
+
+    configured_max_prompt_length = objective.get(
+        "maxPromptLength",
+        DEFAULT_DPO_MAX_PROMPT_LENGTH,
+    )
+    max_prompt_length = (
+        DEFAULT_DPO_MAX_PROMPT_LENGTH
+        if configured_max_prompt_length is None
+        else configured_max_prompt_length
+    )
+    if (
+        isinstance(max_prompt_length, bool)
+        or not isinstance(max_prompt_length, int)
+        or max_prompt_length <= 0
+    ):
+        raise ValueError(
+            "DPO objective maxPromptLength must be an integer greater than zero"
+        )
+
+    return TrainingObjectiveSpec(
+        objective_type=OBJECTIVE_TYPE_DPO,
+        beta=beta,
+        loss_type=loss_type,
+        max_prompt_length=max_prompt_length,
+    )
 
 
 def require_hf_commit_hash(revision: Any, *, description: str) -> str:
@@ -1076,7 +1220,6 @@ def load_training_dataset(
             f"datasets[{dataset_spec.index}] {error}"
         ) from None
 
-
 def configured_training_loss(train_config: Mapping[str, Any]) -> str:
     cfg = unsloth_config(train_config)
     configured_loss = cfg.get("loss", LOSS_ALL)
@@ -1087,6 +1230,10 @@ def configured_training_loss(train_config: Mapping[str, Any]) -> str:
 
 
 def dataset_compatibility_group(dataset_type: str, *, loss: str) -> str:
+    if dataset_type == DATASET_TYPE_PREFERENCE:
+        raise ValueError(
+            "preference datasets are supported only for the DPO objective"
+        )
     if loss == LOSS_RESPONSE and dataset_type not in CHAT_DATASET_TYPES:
         raise ValueError(
             "response SFT loss is supported only for messages and sharegpt datasets"
@@ -1159,6 +1306,71 @@ def training_loss(
     dataset_compatibility_group(dataset_type, loss=loss)
     validate_response_packing(train_config, loss=loss)
     return loss
+
+
+def validate_training_objective(
+    train_config: Mapping[str, Any],
+    *,
+    objective: TrainingObjectiveSpec,
+    dataset_spec: TrainingDatasetSpec,
+) -> str:
+    if objective.objective_type == OBJECTIVE_TYPE_SFT:
+        if dataset_spec.dataset_type == DATASET_TYPE_PREFERENCE:
+            raise ValueError(
+                "preference datasets are supported only for the DPO objective"
+            )
+        return training_loss(
+            train_config,
+            dataset_type=dataset_spec.dataset_type,
+        )
+
+    if dataset_spec.dataset_type != DATASET_TYPE_PREFERENCE:
+        raise ValueError(
+            "DPO objective requires a preference dataset with prompt, chosen, "
+            "and rejected fields"
+        )
+    if (
+        dataset_spec.loader.loader_type == DATASET_LOADER_TEXT
+    ):
+        raise ValueError(
+            "preference datasets do not support the text loader because DPO "
+            "requires prompt, chosen, and rejected columns"
+        )
+
+    cfg = unsloth_config(train_config)
+    packing = cfg.get("packing", False)
+    if not isinstance(packing, bool):
+        raise ValueError("config.unsloth.packing must be a boolean")
+    if packing:
+        raise ValueError("DPO objective does not support packing")
+
+    configured_loss = cfg.get("loss", LOSS_ALL)
+    loss = LOSS_ALL if configured_loss is None else configured_loss
+    if not isinstance(loss, str) or loss not in SUPPORTED_LOSSES:
+        raise ValueError(f"unsupported SFT loss {loss!r}")
+    if loss == LOSS_RESPONSE:
+        raise ValueError(
+            "response SFT loss is not supported for the DPO objective"
+        )
+
+    max_seq_length = cfg.get("maxSeqLength")
+    if (
+        isinstance(max_seq_length, bool)
+        or not isinstance(max_seq_length, int)
+        or max_seq_length <= 0
+    ):
+        raise ValueError(
+            "config.unsloth.maxSeqLength must be an integer greater than zero"
+        )
+    if (
+        objective.max_prompt_length is None
+        or objective.max_prompt_length > max_seq_length
+    ):
+        raise ValueError(
+            "DPO objective maxPromptLength must not exceed "
+            "config.unsloth.maxSeqLength"
+        )
+    return LOSS_ALL
 
 
 def dataset_error_subject(
@@ -1384,6 +1596,16 @@ def validate_training_dataset(
             raise ValueError(
                 f'{dataset_type} dataset record {record_index} field "completion" must be a non-empty string'
             )
+        if dataset_type == DATASET_TYPE_PREFERENCE:
+            for field in DATASET_REQUIRED_FIELDS[DATASET_TYPE_PREFERENCE]:
+                if not record[field].strip():
+                    raise ValueError(
+                        f'{subject} field "{field}" must be a non-empty string'
+                    )
+            if record["chosen"] == record["rejected"]:
+                raise ValueError(
+                    f'{subject} fields "chosen" and "rejected" must be distinct'
+                )
         if dataset_type == DATASET_TYPE_TEXT and record["text"] == "":
             raise ValueError(
                 f'{subject} field "text" must be a non-empty string'
@@ -3988,6 +4210,212 @@ def cleanup_gguf_export(export_directory: Path | str) -> None:
     shutil.rmtree(Path(f"{export_path}_gguf"), ignore_errors=True)
 
 
+def require_dpo_tokenizer(processing_class: Any) -> None:
+    tokenizer = getattr(processing_class, "tokenizer", processing_class)
+    eos_token = getattr(tokenizer, "eos_token", None)
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if not isinstance(eos_token, str) or not eos_token:
+        raise RuntimeError("DPO training requires a tokenizer EOS token")
+    if isinstance(eos_token_id, bool) or not isinstance(eos_token_id, int):
+        raise RuntimeError("DPO training requires a tokenizer EOS token ID")
+
+
+def dpo_prepared_token_ids(
+    record: Mapping[str, Any],
+    *,
+    field: str,
+    record_index: int,
+) -> list[int]:
+    if field not in record:
+        raise RuntimeError(
+            f'DPO trainer prepared preference record {record_index} without "{field}"'
+        )
+
+    raw_token_ids = sequence_values(
+        record[field],
+        description=(
+            f'preference record {record_index} field "{field}" token IDs'
+        ),
+        preprocessing="DPO",
+    )
+    token_ids = []
+    for token_index, raw_token_id in enumerate(raw_token_ids):
+        try:
+            token_id = operator.index(raw_token_id)
+        except TypeError as error:
+            raise RuntimeError(
+                "DPO preprocessing preference record "
+                f'{record_index} field "{field}" token ID {token_index} '
+                "must be an integer"
+            ) from error
+        if isinstance(raw_token_id, bool) or token_id < 0:
+            raise RuntimeError(
+                "DPO preprocessing preference record "
+                f'{record_index} field "{field}" token ID {token_index} '
+                "must be a non-negative integer"
+            )
+        token_ids.append(token_id)
+
+    return token_ids
+
+
+def effective_dpo_completion_token_ids(
+    prompt_token_ids: Sequence[int],
+    completion_token_ids: Sequence[int],
+    *,
+    max_length: int,
+    is_encoder_decoder: bool,
+) -> list[int]:
+    if is_encoder_decoder:
+        return list(completion_token_ids)
+
+    # Pinned TRL right-flushes prompt + completion, keeps the final max_length
+    # positions, and applies completion loss only where the completion mask is 1.
+    first_retained_index = max(
+        0,
+        len(prompt_token_ids) + len(completion_token_ids) - max_length,
+    )
+    completion_offset = max(
+        0,
+        first_retained_index - len(prompt_token_ids),
+    )
+    return list(completion_token_ids[completion_offset:])
+
+
+def validate_prepared_dpo_dataset(
+    train_dataset: Any,
+    *,
+    max_length: int,
+    is_encoder_decoder: bool,
+) -> None:
+    for record_index, record in enumerate(train_dataset):
+        if not isinstance(record, Mapping):
+            raise RuntimeError(
+                f"DPO trainer prepared preference record {record_index} "
+                "as a non-mapping value"
+            )
+
+        prompt_token_ids = dpo_prepared_token_ids(
+            record,
+            field="prompt_input_ids",
+            record_index=record_index,
+        )
+        chosen_token_ids = dpo_prepared_token_ids(
+            record,
+            field="chosen_input_ids",
+            record_index=record_index,
+        )
+        rejected_token_ids = dpo_prepared_token_ids(
+            record,
+            field="rejected_input_ids",
+            record_index=record_index,
+        )
+        if not chosen_token_ids or not rejected_token_ids:
+            raise RuntimeError(
+                f"DPO trainer prepared preference record {record_index} "
+                "with an empty completion token sequence"
+            )
+
+        effective_chosen_token_ids = effective_dpo_completion_token_ids(
+            prompt_token_ids,
+            chosen_token_ids,
+            max_length=max_length,
+            is_encoder_decoder=is_encoder_decoder,
+        )
+        effective_rejected_token_ids = effective_dpo_completion_token_ids(
+            prompt_token_ids,
+            rejected_token_ids,
+            max_length=max_length,
+            is_encoder_decoder=is_encoder_decoder,
+        )
+        if effective_chosen_token_ids == effective_rejected_token_ids:
+            raise RuntimeError(
+                f"DPO trainer prepared preference record {record_index} with "
+                "token-identical chosen and rejected completions after "
+                "tokenization and effective truncation"
+            )
+
+
+def validate_dpo_trainer_contract(
+    trainer: Any,
+    *,
+    policy_model: Any,
+    objective: TrainingObjectiveSpec,
+    max_seq_length: int,
+) -> None:
+    if getattr(trainer, "ref_model", object()) is not None:
+        raise RuntimeError(
+            "DPO trainer must use ref_model=None so the disabled policy "
+            "adapter supplies reference behavior"
+        )
+    if getattr(trainer, "is_peft_model", False) is not True:
+        raise RuntimeError("DPO trainer did not recognize the policy as a PEFT model")
+    if getattr(trainer, "reference_free", True) is not False:
+        raise RuntimeError("DPO trainer must not use reference-free training")
+    if getattr(trainer, "model", None) is not policy_model:
+        raise RuntimeError(
+            "DPO trainer replaced the policy model that AIKit saves after training"
+        )
+
+    accelerator = getattr(trainer, "accelerator", None)
+    unwrap_model = getattr(accelerator, "unwrap_model", None)
+    if not callable(unwrap_model):
+        raise RuntimeError("DPO trainer does not expose model unwrapping")
+    try:
+        effective_model = unwrap_model(trainer.model)
+    except Exception:
+        raise RuntimeError("DPO trainer policy model could not be unwrapped") from None
+    if not callable(getattr(effective_model, "disable_adapter", None)):
+        raise RuntimeError(
+            "DPO trainer policy model does not support disabling its PEFT adapter"
+        )
+
+    if getattr(trainer, "beta", None) != objective.beta:
+        raise RuntimeError("DPO trainer beta does not match the configured objective")
+    effective_loss_types = getattr(trainer, "loss_type", None)
+    if isinstance(effective_loss_types, str):
+        effective_loss_types = [effective_loss_types]
+    if effective_loss_types != [objective.loss_type]:
+        raise RuntimeError(
+            "DPO trainer loss type does not match the configured objective"
+        )
+    if getattr(trainer, "max_prompt_length", None) != objective.max_prompt_length:
+        raise RuntimeError(
+            "DPO trainer max prompt length does not match the configured objective"
+        )
+    if getattr(trainer, "max_length", None) != max_seq_length:
+        raise RuntimeError(
+            "DPO trainer max length does not match config.unsloth.maxSeqLength"
+        )
+    if getattr(trainer, "max_completion_length", object()) is not None:
+        raise RuntimeError(
+            "DPO trainer must not apply a separate completion truncation limit"
+        )
+    if (
+        getattr(trainer, "truncation_mode", None)
+        != DPO_TRUNCATION_KEEP_END
+    ):
+        raise RuntimeError(
+            "DPO trainer must use keep_end full-sequence truncation"
+        )
+
+    train_dataset = getattr(trainer, "train_dataset", None)
+    try:
+        record_count = len(train_dataset)
+    except (TypeError, AttributeError):
+        raise RuntimeError("DPO trainer does not expose a sized training dataset") from None
+    if record_count == 0:
+        raise RuntimeError("DPO trainer prepared an empty training dataset")
+
+    validate_prepared_dpo_dataset(
+        train_dataset,
+        max_length=max_seq_length,
+        is_encoder_decoder=bool(
+            getattr(trainer, "is_encoder_decoder", False)
+        ),
+    )
+
+
 def load_train_dependencies() -> TrainDependencies:
     # Unsloth must be imported before Transformers-based training dependencies.
     from unsloth import FastLanguageModel, is_bfloat16_supported
@@ -3996,7 +4424,7 @@ def load_train_dependencies() -> TrainDependencies:
     from unsloth_zoo.dataset_utils import get_chat_template_parts
     from datasets import Dataset, concatenate_datasets, load_dataset
     from huggingface_hub import model_info
-    from trl import SFTConfig, SFTTrainer
+    from trl import DPOConfig, DPOTrainer, SFTConfig, SFTTrainer
 
     return TrainDependencies(
         fast_language_model=FastLanguageModel,
@@ -4007,6 +4435,8 @@ def load_train_dependencies() -> TrainDependencies:
         resolve_model_name=get_model_name,
         sft_config=SFTConfig,
         sft_trainer=SFTTrainer,
+        dpo_config=DPOConfig,
+        dpo_trainer=DPOTrainer,
         get_chat_template_parts=get_chat_template_parts,
         train_on_responses_only=train_on_responses_only,
         concatenate_datasets=concatenate_datasets,
@@ -4023,25 +4453,61 @@ def load_export_dependencies() -> ExportDependencies:
     )
 
 
+def save_trained_model(
+    model: Any,
+    tokenizer: Any,
+    trained_model_directory: Path | str,
+) -> Path:
+    trained_model_path = Path(trained_model_directory)
+    trained_model_path.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(trained_model_path)
+    tokenizer.save_pretrained(trained_model_path)
+    return trained_model_path
+
+
 def train_model(
     train_config: Mapping[str, Any],
     *,
     trained_model_directory: Path | str = TRAINED_MODEL_DIRECTORY,
     dependencies: TrainDependencies | None = None,
 ) -> Path:
+    objective = training_objective_spec(train_config)
     dataset_specs = training_dataset_specs(train_config)
-    loss = configured_training_loss(train_config)
-    compatibility = training_dataset_compatibility(
-        dataset_specs,
-        loss=loss,
-    )
-    validate_response_packing(train_config, loss=loss)
+
+    if objective.objective_type == OBJECTIVE_TYPE_DPO:
+        if len(dataset_specs) != 1:
+            raise ValueError(
+                "DPO objective requires exactly one preference dataset"
+            )
+        loss = validate_training_objective(
+            train_config,
+            objective=objective,
+            dataset_spec=dataset_specs[0],
+        )
+        compatibility = None
+    else:
+        loss = configured_training_loss(train_config)
+        compatibility = training_dataset_compatibility(
+            dataset_specs,
+            loss=loss,
+        )
+        validate_response_packing(train_config, loss=loss)
 
     if dependencies is None:
         dependencies = load_train_dependencies()
 
     cfg = unsloth_config(train_config)
     max_seq_length = cfg["maxSeqLength"]
+    learning_rate = normalize_go_yaml_float(
+        cfg["learningRate"],
+        description="config.unsloth.learningRate",
+        allow_zero=False,
+    )
+    weight_decay = normalize_go_yaml_float(
+        cfg["weightDecay"],
+        description="config.unsloth.weightDecay",
+        allow_zero=True,
+    )
 
     source_datasets = []
     for dataset_spec in dataset_specs:
@@ -4056,6 +4522,7 @@ def train_model(
             validation_source = None
             if (
                 dataset_spec.dataset_type in CHAT_DATASET_TYPES
+                or dataset_spec.dataset_type == DATASET_TYPE_PREFERENCE
                 or dataset_spec.dataset_type == DATASET_TYPE_TEXT
             ):
                 validation_source = dataset_spec.source
@@ -4075,7 +4542,8 @@ def train_model(
                     source=dataset_spec.source,
                 )
             if (
-                dataset_spec.dataset_type in CHAT_DATASET_TYPES
+                objective.objective_type == OBJECTIVE_TYPE_SFT
+                and dataset_spec.dataset_type in CHAT_DATASET_TYPES
                 and loss == LOSS_RESPONSE
             ):
                 validate_response_training_dataset(
@@ -4092,93 +4560,117 @@ def train_model(
         load_in_4bit=cfg["loadIn4bit"],
     )
 
-    has_chat_dataset = any(
-        dataset_spec.dataset_type in CHAT_DATASET_TYPES
-        for dataset_spec in dataset_specs
-    )
-    has_text_dataset = any(
-        dataset_spec.dataset_type == DATASET_TYPE_TEXT
-        for dataset_spec in dataset_specs
-    )
-    response_only = compatibility == DATASET_COMPATIBILITY_RESPONSE_CHAT
-    completion_only = (
-        compatibility == DATASET_COMPATIBILITY_PROMPT_COMPLETION
-    )
-    validate_all_full_sequence_records = (
-        compatibility == DATASET_COMPATIBILITY_FULL_SEQUENCE
-        and (len(dataset_specs) > 1 or has_chat_dataset)
-    )
-
+    dataset = None
+    has_chat_dataset = False
+    has_text_dataset = False
+    response_only = False
+    completion_only = False
+    validate_all_full_sequence_records = False
     response_markers = None
-    if has_chat_dataset:
-        require_messages_chat_template(tokenizer)
-        if response_only:
-            response_markers = derive_response_markers(
-                tokenizer,
-                get_chat_template_parts=dependencies.get_chat_template_parts,
-            )
-
     text_policy = None
-    if has_text_dataset:
-        text_policy = text_boundary_policy(tokenizer)
+    prompt_prefix_fingerprint = None
+    messages_token_fingerprint = None
 
-    prompt_add_special_tokens = None
-    if completion_only:
-        first_prompt_record = next(iter(source_datasets[0]))
-        prompt_add_special_tokens = prompt_completion_add_special_tokens(
-            tokenizer,
-            first_prompt_record["prompt"],
+    if objective.objective_type == OBJECTIVE_TYPE_DPO:
+        require_dpo_tokenizer(tokenizer)
+        dataset = source_datasets[0]
+    else:
+        has_chat_dataset = any(
+            dataset_spec.dataset_type in CHAT_DATASET_TYPES
+            for dataset_spec in dataset_specs
+        )
+        has_text_dataset = any(
+            dataset_spec.dataset_type == DATASET_TYPE_TEXT
+            for dataset_spec in dataset_specs
+        )
+        response_only = compatibility == DATASET_COMPATIBILITY_RESPONSE_CHAT
+        completion_only = (
+            compatibility == DATASET_COMPATIBILITY_PROMPT_COMPLETION
+        )
+        validate_all_full_sequence_records = (
+            compatibility == DATASET_COMPATIBILITY_FULL_SEQUENCE
+            and (len(dataset_specs) > 1 or has_chat_dataset)
         )
 
-    rendered_source_datasets = []
-    canonical_chat_fingerprints = []
-    prompt_prefix_fingerprints = []
-    for dataset_spec, source_dataset in zip(dataset_specs, source_datasets):
-        dataset_index = dataset_spec.index
-        if dataset_index is None:
-            raise RuntimeError("parsed training dataset is missing its index")
-        with indexed_dataset_errors(dataset_index):
-            if dataset_spec.dataset_type in CHAT_DATASET_TYPES:
-                messages_source_dataset = source_dataset
-                source_dataset = render_messages_dataset(
-                    messages_source_dataset,
-                    processing_class=tokenizer,
-                    source=dataset_spec.source,
-                    dataset_type=dataset_spec.dataset_type,
+        if has_chat_dataset:
+            require_messages_chat_template(tokenizer)
+            if response_only:
+                response_markers = derive_response_markers(
+                    tokenizer,
+                    get_chat_template_parts=(
+                        dependencies.get_chat_template_parts
+                    ),
                 )
-                canonical_chat_fingerprints.append(
-                    validate_messages_tokenization(
+
+        if has_text_dataset:
+            text_policy = text_boundary_policy(tokenizer)
+
+        prompt_add_special_tokens = None
+        if completion_only:
+            first_prompt_record = next(iter(source_datasets[0]))
+            prompt_add_special_tokens = prompt_completion_add_special_tokens(
+                tokenizer,
+                first_prompt_record["prompt"],
+            )
+
+        rendered_source_datasets = []
+        canonical_chat_fingerprints = []
+        prompt_prefix_fingerprints = []
+        for dataset_spec, source_dataset in zip(
+            dataset_specs,
+            source_datasets,
+        ):
+            dataset_index = dataset_spec.index
+            if dataset_index is None:
+                raise RuntimeError(
+                    "parsed training dataset is missing its index"
+                )
+            with indexed_dataset_errors(dataset_index):
+                if dataset_spec.dataset_type in CHAT_DATASET_TYPES:
+                    messages_source_dataset = source_dataset
+                    source_dataset = render_messages_dataset(
                         messages_source_dataset,
-                        source_dataset,
                         processing_class=tokenizer,
-                        max_seq_length=max_seq_length,
                         source=dataset_spec.source,
                         dataset_type=dataset_spec.dataset_type,
-                        response_markers=response_markers,
                     )
-                )
-            elif dataset_spec.dataset_type == DATASET_TYPE_PROMPT_COMPLETION:
-                prompt_prefix_fingerprints.append(
-                    validate_prompt_completion_tokenization(
+                    canonical_chat_fingerprints.append(
+                        validate_messages_tokenization(
+                            messages_source_dataset,
+                            source_dataset,
+                            processing_class=tokenizer,
+                            max_seq_length=max_seq_length,
+                            source=dataset_spec.source,
+                            dataset_type=dataset_spec.dataset_type,
+                            response_markers=response_markers,
+                        )
+                    )
+                elif (
+                    dataset_spec.dataset_type
+                    == DATASET_TYPE_PROMPT_COMPLETION
+                ):
+                    prompt_prefix_fingerprints.append(
+                        validate_prompt_completion_tokenization(
+                            source_dataset,
+                            processing_class=tokenizer,
+                            max_seq_length=max_seq_length,
+                            add_special_tokens=prompt_add_special_tokens,
+                        )
+                    )
+                elif dataset_spec.dataset_type == DATASET_TYPE_TEXT:
+                    if text_policy is None:
+                        raise RuntimeError(
+                            "text preprocessing did not produce a boundary "
+                            "policy"
+                        )
+                    validate_text_sequence_lengths(
                         source_dataset,
                         processing_class=tokenizer,
+                        policy=text_policy,
                         max_seq_length=max_seq_length,
-                        add_special_tokens=prompt_add_special_tokens,
+                        source=dataset_spec.source,
                     )
-                )
-            elif dataset_spec.dataset_type == DATASET_TYPE_TEXT:
-                if text_policy is None:
-                    raise RuntimeError(
-                        "text preprocessing did not produce a boundary policy"
-                    )
-                validate_text_sequence_lengths(
-                    source_dataset,
-                    processing_class=tokenizer,
-                    policy=text_policy,
-                    max_seq_length=max_seq_length,
-                    source=dataset_spec.source,
-                )
-            rendered_source_datasets.append(source_dataset)
+                rendered_source_datasets.append(source_dataset)
 
     base_model_name, base_model_revision = resolve_export_base_model(
         train_config["baseModel"],
@@ -4213,6 +4705,58 @@ def train_model(
         base_model_name=base_model_name,
         revision=base_model_revision,
     )
+
+    if objective.objective_type == OBJECTIVE_TYPE_DPO:
+        if not callable(getattr(model, "disable_adapter", None)):
+            raise RuntimeError(
+                "DPO policy model does not support disabling its PEFT adapter"
+            )
+        bfloat16_supported = dependencies.is_bfloat16_supported()
+        trainer = dependencies.dpo_trainer(
+            model=model,
+            ref_model=None,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+            args=dependencies.dpo_config(
+                output_dir="outputs",
+                dataset_num_proc=2,
+                max_length=max_seq_length,
+                max_prompt_length=objective.max_prompt_length,
+                max_completion_length=None,
+                truncation_mode=DPO_TRUNCATION_KEEP_END,
+                beta=objective.beta,
+                loss_type=objective.loss_type,
+                reference_free=False,
+                per_device_train_batch_size=cfg["batchSize"],
+                gradient_accumulation_steps=cfg[
+                    "gradientAccumulationSteps"
+                ],
+                warmup_steps=cfg["warmupSteps"],
+                max_steps=cfg["maxSteps"],
+                learning_rate=learning_rate,
+                fp16=not bfloat16_supported,
+                bf16=bfloat16_supported,
+                logging_steps=cfg["loggingSteps"],
+                optim=cfg["optimizer"],
+                weight_decay=weight_decay,
+                lr_scheduler_type=cfg["lrSchedulerType"],
+                seed=cfg["seed"],
+                save_strategy="no",
+                report_to="none",
+            ),
+        )
+        validate_dpo_trainer_contract(
+            trainer,
+            policy_model=model,
+            objective=objective,
+            max_seq_length=max_seq_length,
+        )
+        trainer.train()
+        return save_trained_model(
+            model,
+            tokenizer,
+            trained_model_directory,
+        )
 
     canonical_datasets = []
     for dataset_spec, source_dataset in zip(
@@ -4287,16 +4831,15 @@ def train_model(
     else:
         if not callable(dependencies.concatenate_datasets):
             raise RuntimeError(
-                "multiple training datasets require datasets.concatenate_datasets"
+                "multiple training datasets require "
+                "datasets.concatenate_datasets"
             )
         dataset = dependencies.concatenate_datasets(canonical_datasets)
 
-    messages_token_fingerprint = None
     if response_only or validate_all_full_sequence_records:
         messages_token_fingerprint = merge_messages_token_fingerprints(
             messages_token_fingerprints
         )
-    prompt_prefix_fingerprint = None
     if completion_only:
         prompt_prefix_fingerprint = merge_prompt_prefix_fingerprints(
             prompt_prefix_fingerprints
@@ -4320,12 +4863,12 @@ def train_model(
             gradient_accumulation_steps=cfg["gradientAccumulationSteps"],
             warmup_steps=cfg["warmupSteps"],
             max_steps=cfg["maxSteps"],
-            learning_rate=cfg["learningRate"],
+            learning_rate=learning_rate,
             fp16=not bfloat16_supported,
             bf16=bfloat16_supported,
             logging_steps=cfg["loggingSteps"],
             optim=cfg["optimizer"],
-            weight_decay=cfg["weightDecay"],
+            weight_decay=weight_decay,
             lr_scheduler_type=cfg["lrSchedulerType"],
             seed=cfg["seed"],
             save_strategy="no",
@@ -4335,9 +4878,9 @@ def train_model(
     if response_only:
         if bool(getattr(trainer.args, "packing", False)):
             raise RuntimeError(
-                "response-only messages preprocessing does not support effective "
-                "trainer packing because response masks must not cross "
-                "conversation boundaries"
+                "response-only messages preprocessing does not support "
+                "effective trainer packing because response masks must not "
+                "cross conversation boundaries"
             )
         if response_markers is None:
             raise RuntimeError(
@@ -4371,7 +4914,11 @@ def train_model(
             eos_token_id=tokenizer.eos_token_id,
             max_seq_length=max_seq_length,
             packing=bool(getattr(trainer.args, "packing", False)),
-            packing_strategy=getattr(trainer.args, "packing_strategy", "bfd"),
+            packing_strategy=getattr(
+                trainer.args,
+                "packing_strategy",
+                "bfd",
+            ),
             expected_prompt_prefix_fingerprint=prompt_prefix_fingerprint,
         )
 
@@ -4386,7 +4933,11 @@ def train_model(
             max_seq_length=max_seq_length,
             packing=bool(getattr(trainer.args, "packing", False)),
             padding_free=bool(getattr(trainer.args, "padding_free", False)),
-            packing_strategy=getattr(trainer.args, "packing_strategy", "bfd"),
+            packing_strategy=getattr(
+                trainer.args,
+                "packing_strategy",
+                "bfd",
+            ),
             expected_fingerprint=messages_token_fingerprint,
             loss=loss,
             response_markers=response_markers,
@@ -4404,13 +4955,7 @@ def train_model(
             policy=text_policy,
         )
     trainer.train()
-
-    trained_model_path = Path(trained_model_directory)
-    trained_model_path.mkdir(parents=True, exist_ok=True)
-    model.save_pretrained(trained_model_path)
-    tokenizer.save_pretrained(trained_model_path)
-    return trained_model_path
-
+    return save_trained_model(model, tokenizer, trained_model_directory)
 
 def export_model(
     export_config: Mapping[str, Any],

--- a/pkg/finetune/test_target_unsloth.py
+++ b/pkg/finetune/test_target_unsloth.py
@@ -2,6 +2,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import math
 import tempfile
 import threading
 import unittest
@@ -81,6 +82,21 @@ def example_train_config():
             }
         },
     }
+
+
+def example_dpo_train_config():
+    train_config = example_train_config()
+    train_config["objective"] = {
+        "type": "dpo",
+        "beta": 0.1,
+        "lossType": "sigmoid",
+        "maxPromptLength": 512,
+    }
+    train_config["datasets"] = [
+        {"source": "organization/preferences", "type": "preference"}
+    ]
+    train_config["config"]["unsloth"]["learningRate"] = 0.000001
+    return train_config
 
 
 def in_memory_dataset(rows):
@@ -478,12 +494,66 @@ def example_train_dependencies(dataset):
         resolve_model_name=mock.Mock(return_value="example/resolved-model"),
         sft_config=mock.Mock(return_value="sft-config"),
         sft_trainer=mock.Mock(return_value=trainer),
+        dpo_config=mock.Mock(return_value="dpo-config"),
+        dpo_trainer=mock.Mock(),
         get_chat_template_parts=mock.Mock(
             return_value=("<user>", "<assistant>")
         ),
         train_on_responses_only=mock.Mock(side_effect=lambda trainer, **_: trainer),
         concatenate_datasets=mock.Mock(),
     )
+    return dependencies
+
+
+def example_dpo_train_dependencies(dataset, *, train_config=None):
+    if train_config is None:
+        train_config = example_dpo_train_config()
+    dependencies = example_train_dependencies(dataset)
+    base_model = dependencies.fast_language_model.from_pretrained.return_value[0]
+    tokenizer = TextPreprocessingTokenizer(auto_bos=False)
+    tokenizer.tokenizer = tokenizer
+    dependencies.fast_language_model.from_pretrained.return_value = (
+        base_model,
+        tokenizer,
+    )
+    trainer = mock.Mock()
+    trainer.ref_model = None
+    trainer.is_peft_model = True
+    trainer.reference_free = False
+    trainer.beta = train_config["objective"]["beta"]
+    trainer.loss_type = [train_config["objective"]["lossType"]]
+    trainer.max_prompt_length = train_config["objective"]["maxPromptLength"]
+    trainer.max_completion_length = None
+    trainer.max_length = train_config["config"]["unsloth"]["maxSeqLength"]
+    trainer.truncation_mode = target_unsloth.DPO_TRUNCATION_KEEP_END
+    trainer.is_encoder_decoder = False
+    trainer.model = dependencies.fast_language_model.get_peft_model.return_value
+    trainer.accelerator = mock.Mock()
+    trainer.accelerator.unwrap_model.side_effect = lambda model: model
+
+    def token_ids(text):
+        return tokenizer(text, add_special_tokens=False)["input_ids"]
+
+    def construct_trainer(**kwargs):
+        prepared_rows = []
+        for row in kwargs["train_dataset"]:
+            prepared_rows.append(
+                {
+                    "prompt_input_ids": token_ids(row["prompt"])[
+                        -trainer.max_prompt_length :
+                    ],
+                    "chosen_input_ids": token_ids(row["chosen"])
+                    + [tokenizer.eos_token_id],
+                    "rejected_input_ids": token_ids(row["rejected"])
+                    + [tokenizer.eos_token_id],
+                }
+            )
+        trainer.train_dataset = FunctionalDataset(prepared_rows)
+        return trainer
+
+    dependencies.dpo_config.return_value = "dpo-config"
+    dependencies.dpo_trainer.side_effect = construct_trainer
+    dependencies.dpo_trainer.runtime_trainer = trainer
     return dependencies
 
 
@@ -670,6 +740,189 @@ class CLITest(unittest.TestCase):
         export_model.assert_called_once_with(export_config)
         self.assertEqual(output.getvalue(), "Loaded export configuration.\n")
         self.assertNotIn("must-not-log", output.getvalue())
+
+
+class TrainingObjectiveTest(unittest.TestCase):
+    def test_defaults_to_sft_when_omitted_null_or_empty(self):
+        for objective in (mock.sentinel.omitted, None, {}):
+            with self.subTest(objective=objective):
+                train_config = example_train_config()
+                if objective is not mock.sentinel.omitted:
+                    train_config["objective"] = objective
+                self.assertEqual(
+                    target_unsloth.training_objective_spec(train_config),
+                    target_unsloth.TrainingObjectiveSpec(
+                        objective_type="sft",
+                        beta=None,
+                        loss_type=None,
+                        max_prompt_length=None,
+                    ),
+                )
+
+    def test_parses_dpo_defaults_and_explicit_values(self):
+        train_config = example_train_config()
+        train_config["objective"] = {"type": "dpo"}
+        self.assertEqual(
+            target_unsloth.training_objective_spec(train_config),
+            target_unsloth.TrainingObjectiveSpec(
+                objective_type="dpo",
+                beta=0.1,
+                loss_type="sigmoid",
+                max_prompt_length=512,
+            ),
+        )
+
+        train_config["objective"] = {
+            "type": "dpo",
+            "beta": 0.25,
+            "lossType": "sigmoid",
+            "maxPromptLength": 128,
+        }
+        self.assertEqual(
+            target_unsloth.training_objective_spec(train_config),
+            target_unsloth.TrainingObjectiveSpec(
+                objective_type="dpo",
+                beta=0.25,
+                loss_type="sigmoid",
+                max_prompt_length=128,
+            ),
+        )
+
+    def test_normalizes_go_yaml_scientific_dpo_beta(self):
+        train_config = target_unsloth.parse_config(
+            """objective:
+  type: dpo
+  beta: 1e-06
+  lossType: sigmoid
+  maxPromptLength: 512
+"""
+        )
+        self.assertEqual(train_config["objective"]["beta"], "1e-06")
+
+        objective = target_unsloth.training_objective_spec(train_config)
+
+        self.assertEqual(objective.beta, 1e-6)
+        self.assertIsInstance(objective.beta, float)
+
+    def test_rejects_invalid_objective_shapes_and_fields(self):
+        cases = (
+            ([], "must be a mapping"),
+            ({1: "dpo"}, "field names must be strings"),
+            ({"type": "dpo", "future": True}, "unknown fields"),
+            ({"type": ""}, "unsupported training objective"),
+            ({"type": "orpo"}, "unsupported training objective"),
+            ({"type": "sft", "beta": 0.1}, "does not support DPO fields"),
+            ({"type": "sft", "lossType": None}, "does not support DPO fields"),
+        )
+        for objective, error_pattern in cases:
+            with self.subTest(objective=objective):
+                train_config = example_train_config()
+                train_config["objective"] = objective
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.training_objective_spec(train_config)
+
+    def test_rejects_invalid_dpo_values(self):
+        cases = (
+            ("beta", False, "beta.*finite"),
+            ("beta", "0.1", "beta.*finite"),
+            ("beta", "0e+00", "beta.*finite"),
+            ("beta", "-1e-06", "beta.*finite"),
+            ("beta", "1e+309", "beta.*finite"),
+            ("beta", 0, "beta.*finite"),
+            ("beta", -0.1, "beta.*finite"),
+            ("beta", math.nan, "beta.*finite"),
+            ("beta", math.inf, "beta.*finite"),
+            ("lossType", "", "unsupported DPO.*loss"),
+            ("lossType", "hinge", "unsupported DPO.*loss"),
+            ("maxPromptLength", False, "maxPromptLength.*integer"),
+            ("maxPromptLength", 1.5, "maxPromptLength.*integer"),
+            ("maxPromptLength", 0, "maxPromptLength.*integer"),
+            ("maxPromptLength", -1, "maxPromptLength.*integer"),
+        )
+        for field, value, error_pattern in cases:
+            with self.subTest(field=field, value=value):
+                train_config = example_train_config()
+                train_config["objective"] = {"type": "dpo", field: value}
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.training_objective_spec(train_config)
+
+    def test_validates_objective_dataset_and_sft_settings(self):
+        train_config = example_dpo_train_config()
+        objective = target_unsloth.training_objective_spec(train_config)
+        dataset_spec = target_unsloth.training_dataset_spec(train_config)
+        self.assertEqual(
+            target_unsloth.validate_training_objective(
+                train_config,
+                objective=objective,
+                dataset_spec=dataset_spec,
+            ),
+            "all",
+        )
+
+        cases = (
+            (
+                "SFT preference",
+                lambda config: config.pop("objective"),
+                "preference datasets.*DPO",
+            ),
+            (
+                "DPO Alpaca",
+                lambda config: config["datasets"][0].update(type="alpaca"),
+                "DPO objective requires a preference dataset",
+            ),
+            (
+                "DPO packing",
+                lambda config: config["config"]["unsloth"].update(
+                    packing=True
+                ),
+                "DPO objective does not support packing",
+            ),
+            (
+                "DPO non-boolean packing",
+                lambda config: config["config"]["unsloth"].update(
+                    packing="false"
+                ),
+                "packing must be a boolean",
+            ),
+            (
+                "DPO response loss",
+                lambda config: config["config"]["unsloth"].update(
+                    loss="response"
+                ),
+                "response SFT loss.*DPO",
+            ),
+            (
+                "DPO prompt too long",
+                lambda config: config["objective"].update(
+                    maxPromptLength=4096
+                ),
+                "maxPromptLength must not exceed",
+            ),
+            (
+                "DPO text loader",
+                lambda config: config["datasets"][0].update(
+                    source="https://example.test/preferences.txt",
+                    loader={"type": "text"},
+                ),
+                "do not support the text loader",
+            ),
+        )
+        for name, mutate, error_pattern in cases:
+            with self.subTest(name=name):
+                invalid_config = example_dpo_train_config()
+                mutate(invalid_config)
+                invalid_objective = target_unsloth.training_objective_spec(
+                    invalid_config
+                )
+                invalid_dataset = target_unsloth.training_dataset_spec(
+                    invalid_config
+                )
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.validate_training_objective(
+                        invalid_config,
+                        objective=invalid_objective,
+                        dataset_spec=invalid_dataset,
+                    )
 
 
 class DatasetSourceTest(unittest.TestCase):
@@ -1474,9 +1727,9 @@ class MultipleDatasetConfigTest(unittest.TestCase):
             (
                 [
                     {"source": "first", "type": "text"},
-                    {"source": "second", "type": "preference"},
+                    {"source": "second", "type": "future"},
                 ],
-                r"datasets\[1\]\.type.*preference",
+                r"datasets\[1\]\.type.*future",
             ),
             (
                 [
@@ -1561,6 +1814,23 @@ class MultipleDatasetConfigTest(unittest.TestCase):
             target_unsloth.training_dataset_compatibility(
                 specs,
                 loss="response",
+            )
+
+        specs = target_unsloth.training_dataset_specs(
+            {
+                "datasets": [
+                    {"source": "first", "type": "text"},
+                    {"source": "second", "type": "preference"},
+                ]
+            }
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"datasets\[1\] type preference.*only for the DPO objective",
+        ):
+            target_unsloth.training_dataset_compatibility(
+                specs,
+                loss="all",
             )
 
 
@@ -3919,8 +4189,11 @@ class TrainingPhaseTest(unittest.TestCase):
         rows,
         error_pattern,
     ):
-        train_config = example_train_config()
-        train_config["datasets"][0]["type"] = dataset_type
+        if dataset_type == target_unsloth.DATASET_TYPE_PREFERENCE:
+            train_config = example_dpo_train_config()
+        else:
+            train_config = example_train_config()
+            train_config["datasets"][0]["type"] = dataset_type
         dataset = in_memory_dataset(rows)
         dependencies = example_train_dependencies(dataset)
 
@@ -3939,9 +4212,10 @@ class TrainingPhaseTest(unittest.TestCase):
             dependencies.resolve_model_name.assert_not_called()
             dependencies.model_info.assert_not_called()
             dependencies.sft_trainer.assert_not_called()
+            dependencies.dpo_trainer.assert_not_called()
 
         dependencies.load_dataset.assert_called_once_with(
-            "organization/dataset",
+            train_config["datasets"][0]["source"],
             split="train",
         )
 
@@ -4048,6 +4322,8 @@ class TrainingPhaseTest(unittest.TestCase):
             dependencies.sft_config.call_args.kwargs.get("completion_only_loss"),
             False,
         )
+        dependencies.dpo_config.assert_not_called()
+        dependencies.dpo_trainer.assert_not_called()
 
     def test_messages_dataset_renders_to_text_and_verifies_actual_full_loss(self):
         train_config = example_train_config()
@@ -5213,6 +5489,11 @@ class TrainingPhaseTest(unittest.TestCase):
             ]
         }
         valid_text = {"text": "A complete preformatted sequence."}
+        valid_preference = {
+            "prompt": "Question?",
+            "chosen": "A careful answer.",
+            "rejected": "An unsafe answer.",
+        }
         cases = (
             (
                 "empty messages dataset",
@@ -5312,6 +5593,60 @@ class TrainingPhaseTest(unittest.TestCase):
                 "source 'organization/dataset' row 1.*text.*non-empty string",
             ),
             (
+                "empty preference dataset",
+                "preference",
+                [],
+                "preference dataset source 'organization/preferences'.*at least one",
+            ),
+            (
+                "missing preference column",
+                "preference",
+                [{"prompt": "Question?", "chosen": "Answer."}],
+                "missing required columns.*rejected",
+            ),
+            (
+                "null preference prompt",
+                "preference",
+                [{**valid_preference, "prompt": None}],
+                "prompt.*string",
+            ),
+            (
+                "non-string preference chosen",
+                "preference",
+                [{**valid_preference, "chosen": ["Answer"]}],
+                "chosen.*string",
+            ),
+            (
+                "null preference rejected",
+                "preference",
+                [{**valid_preference, "rejected": None}],
+                "rejected.*string",
+            ),
+            (
+                "empty preference prompt",
+                "preference",
+                [{**valid_preference, "prompt": ""}],
+                "prompt.*non-empty string",
+            ),
+            (
+                "whitespace preference chosen",
+                "preference",
+                [{**valid_preference, "chosen": " \t"}],
+                "chosen.*non-empty string",
+            ),
+            (
+                "empty preference rejected",
+                "preference",
+                [{**valid_preference, "rejected": ""}],
+                "rejected.*non-empty string",
+            ),
+            (
+                "identical preference choices",
+                "preference",
+                [{**valid_preference, "rejected": valid_preference["chosen"]}],
+                "chosen.*rejected.*distinct",
+            ),
+            (
                 "missing Alpaca column",
                 "alpaca",
                 [{"instruction": "Summarize", "input": "Passage"}],
@@ -5365,6 +5700,8 @@ class TrainingPhaseTest(unittest.TestCase):
             resolve_model_name=mock.Mock(return_value="example/resolved-model"),
             sft_config=mock.Mock(),
             sft_trainer=mock.Mock(),
+            dpo_config=mock.Mock(),
+            dpo_trainer=mock.Mock(),
             get_chat_template_parts=mock.Mock(),
             train_on_responses_only=mock.Mock(),
         )
@@ -5385,6 +5722,549 @@ class TrainingPhaseTest(unittest.TestCase):
         )
         dataset.map.assert_not_called()
         dataset.projected_dataset.map.assert_not_called()
+
+
+class DPOTrainingPhaseTest(unittest.TestCase):
+    def preference_rows(self):
+        return [
+            {
+                "prompt": "How should I rotate an API key?",
+                "chosen": "Deploy a replacement before revoking the old key.",
+                "rejected": "Revoke the old key before creating a replacement.",
+                "metadata": "must be removed",
+            },
+            {
+                "prompt": "How should I store a secret?",
+                "chosen": "Use a dedicated secret manager.",
+                "rejected": "Commit it to source control.",
+                "metadata": "must also be removed",
+            },
+        ]
+
+    def test_trains_dpo_without_sft_formatting_and_preserves_preferences(self):
+        train_config = example_dpo_train_config()
+        train_config["objective"].update(beta=0.25, maxPromptLength=128)
+        train_config["config"]["unsloth"].update(
+            maxSeqLength=1024,
+            batchSize=1,
+            gradientAccumulationSteps=2,
+            warmupSteps=3,
+            maxSteps=4,
+            learningRate=0.000001,
+            loggingSteps=5,
+            optimizer="adamw_8bit",
+            weightDecay=0.02,
+            lrSchedulerType="cosine",
+            seed=7,
+        )
+        dataset = FunctionalDataset(self.preference_rows())
+        dependencies = example_dpo_train_dependencies(
+            dataset,
+            train_config=train_config,
+        )
+        base_model, tokenizer = (
+            dependencies.fast_language_model.from_pretrained.return_value
+        )
+        adapter_model = (
+            dependencies.fast_language_model.get_peft_model.return_value
+        )
+        runtime_trainer = dependencies.dpo_trainer.runtime_trainer
+
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            mock.patch.object(
+                target_unsloth,
+                "prepare_training_dataset",
+            ) as prepare_training_dataset,
+            mock.patch.object(
+                target_unsloth,
+                "format_alpaca_examples",
+            ) as format_alpaca_examples,
+        ):
+            trained_model_directory = (
+                Path(temporary_directory) / "trained-model"
+            )
+            result = target_unsloth.train_model(
+                train_config,
+                trained_model_directory=trained_model_directory,
+                dependencies=dependencies,
+            )
+
+        self.assertEqual(result, trained_model_directory)
+        dependencies.load_dataset.assert_called_once_with(
+            "organization/preferences",
+            split="train",
+        )
+        dataset.select_columns.assert_called_once_with(
+            ["prompt", "chosen", "rejected"]
+        )
+        projected_dataset = dataset.projected_dataset
+        self.assertEqual(
+            projected_dataset.column_names,
+            ["prompt", "chosen", "rejected"],
+        )
+        self.assertEqual(
+            list(projected_dataset),
+            [
+                {
+                    "prompt": row["prompt"],
+                    "chosen": row["chosen"],
+                    "rejected": row["rejected"],
+                }
+                for row in self.preference_rows()
+            ],
+        )
+        projected_dataset.map.assert_not_called()
+        prepare_training_dataset.assert_not_called()
+        format_alpaca_examples.assert_not_called()
+        dependencies.sft_config.assert_not_called()
+        dependencies.sft_trainer.assert_not_called()
+        dependencies.get_chat_template_parts.assert_not_called()
+        dependencies.train_on_responses_only.assert_not_called()
+
+        dependencies.dpo_config.assert_called_once_with(
+            output_dir="outputs",
+            dataset_num_proc=2,
+            max_length=1024,
+            max_prompt_length=128,
+            max_completion_length=None,
+            truncation_mode="keep_end",
+            beta=0.25,
+            loss_type="sigmoid",
+            reference_free=False,
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=2,
+            warmup_steps=3,
+            max_steps=4,
+            learning_rate=0.000001,
+            fp16=False,
+            bf16=True,
+            logging_steps=5,
+            optim="adamw_8bit",
+            weight_decay=0.02,
+            lr_scheduler_type="cosine",
+            seed=7,
+            save_strategy="no",
+            report_to="none",
+        )
+        dependencies.dpo_trainer.assert_called_once_with(
+            model=adapter_model,
+            ref_model=None,
+            train_dataset=projected_dataset,
+            processing_class=tokenizer,
+            args="dpo-config",
+        )
+        dpo_kwargs = dependencies.dpo_config.call_args.kwargs
+        for sft_only_field in (
+            "packing",
+            "dataset_text_field",
+            "assistant_only_loss",
+            "completion_only_loss",
+            "peft_config",
+        ):
+            self.assertNotIn(sft_only_field, dpo_kwargs)
+            self.assertNotIn(
+                sft_only_field,
+                dependencies.dpo_trainer.call_args.kwargs,
+            )
+
+        runtime_trainer.train.assert_called_once_with()
+        dependencies.fast_language_model.from_pretrained.assert_called_once_with(
+            model_name="example/model",
+            max_seq_length=1024,
+            dtype=None,
+            load_in_4bit=True,
+        )
+        dependencies.fast_language_model.get_peft_model.assert_called_once()
+        adapter_model.save_pretrained.assert_called_once_with(
+            trained_model_directory
+        )
+        tokenizer.save_pretrained.assert_called_once_with(
+            trained_model_directory
+        )
+        self.assertIs(
+            base_model,
+            dependencies.fast_language_model.from_pretrained.return_value[0],
+        )
+
+    def test_normalizes_go_yaml_scientific_floats_for_dpo_config(self):
+        train_config = target_unsloth.parse_config(
+            """baseModel: example/model
+objective:
+  type: dpo
+  beta: 1e-06
+  lossType: sigmoid
+  maxPromptLength: 512
+datasets:
+- source: organization/preferences
+  type: preference
+config:
+  unsloth:
+    packing: false
+    maxSeqLength: 2048
+    loadIn4bit: true
+    loss: all
+    batchSize: 2
+    gradientAccumulationSteps: 4
+    warmupSteps: 10
+    maxSteps: 60
+    learningRate: 1e-06
+    loggingSteps: 1
+    optimizer: adamw_8bit
+    weightDecay: 1e-06
+    lrSchedulerType: linear
+    seed: 42
+"""
+        )
+        cfg = train_config["config"]["unsloth"]
+        self.assertEqual(train_config["objective"]["beta"], "1e-06")
+        self.assertEqual(cfg["learningRate"], "1e-06")
+        self.assertEqual(cfg["weightDecay"], "1e-06")
+
+        dataset = FunctionalDataset(self.preference_rows())
+        dependencies = example_dpo_train_dependencies(
+            dataset,
+            train_config=train_config,
+        )
+        dependencies.dpo_trainer.runtime_trainer.beta = 1e-6
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target_unsloth.train_model(
+                train_config,
+                trained_model_directory=(
+                    Path(temporary_directory) / "trained-model"
+                ),
+                dependencies=dependencies,
+            )
+
+        dpo_config = dependencies.dpo_config.call_args.kwargs
+        self.assertEqual(dpo_config["beta"], 1e-6)
+        self.assertIsInstance(dpo_config["beta"], float)
+        self.assertEqual(dpo_config["learning_rate"], 1e-6)
+        self.assertIsInstance(dpo_config["learning_rate"], float)
+        self.assertEqual(dpo_config["weight_decay"], 1e-6)
+        self.assertIsInstance(dpo_config["weight_decay"], float)
+
+    def test_rejects_invalid_transport_floats_before_loading_or_model_allocation(
+        self,
+    ):
+        cases = (
+            ("learningRate", "0e+00", "learningRate.*greater than zero"),
+            ("learningRate", "1e+309", "learningRate.*greater than zero"),
+            ("weightDecay", "-1e-06", "weightDecay.*zero or greater"),
+            ("weightDecay", "1e+309", "weightDecay.*zero or greater"),
+        )
+        for field, value, error_pattern in cases:
+            with self.subTest(field=field, value=value):
+                train_config = example_dpo_train_config()
+                train_config["config"]["unsloth"][field] = value
+                dependencies = example_train_dependencies(mock.Mock())
+
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.train_model(
+                        train_config,
+                        dependencies=dependencies,
+                    )
+
+                dependencies.load_dataset.assert_not_called()
+                dependencies.fast_language_model.from_pretrained.assert_not_called()
+                dependencies.fast_language_model.get_peft_model.assert_not_called()
+                dependencies.dpo_config.assert_not_called()
+                dependencies.dpo_trainer.assert_not_called()
+
+    def test_rejects_dpo_configuration_before_loading_or_model_allocation(self):
+        cases = (
+            (
+                "SFT dataset",
+                lambda config: config["datasets"][0].update(type="alpaca"),
+                "DPO objective requires a preference dataset",
+            ),
+            (
+                "packing",
+                lambda config: config["config"]["unsloth"].update(
+                    packing=True
+                ),
+                "does not support packing",
+            ),
+            (
+                "response loss",
+                lambda config: config["config"]["unsloth"].update(
+                    loss="response"
+                ),
+                "response SFT loss",
+            ),
+        )
+        for name, mutate, error_pattern in cases:
+            with self.subTest(name=name):
+                train_config = example_dpo_train_config()
+                mutate(train_config)
+                dependencies = example_train_dependencies(mock.Mock())
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.train_model(
+                        train_config,
+                        dependencies=dependencies,
+                    )
+                dependencies.load_dataset.assert_not_called()
+                dependencies.fast_language_model.from_pretrained.assert_not_called()
+                dependencies.fast_language_model.get_peft_model.assert_not_called()
+                dependencies.sft_trainer.assert_not_called()
+                dependencies.dpo_trainer.assert_not_called()
+
+    def test_rejects_multiple_preference_datasets_before_loading(self):
+        train_config = example_dpo_train_config()
+        train_config["datasets"].append(
+            {
+                "source": "organization/other-preferences",
+                "type": "preference",
+            }
+        )
+        dependencies = example_train_dependencies(mock.Mock())
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DPO objective requires exactly one preference dataset",
+        ):
+            target_unsloth.train_model(
+                train_config,
+                dependencies=dependencies,
+            )
+
+        dependencies.load_dataset.assert_not_called()
+        dependencies.fast_language_model.from_pretrained.assert_not_called()
+        dependencies.fast_language_model.get_peft_model.assert_not_called()
+        dependencies.sft_trainer.assert_not_called()
+        dependencies.dpo_trainer.assert_not_called()
+
+    def test_rejects_preference_pair_collapsed_by_effective_truncation(self):
+        train_config = example_dpo_train_config()
+        train_config["objective"]["maxPromptLength"] = 3
+        train_config["config"]["unsloth"]["maxSeqLength"] = 3
+        dataset = FunctionalDataset(
+            [
+                {
+                    "prompt": "Prompt",
+                    "chosen": "Xab",
+                    "rejected": "Yab",
+                }
+            ]
+        )
+        dependencies = example_dpo_train_dependencies(
+            dataset,
+            train_config=train_config,
+        )
+        runtime_trainer = dependencies.dpo_trainer.runtime_trainer
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "record 0.*token-identical.*effective truncation",
+        ):
+            target_unsloth.train_model(
+                train_config,
+                dependencies=dependencies,
+            )
+
+        runtime_trainer.train.assert_not_called()
+        runtime_trainer.model.save_pretrained.assert_not_called()
+
+    def test_rejects_invalid_dpo_runtime_contract_before_training(self):
+        cases = (
+            (
+                "reference model",
+                lambda trainer, _model: setattr(trainer, "ref_model", object()),
+                "must use ref_model=None",
+            ),
+            (
+                "not PEFT",
+                lambda trainer, _model: setattr(
+                    trainer, "is_peft_model", False
+                ),
+                "did not recognize.*PEFT",
+            ),
+            (
+                "reference free",
+                lambda trainer, _model: setattr(
+                    trainer, "reference_free", True
+                ),
+                "must not use reference-free",
+            ),
+            (
+                "policy model replaced",
+                lambda trainer, _model: setattr(trainer, "model", mock.Mock()),
+                "replaced the policy model",
+            ),
+            (
+                "adapter cannot be disabled",
+                lambda _trainer, model: setattr(model, "disable_adapter", None),
+                "does not support disabling.*PEFT adapter",
+            ),
+            (
+                "beta mismatch",
+                lambda trainer, _model: setattr(trainer, "beta", 0.2),
+                "beta does not match",
+            ),
+            (
+                "loss mismatch",
+                lambda trainer, _model: setattr(
+                    trainer, "loss_type", ["hinge"]
+                ),
+                "loss type does not match",
+            ),
+            (
+                "prompt length mismatch",
+                lambda trainer, _model: setattr(
+                    trainer, "max_prompt_length", 128
+                ),
+                "max prompt length does not match",
+            ),
+            (
+                "sequence length mismatch",
+                lambda trainer, _model: setattr(
+                    trainer, "max_length", 1024
+                ),
+                "max length does not match",
+            ),
+            (
+                "completion length limit",
+                lambda trainer, _model: setattr(
+                    trainer, "max_completion_length", 128
+                ),
+                "must not apply a separate completion truncation limit",
+            ),
+            (
+                "truncation mode mismatch",
+                lambda trainer, _model: setattr(
+                    trainer, "truncation_mode", "keep_start"
+                ),
+                "must use keep_end",
+            ),
+        )
+        for name, mutate, error_pattern in cases:
+            with self.subTest(name=name):
+                train_config = example_dpo_train_config()
+                dataset = in_memory_dataset(self.preference_rows())
+                dependencies = example_dpo_train_dependencies(dataset)
+                runtime_trainer = mock.Mock()
+                runtime_trainer.ref_model = None
+                runtime_trainer.is_peft_model = True
+                runtime_trainer.reference_free = False
+                runtime_trainer.beta = 0.1
+                runtime_trainer.loss_type = ["sigmoid"]
+                runtime_trainer.max_prompt_length = 512
+                runtime_trainer.max_completion_length = None
+                runtime_trainer.max_length = 2048
+                runtime_trainer.truncation_mode = (
+                    target_unsloth.DPO_TRUNCATION_KEEP_END
+                )
+                runtime_trainer.is_encoder_decoder = False
+                runtime_trainer.model = (
+                    dependencies.fast_language_model.get_peft_model.return_value
+                )
+                runtime_trainer.accelerator = mock.Mock()
+                runtime_trainer.accelerator.unwrap_model.side_effect = (
+                    lambda model: model
+                )
+
+                def construct_trainer(**kwargs):
+                    runtime_trainer.train_dataset = kwargs["train_dataset"]
+                    return runtime_trainer
+
+                dependencies.dpo_trainer.side_effect = construct_trainer
+                mutate(runtime_trainer, runtime_trainer.model)
+                with self.assertRaisesRegex(RuntimeError, error_pattern):
+                    target_unsloth.train_model(
+                        train_config,
+                        dependencies=dependencies,
+                    )
+                runtime_trainer.train.assert_not_called()
+                runtime_trainer.model.save_pretrained.assert_not_called()
+
+    def test_rejects_empty_dataset_after_dpo_trainer_preprocessing(self):
+        train_config = example_dpo_train_config()
+        dataset = in_memory_dataset(self.preference_rows())
+        dependencies = example_dpo_train_dependencies(dataset)
+        runtime_trainer = dependencies.dpo_trainer.runtime_trainer
+
+        def construct_empty_trainer(**_kwargs):
+            runtime_trainer.train_dataset = []
+            return runtime_trainer
+
+        dependencies.dpo_trainer.side_effect = construct_empty_trainer
+        with self.assertRaisesRegex(RuntimeError, "prepared an empty"):
+            target_unsloth.train_model(
+                train_config,
+                dependencies=dependencies,
+            )
+
+        runtime_trainer.train.assert_not_called()
+        runtime_trainer.model.save_pretrained.assert_not_called()
+
+    def test_dpo_checksum_failure_prevents_parser_and_model_allocation(self):
+        body = (
+            b'{"prompt":"Question?","chosen":"Safe",'
+            b'"rejected":"Unsafe"}\n'
+        )
+        with LocalDatasetServer({"/preferences.jsonl": body}) as server:
+            signed_url = (
+                server.url("/preferences.jsonl")
+                + "?token=private-value#fragment-marker"
+            )
+            train_config = example_dpo_train_config()
+            train_config["datasets"][0].update(
+                source=signed_url,
+                loader={
+                    "type": "json",
+                    "checksum": "sha256:" + "0" * 64,
+                },
+            )
+            dependencies = example_dpo_train_dependencies(mock.Mock())
+
+            with tempfile.TemporaryDirectory() as cache_directory:
+                with mock.patch.dict(
+                    target_unsloth.os.environ,
+                    {"HF_DATASETS_CACHE": cache_directory},
+                ):
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        "checksum does not match",
+                    ) as raised:
+                        target_unsloth.train_model(
+                            train_config,
+                            dependencies=dependencies,
+                        )
+
+        for secret in ("token", "private-value", "fragment-marker"):
+            self.assertNotIn(secret, str(raised.exception))
+        dependencies.load_dataset.assert_not_called()
+        dependencies.fast_language_model.from_pretrained.assert_not_called()
+        dependencies.fast_language_model.get_peft_model.assert_not_called()
+        dependencies.dpo_trainer.assert_not_called()
+
+    def test_rejects_missing_dpo_tokenizer_eos_before_lora_allocation(self):
+        train_config = example_dpo_train_config()
+        dataset = in_memory_dataset(self.preference_rows())
+        dependencies = example_dpo_train_dependencies(dataset)
+        tokenizer = dependencies.fast_language_model.from_pretrained.return_value[1]
+        tokenizer.eos_token = None
+
+        with self.assertRaisesRegex(RuntimeError, "tokenizer EOS token"):
+            target_unsloth.train_model(
+                train_config,
+                dependencies=dependencies,
+            )
+
+        dependencies.fast_language_model.get_peft_model.assert_not_called()
+        dependencies.dpo_trainer.assert_not_called()
+
+    def test_imports_unsloth_before_trl_dpo_dependencies(self):
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        function_start = source.index("def load_train_dependencies()")
+        function_end = source.index("\ndef load_export_dependencies()", function_start)
+        dependency_source = source[function_start:function_end]
+        self.assertLess(
+            dependency_source.index("from unsloth import"),
+            dependency_source.index("from trl import"),
+        )
+        self.assertIn("DPOConfig", dependency_source)
+        self.assertIn("DPOTrainer", dependency_source)
 
 
 class MultipleTrainingDatasetsTest(unittest.TestCase):

--- a/pkg/finetune/test_target_unsloth.py
+++ b/pkg/finetune/test_target_unsloth.py
@@ -5737,6 +5737,47 @@ class MultipleTrainingDatasetsTest(unittest.TestCase):
             [False, True],
         )
 
+    def test_rejects_prompt_completion_special_token_boundary_changes(self):
+        plain_row = {"prompt": "A", "completion": " C"}
+        explicit_bos_row = {"prompt": "<bos>B", "completion": " C"}
+        cases = (
+            (
+                [FunctionalDataset([plain_row]), FunctionalDataset([explicit_bos_row])],
+                r"datasets\[1\] prompt-completion preprocessing record 0.*"
+                r"source add_special_tokens=False.*"
+                r"combined dataset add_special_tokens=True",
+            ),
+            (
+                [FunctionalDataset([explicit_bos_row]), FunctionalDataset([plain_row])],
+                r"datasets\[1\] prompt-completion preprocessing record 0.*"
+                r"source add_special_tokens=True.*"
+                r"combined dataset add_special_tokens=False",
+            ),
+        )
+
+        for datasets, error_pattern in cases:
+            with self.subTest(first_prompt=datasets[0][0]["prompt"]):
+                dependencies = self.dependencies_for(datasets)
+                base_model = (
+                    dependencies.fast_language_model.from_pretrained.return_value[0]
+                )
+                dependencies.fast_language_model.from_pretrained.return_value = (
+                    base_model,
+                    TextPreprocessingTokenizer(auto_bos=True),
+                )
+
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.train_model(
+                        self.config_for(
+                            ["prompt-completion", "prompt-completion"]
+                        ),
+                        dependencies=dependencies,
+                    )
+
+                dependencies.fast_language_model.get_peft_model.assert_not_called()
+                dependencies.concatenate_datasets.assert_not_called()
+                dependencies.sft_trainer.assert_not_called()
+
     def test_multiple_prompt_completion_sources_preserve_duplicates_through_bfd(self):
         config = self.config_for(
             ["prompt-completion", "prompt-completion"],
@@ -5805,11 +5846,12 @@ class MultipleTrainingDatasetsTest(unittest.TestCase):
             and "<bos>Duplicate" in call.args[0]
         ]
         self.assertTrue(second_source_tokenization_calls)
-        self.assertTrue(
-            all(
-                call.kwargs["add_special_tokens"] is True
+        self.assertEqual(
+            {
+                call.kwargs["add_special_tokens"]
                 for call in second_source_tokenization_calls
-            )
+            },
+            {False, True},
         )
         trainer.train.assert_called_once_with()
 

--- a/pkg/finetune/test_target_unsloth.py
+++ b/pkg/finetune/test_target_unsloth.py
@@ -5543,7 +5543,10 @@ class MultipleTrainingDatasetsTest(unittest.TestCase):
                 FunctionalDataset([{"conversations": sharegpt, "id": 4}]),
             ]
         )
-        tokenizer = MessagesTokenizer()
+        # Use a tokenizer without a BOS token so every full-sequence source has
+        # the same rendered-text special-token policy. A separate regression
+        # test covers mixed policies that change token boundaries.
+        tokenizer = MessagesTokenizer(bos_token=None, bos_token_id=None)
         base_model = dependencies.fast_language_model.from_pretrained.return_value[0]
         dependencies.fast_language_model.from_pretrained.return_value = (
             base_model,
@@ -5666,6 +5669,73 @@ class MultipleTrainingDatasetsTest(unittest.TestCase):
         )
         dependencies.train_on_responses_only.assert_not_called()
         trainer.train.assert_called_once_with()
+
+    def test_rejects_mixed_full_sequence_special_token_boundary_changes(self):
+        alpaca_row = {
+            "instruction": "Summarize",
+            "input": "First source",
+            "output": "Summary",
+        }
+        messages_row = {
+            "messages": [
+                {"role": "user", "content": "Question?"},
+                {"role": "assistant", "content": "Answer."},
+            ]
+        }
+        cases = (
+            (
+                ["alpaca", "messages"],
+                [FunctionalDataset([alpaca_row]), FunctionalDataset([messages_row])],
+                r"datasets\[1\] messages dataset.*tokenizes differently.*"
+                r"source add_special_tokens=False.*"
+                r"combined full-sequence add_special_tokens=True",
+            ),
+            (
+                ["messages", "alpaca"],
+                [FunctionalDataset([messages_row]), FunctionalDataset([alpaca_row])],
+                r"datasets\[1\] alpaca dataset.*tokenizes differently.*"
+                r"source add_special_tokens=True.*"
+                r"combined full-sequence add_special_tokens=False",
+            ),
+        )
+
+        for dataset_types, datasets, error_pattern in cases:
+            with self.subTest(dataset_types=dataset_types):
+                dependencies = self.dependencies_for(datasets)
+                base_model = (
+                    dependencies.fast_language_model.from_pretrained.return_value[0]
+                )
+                dependencies.fast_language_model.from_pretrained.return_value = (
+                    base_model,
+                    MessagesTokenizer(),
+                )
+
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.train_model(
+                        self.config_for(dataset_types),
+                        dependencies=dependencies,
+                    )
+
+                dependencies.concatenate_datasets.assert_not_called()
+                dependencies.sft_trainer.assert_not_called()
+
+    def test_allows_noop_full_sequence_special_token_policy_difference(self):
+        tokenizer = TextPreprocessingTokenizer(auto_bos=False)
+        fingerprint = target_unsloth.validate_full_sequence_text_tokenization(
+            FunctionalDataset([{"text": "plain text"}]),
+            processing_class=tokenizer,
+            max_seq_length=128,
+            dataset_type="alpaca",
+            source="organization/source-0",
+            dataset_index=0,
+            add_special_tokens=False,
+        )
+
+        self.assertEqual(fingerprint.sequence_count, 1)
+        self.assertEqual(
+            [call["add_special_tokens"] for call in tokenizer.calls],
+            [False, True],
+        )
 
     def test_multiple_prompt_completion_sources_preserve_duplicates_through_bfd(self):
         config = self.config_for(

--- a/pkg/finetune/test_target_unsloth.py
+++ b/pkg/finetune/test_target_unsloth.py
@@ -482,6 +482,7 @@ def example_train_dependencies(dataset):
             return_value=("<user>", "<assistant>")
         ),
         train_on_responses_only=mock.Mock(side_effect=lambda trainer, **_: trainer),
+        concatenate_datasets=mock.Mock(),
     )
     return dependencies
 
@@ -1415,6 +1416,152 @@ class DatasetLoaderTest(unittest.TestCase):
             self.assertNotIn(secret, message)
         self.assertIsNone(raised.exception.__cause__)
         self.assertTrue(raised.exception.__suppress_context__)
+
+
+class MultipleDatasetConfigTest(unittest.TestCase):
+    def test_parses_every_dataset_in_yaml_order_with_indexes(self):
+        revision = "0123456789abcdef0123456789abcdef01234567"
+        config = {
+            "datasets": [
+                {"source": "organization/first", "type": "alpaca"},
+                {
+                    "source": "organization/second",
+                    "type": "text",
+                    "loader": {
+                        "type": "huggingface",
+                        "subset": "default",
+                        "split": "train_sft",
+                        "revision": revision,
+                    },
+                },
+                {"source": "organization/third", "type": "messages"},
+            ]
+        }
+
+        specs = target_unsloth.training_dataset_specs(config)
+
+        self.assertEqual([spec.index for spec in specs], [0, 1, 2])
+        self.assertEqual(
+            [spec.source for spec in specs],
+            [
+                "organization/first",
+                "organization/second",
+                "organization/third",
+            ],
+        )
+        self.assertEqual(
+            specs[1].loader,
+            target_unsloth.DatasetLoaderSpec(
+                loader_type="huggingface",
+                subset="default",
+                split="train_sft",
+                revision=revision,
+                checksum=None,
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "exactly one dataset"):
+            target_unsloth.training_dataset_spec(config)
+
+    def test_rejects_indexed_dataset_and_loader_configuration_errors(self):
+        cases = (
+            (
+                [
+                    {"source": "first", "type": "text"},
+                    {"source": " ", "type": "text"},
+                ],
+                r"datasets\[1\]\.source",
+            ),
+            (
+                [
+                    {"source": "first", "type": "text"},
+                    {"source": "second", "type": "preference"},
+                ],
+                r"datasets\[1\]\.type.*preference",
+            ),
+            (
+                [
+                    {"source": "first", "type": "text"},
+                    {
+                        "source": "second",
+                        "type": "text",
+                        "loader": {"type": "huggingface", "split": "bad-split"},
+                    },
+                ],
+                r"datasets\[1\]\.loader.*split",
+            ),
+        )
+        for datasets, error_pattern in cases:
+            with self.subTest(error_pattern=error_pattern):
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.training_dataset_specs({"datasets": datasets})
+
+    def test_validates_one_semantic_compatibility_group(self):
+        cases = (
+            (
+                ["alpaca", "text", "messages", "sharegpt"],
+                "all",
+                target_unsloth.DATASET_COMPATIBILITY_FULL_SEQUENCE,
+            ),
+            (
+                ["prompt-completion", "prompt-completion"],
+                "all",
+                target_unsloth.DATASET_COMPATIBILITY_PROMPT_COMPLETION,
+            ),
+            (
+                ["messages", "sharegpt"],
+                "response",
+                target_unsloth.DATASET_COMPATIBILITY_RESPONSE_CHAT,
+            ),
+        )
+        for dataset_types, loss, expected in cases:
+            with self.subTest(dataset_types=dataset_types, loss=loss):
+                specs = target_unsloth.training_dataset_specs(
+                    {
+                        "datasets": [
+                            {"source": f"source-{index}", "type": dataset_type}
+                            for index, dataset_type in enumerate(dataset_types)
+                        ]
+                    }
+                )
+                self.assertEqual(
+                    target_unsloth.training_dataset_compatibility(
+                        specs,
+                        loss=loss,
+                    ),
+                    expected,
+                )
+
+        specs = target_unsloth.training_dataset_specs(
+            {
+                "datasets": [
+                    {"source": "first", "type": "alpaca"},
+                    {"source": "second", "type": "prompt-completion"},
+                ]
+            }
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"datasets\[1\] type prompt-completion is incompatible with "
+            r"datasets\[0\] type alpaca: completion-only and full-sequence",
+        ):
+            target_unsloth.training_dataset_compatibility(specs, loss="all")
+
+        specs = target_unsloth.training_dataset_specs(
+            {
+                "datasets": [
+                    {"source": "first", "type": "messages"},
+                    {"source": "second", "type": "text"},
+                ]
+            }
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"datasets\[1\] type text.*supported only for messages and sharegpt",
+        ):
+            target_unsloth.training_dataset_compatibility(
+                specs,
+                loss="response",
+            )
 
 
 class MessagesSchemaTest(unittest.TestCase):
@@ -3685,6 +3832,85 @@ class TextPreprocessingContractTest(unittest.TestCase):
             )
 
 
+class MultiSourceFingerprintTest(unittest.TestCase):
+    def test_message_fingerprints_merge_order_independently_and_keep_duplicates(self):
+        duplicate = [11, 12, 13]
+        other = [21, 22]
+        first_source = target_unsloth.empty_messages_token_fingerprint()
+        first_source = target_unsloth.extend_messages_token_fingerprint(
+            first_source,
+            duplicate,
+            description="first source duplicate",
+        )
+        second_source = target_unsloth.empty_messages_token_fingerprint()
+        for token_ids in (other, duplicate):
+            second_source = target_unsloth.extend_messages_token_fingerprint(
+                second_source,
+                token_ids,
+                description="second source sequence",
+            )
+
+        merged = target_unsloth.merge_messages_token_fingerprints(
+            [first_source, second_source]
+        )
+        reordered = target_unsloth.empty_messages_token_fingerprint()
+        for token_ids in (duplicate, duplicate, other):
+            reordered = target_unsloth.extend_messages_token_fingerprint(
+                reordered,
+                token_ids,
+                description="BFD reordered sequence",
+            )
+        missing_duplicate = target_unsloth.empty_messages_token_fingerprint()
+        for token_ids in (duplicate, other):
+            missing_duplicate = target_unsloth.extend_messages_token_fingerprint(
+                missing_duplicate,
+                token_ids,
+                description="missing duplicate sequence",
+            )
+
+        self.assertEqual(merged, reordered)
+        self.assertEqual(merged.sequence_count, 3)
+        self.assertNotEqual(merged, missing_duplicate)
+
+    def test_prompt_fingerprints_merge_order_independently_and_keep_duplicates(self):
+        duplicate = [31, 32]
+        other = [41]
+        first_source = target_unsloth.empty_prompt_prefix_fingerprint()
+        for token_ids in (duplicate, other):
+            first_source = target_unsloth.extend_prompt_prefix_fingerprint(
+                first_source,
+                token_ids,
+                description="first source prompt",
+            )
+        second_source = target_unsloth.extend_prompt_prefix_fingerprint(
+            target_unsloth.empty_prompt_prefix_fingerprint(),
+            duplicate,
+            description="second source duplicate prompt",
+        )
+
+        merged = target_unsloth.merge_prompt_prefix_fingerprints(
+            [first_source, second_source]
+        )
+        reordered = target_unsloth.empty_prompt_prefix_fingerprint()
+        for token_ids in (duplicate, duplicate, other):
+            reordered = target_unsloth.extend_prompt_prefix_fingerprint(
+                reordered,
+                token_ids,
+                description="BFD reordered prompt",
+            )
+        missing_duplicate = target_unsloth.empty_prompt_prefix_fingerprint()
+        for token_ids in (duplicate, other):
+            missing_duplicate = target_unsloth.extend_prompt_prefix_fingerprint(
+                missing_duplicate,
+                token_ids,
+                description="missing duplicate prompt",
+            )
+
+        self.assertEqual(merged, reordered)
+        self.assertEqual(merged.sequence_count, 3)
+        self.assertNotEqual(merged, missing_duplicate)
+
+
 class TrainingPhaseTest(unittest.TestCase):
     def assert_dataset_rejected_before_model(
         self,
@@ -3795,6 +4021,7 @@ class TrainingPhaseTest(unittest.TestCase):
             "organization/dataset",
             split="train",
         )
+        dependencies.concatenate_datasets.assert_not_called()
         dataset.select_columns.assert_called_once_with(
             ["instruction", "input", "output"]
         )
@@ -3931,6 +4158,7 @@ class TrainingPhaseTest(unittest.TestCase):
             False,
         )
         self.assertEqual(trainer.data_collator.call_count, 1)
+        dependencies.concatenate_datasets.assert_not_called()
         trainer.train.assert_called_once_with()
         tokenizer.save_pretrained.assert_called_once()
 
@@ -4280,6 +4508,7 @@ class TrainingPhaseTest(unittest.TestCase):
         format_alpaca_examples.assert_not_called()
         dependencies.get_chat_template_parts.assert_not_called()
         dependencies.train_on_responses_only.assert_not_called()
+        dependencies.concatenate_datasets.assert_not_called()
         for call in tokenizer.apply_calls:
             self.assertFalse(call["add_generation_prompt"])
         trainer.train.assert_called_once_with()
@@ -4594,6 +4823,7 @@ class TrainingPhaseTest(unittest.TestCase):
             )
 
         dataset.select_columns.assert_called_once_with(["prompt", "completion"])
+        dependencies.concatenate_datasets.assert_not_called()
         dataset.map.assert_not_called()
         dataset.projected_dataset.map.assert_not_called()
         self.assertIs(
@@ -4852,6 +5082,7 @@ class TrainingPhaseTest(unittest.TestCase):
             processing_class=tokenizer,
             policy=mock.ANY,
         )
+        dependencies.concatenate_datasets.assert_not_called()
         tokenizer.save_pretrained.assert_called_once()
 
     def test_text_dataset_requires_eos_before_lora_allocation(self):
@@ -5154,6 +5385,552 @@ class TrainingPhaseTest(unittest.TestCase):
         )
         dataset.map.assert_not_called()
         dataset.projected_dataset.map.assert_not_called()
+
+
+class MultipleTrainingDatasetsTest(unittest.TestCase):
+    def config_for(self, dataset_types, *, loss="all", packing=False):
+        config = example_train_config()
+        config["datasets"] = [
+            {"source": f"organization/source-{index}", "type": dataset_type}
+            for index, dataset_type in enumerate(dataset_types)
+        ]
+        config["config"]["unsloth"]["loss"] = loss
+        config["config"]["unsloth"]["packing"] = packing
+        return config
+
+    def dependencies_for(self, datasets):
+        dependencies = example_train_dependencies(datasets[0])
+        dependencies.load_dataset.side_effect = list(datasets)
+
+        def concatenate(source_datasets):
+            return FunctionalDataset(
+                row
+                for source_dataset in source_datasets
+                for row in source_dataset
+            )
+
+        dependencies.concatenate_datasets.side_effect = concatenate
+        return dependencies
+
+    def test_rejects_mixed_groups_before_loading_or_model_allocation(self):
+        cases = (
+            (
+                ["alpaca", "prompt-completion"],
+                "all",
+                r"datasets\[1\] type prompt-completion.*incompatible.*datasets\[0\]",
+            ),
+            (
+                ["messages", "text"],
+                "response",
+                r"datasets\[1\] type text.*supported only for messages and sharegpt",
+            ),
+        )
+        for dataset_types, loss, error_pattern in cases:
+            with self.subTest(dataset_types=dataset_types, loss=loss):
+                dependencies = example_train_dependencies(mock.Mock())
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    target_unsloth.train_model(
+                        self.config_for(dataset_types, loss=loss),
+                        dependencies=dependencies,
+                    )
+
+                dependencies.load_dataset.assert_not_called()
+                dependencies.fast_language_model.from_pretrained.assert_not_called()
+                dependencies.fast_language_model.get_peft_model.assert_not_called()
+                dependencies.concatenate_datasets.assert_not_called()
+                dependencies.sft_trainer.assert_not_called()
+
+    def test_second_source_schema_failure_is_indexed_redacted_and_pre_model(self):
+        config = self.config_for(["text", "text"])
+        signed_url = (
+            "https://example.test/private.json?token=private-value"
+            "#fragment-marker"
+        )
+        config["datasets"][1]["source"] = signed_url
+        dependencies = self.dependencies_for(
+            [
+                FunctionalDataset([{"text": "valid"}]),
+                FunctionalDataset([{"content": "missing text"}]),
+            ]
+        )
+        local_file = Path("/private/tmp/aikit-second-source.json")
+
+        with (
+            mock.patch.object(
+                target_unsloth,
+                "materialize_remote_dataset_file",
+                return_value=nullcontext(local_file),
+            ),
+            self.assertRaisesRegex(
+                ValueError,
+                r"datasets\[1\] text dataset remote JSON URL.*missing required columns",
+            ) as raised,
+        ):
+            target_unsloth.train_model(config, dependencies=dependencies)
+
+        for secret in (signed_url, "private-value", "fragment-marker"):
+            self.assertNotIn(secret, str(raised.exception))
+        self.assertEqual(dependencies.load_dataset.call_count, 2)
+        self.assertEqual(
+            dependencies.load_dataset.call_args_list[0],
+            mock.call("organization/source-0", split="train"),
+        )
+        self.assertEqual(
+            dependencies.load_dataset.call_args_list[1],
+            mock.call(
+                "json",
+                data_files={"train": str(local_file)},
+                split="train",
+            ),
+        )
+        dependencies.fast_language_model.from_pretrained.assert_not_called()
+        dependencies.fast_language_model.get_peft_model.assert_not_called()
+        dependencies.concatenate_datasets.assert_not_called()
+        dependencies.sft_trainer.assert_not_called()
+
+    def test_rejects_empty_later_source_before_model_allocation(self):
+        config = self.config_for(["text", "text"])
+        dependencies = self.dependencies_for(
+            [
+                FunctionalDataset([{"text": "valid"}]),
+                FunctionalDataset([]),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"datasets\[1\] text dataset source 'organization/source-1' "
+            r"must contain at least one record",
+        ):
+            target_unsloth.train_model(config, dependencies=dependencies)
+
+        self.assertEqual(dependencies.load_dataset.call_count, 2)
+        dependencies.fast_language_model.from_pretrained.assert_not_called()
+        dependencies.fast_language_model.get_peft_model.assert_not_called()
+        dependencies.concatenate_datasets.assert_not_called()
+        dependencies.sft_trainer.assert_not_called()
+
+    def test_full_sequence_sources_load_normalize_and_concatenate_in_order(self):
+        config = self.config_for(
+            ["alpaca", "text", "messages", "sharegpt"],
+            packing=True,
+        )
+        config["datasets"][1]["loader"] = {
+            "type": "huggingface",
+            "subset": "default",
+            "split": "train_sft",
+            "revision": "0123456789abcdef0123456789abcdef01234567",
+        }
+        alpaca_row = {
+            "instruction": "Summarize",
+            "input": "First source",
+            "output": "Summary",
+        }
+        text_row = {"text": "Domain text."}
+        messages = [
+            {"role": "user", "content": "Question?"},
+            {"role": "assistant", "content": "Answer."},
+        ]
+        sharegpt = [
+            {"from": "human", "value": "Other question?"},
+            {"from": "gpt", "value": "Other answer."},
+        ]
+        dependencies = self.dependencies_for(
+            [
+                FunctionalDataset([{**alpaca_row, "metadata": "first"}]),
+                FunctionalDataset([{**text_row, "metadata": "second"}]),
+                FunctionalDataset([{"messages": messages, "id": 3}]),
+                FunctionalDataset([{"conversations": sharegpt, "id": 4}]),
+            ]
+        )
+        tokenizer = MessagesTokenizer()
+        base_model = dependencies.fast_language_model.from_pretrained.return_value[0]
+        dependencies.fast_language_model.from_pretrained.return_value = (
+            base_model,
+            tokenizer,
+        )
+        trainer = dependencies.sft_trainer.return_value
+        trainer.args = SimpleNamespace(
+            packing=True,
+            padding_free=True,
+            packing_strategy="bfd",
+            max_length=2048,
+            dataset_num_proc=2,
+        )
+
+        def construct_trainer(**kwargs):
+            texts = [row["text"] for row in kwargs["train_dataset"]]
+            add_special_tokens = target_unsloth.messages_unsloth_add_special_tokens(
+                tokenizer,
+                texts[0],
+            )
+            segments = tokenizer(
+                texts,
+                add_special_tokens=add_special_tokens,
+                truncation=True,
+                max_length=2048,
+            )["input_ids"]
+            reordered = list(reversed(segments))
+            trainer.train_dataset = [
+                {
+                    "input_ids": [
+                        token_id
+                        for segment in reordered
+                        for token_id in segment
+                    ],
+                    "seq_lengths": [len(segment) for segment in reordered],
+                }
+            ]
+            return trainer
+
+        def collate(records):
+            input_ids = list(records[0]["input_ids"])
+            return {"input_ids": [input_ids], "labels": [list(input_ids)]}
+
+        dependencies.sft_trainer.side_effect = construct_trainer
+        trainer.data_collator.side_effect = collate
+        events = []
+        load_dataset = dependencies.load_dataset
+        loaded_datasets = list(load_dataset.side_effect)
+
+        def load_in_order(source, **kwargs):
+            events.append(("load", source, kwargs))
+            return loaded_datasets.pop(0)
+
+        load_dataset.side_effect = load_in_order
+        concatenate = dependencies.concatenate_datasets.side_effect
+
+        def concatenate_in_order(source_datasets):
+            events.append(("concatenate", len(source_datasets)))
+            return concatenate(source_datasets)
+
+        dependencies.concatenate_datasets.side_effect = concatenate_in_order
+
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            mock.patch.object(target_unsloth, "verify_text_preprocessing"),
+        ):
+            target_unsloth.train_model(
+                config,
+                trained_model_directory=Path(temporary_directory) / "trained-model",
+                dependencies=dependencies,
+            )
+
+        self.assertEqual(
+            events,
+            [
+                ("load", "organization/source-0", {"split": "train"}),
+                (
+                    "load",
+                    "organization/source-1",
+                    {
+                        "name": "default",
+                        "split": "train_sft",
+                        "revision": (
+                            "0123456789abcdef0123456789abcdef01234567"
+                        ),
+                    },
+                ),
+                ("load", "organization/source-2", {"split": "train"}),
+                ("load", "organization/source-3", {"split": "train"}),
+                ("concatenate", 4),
+            ],
+        )
+        dependencies.concatenate_datasets.assert_called_once()
+        canonical_sources = dependencies.concatenate_datasets.call_args.args[0]
+        self.assertEqual(len(canonical_sources), 4)
+        self.assertTrue(
+            all(source.column_names == ["text"] for source in canonical_sources)
+        )
+        combined = dependencies.sft_trainer.call_args.kwargs["train_dataset"]
+        expected_texts = [
+            target_unsloth.ALPACA_PROMPT.format(
+                alpaca_row["instruction"],
+                alpaca_row["input"],
+                alpaca_row["output"],
+            )
+            + tokenizer.eos_token,
+            text_row["text"] + tokenizer.eos_token,
+            tokenizer.render(messages),
+            tokenizer.render(
+                [
+                    {"role": "user", "content": "Other question?"},
+                    {"role": "assistant", "content": "Other answer."},
+                ]
+            ),
+        ]
+        self.assertEqual([row["text"] for row in combined], expected_texts)
+        self.assertIs(
+            dependencies.sft_config.call_args.kwargs["completion_only_loss"],
+            False,
+        )
+        dependencies.train_on_responses_only.assert_not_called()
+        trainer.train.assert_called_once_with()
+
+    def test_multiple_prompt_completion_sources_preserve_duplicates_through_bfd(self):
+        config = self.config_for(
+            ["prompt-completion", "prompt-completion"],
+            packing=True,
+        )
+        first_rows = [
+            {"prompt": "Duplicate", "completion": " completion."},
+            {"prompt": "Other", "completion": " completion."},
+        ]
+        second_rows = [
+            {"prompt": "<bos>Duplicate", "completion": " completion."},
+        ]
+        dependencies = self.dependencies_for(
+            [FunctionalDataset(first_rows), FunctionalDataset(second_rows)]
+        )
+        trainer = dependencies.sft_trainer.return_value
+        trainer.args = SimpleNamespace(
+            packing=True,
+            padding_free=True,
+            packing_strategy="bfd",
+            max_length=2048,
+            dataset_num_proc=2,
+        )
+        verification_record = {
+            "input_ids": [11, 12, 13, 2],
+            "completion_mask": [0, 0, 1, 1],
+        }
+        trainer._prepare_dataset.return_value = [verification_record]
+        segment = [11, 12, 13, 2]
+        trainer.train_dataset = [
+            {
+                "input_ids": segment * 3,
+                "completion_mask": [0, 0, 1, 1] * 3,
+                "seq_lengths": [4, 4, 4],
+            }
+        ]
+        trainer.data_collator.return_value = {
+            "input_ids": [verification_record["input_ids"]],
+            "labels": [[-100, -100, 13, 2]],
+        }
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target_unsloth.train_model(
+                config,
+                trained_model_directory=Path(temporary_directory) / "trained-model",
+                dependencies=dependencies,
+            )
+
+        dependencies.concatenate_datasets.assert_called_once()
+        combined = dependencies.sft_trainer.call_args.kwargs["train_dataset"]
+        self.assertEqual(
+            list(combined),
+            [*first_rows, *second_rows],
+        )
+        self.assertIs(
+            dependencies.sft_config.call_args.kwargs["completion_only_loss"],
+            True,
+        )
+        dependencies.train_on_responses_only.assert_not_called()
+        tokenizer = dependencies.fast_language_model.from_pretrained.return_value[1]
+        second_source_tokenization_calls = [
+            call
+            for call in tokenizer.call_args_list
+            if call.args
+            and isinstance(call.args[0], list)
+            and "<bos>Duplicate" in call.args[0]
+        ]
+        self.assertTrue(second_source_tokenization_calls)
+        self.assertTrue(
+            all(
+                call.kwargs["add_special_tokens"] is True
+                for call in second_source_tokenization_calls
+            )
+        )
+        trainer.train.assert_called_once_with()
+
+    def test_response_only_messages_and_sharegpt_apply_masking_once(self):
+        config = self.config_for(
+            ["messages", "sharegpt"],
+            loss="response",
+        )
+        messages = [
+            {"role": "user", "content": "Question?"},
+            {"role": "assistant", "content": "Answer."},
+        ]
+        conversations = [
+            {"from": "human", "value": "Other question?"},
+            {"from": "gpt", "value": "Other answer."},
+        ]
+        dependencies = self.dependencies_for(
+            [
+                FunctionalDataset([{"messages": messages}]),
+                FunctionalDataset([{"conversations": conversations}]),
+            ]
+        )
+        tokenizer = MessagesTokenizer()
+        base_model = dependencies.fast_language_model.from_pretrained.return_value[0]
+        dependencies.fast_language_model.from_pretrained.return_value = (
+            base_model,
+            tokenizer,
+        )
+        trainer = dependencies.sft_trainer.return_value
+        trainer.args = SimpleNamespace(
+            packing=False,
+            padding_free=False,
+            packing_strategy="bfd",
+            max_length=2048,
+            dataset_num_proc=2,
+        )
+
+        def apply_response_masking(actual_trainer, **kwargs):
+            markers = target_unsloth.ResponseMarkers(
+                instruction_part=kwargs["instruction_part"],
+                response_part=kwargs["response_part"],
+                instruction_token_ids=tuple(
+                    tokenizer.raw_token_ids(kwargs["instruction_part"])
+                ),
+                response_token_ids=tuple(
+                    tokenizer.raw_token_ids(kwargs["response_part"])
+                ),
+                use_tokenizer_parts=False,
+            )
+            prepared_rows = []
+            for row in dependencies.sft_trainer.call_args.kwargs["train_dataset"]:
+                input_ids = tokenizer.raw_token_ids(row["text"])
+                prepared_rows.append(
+                    {
+                        "input_ids": input_ids,
+                        "labels": target_unsloth.expected_response_only_labels(
+                            input_ids,
+                            markers=markers,
+                        ),
+                    }
+                )
+            actual_trainer.train_dataset = FunctionalDataset(prepared_rows)
+            return actual_trainer
+
+        dependencies.train_on_responses_only.side_effect = apply_response_masking
+        trainer.data_collator.side_effect = lambda records: {
+            "input_ids": [list(records[0]["input_ids"])],
+            "labels": [list(records[0]["labels"])],
+        }
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target_unsloth.train_model(
+                config,
+                trained_model_directory=Path(temporary_directory) / "trained-model",
+                dependencies=dependencies,
+            )
+
+        dependencies.concatenate_datasets.assert_called_once()
+        combined = dependencies.sft_trainer.call_args.kwargs["train_dataset"]
+        self.assertEqual(
+            [row["text"] for row in combined],
+            [
+                tokenizer.render(messages),
+                tokenizer.render(
+                    [
+                        {"role": "user", "content": "Other question?"},
+                        {"role": "assistant", "content": "Other answer."},
+                    ]
+                ),
+            ],
+        )
+        dependencies.train_on_responses_only.assert_called_once_with(
+            trainer,
+            force_match=True,
+            instruction_part="<user>",
+            response_part="<assistant>",
+        )
+        self.assertIs(
+            dependencies.sft_config.call_args.kwargs["completion_only_loss"],
+            False,
+        )
+        trainer.train.assert_called_once_with()
+
+    @unittest.skipUnless(
+        importlib.util.find_spec("datasets") is not None,
+        "datasets is not installed",
+    )
+    def test_datasets_430_normalizes_string_features_and_preserves_order(self):
+        import datasets
+
+        if datasets.__version__ != "4.3.0":
+            self.skipTest("requires datasets==4.3.0")
+
+        first = datasets.Dataset.from_dict(
+            {"text": ["first-0", "first-1"], "metadata": [1, 2]},
+            features=datasets.Features(
+                {
+                    "text": datasets.Value("large_string"),
+                    "metadata": datasets.Value("int64"),
+                }
+            ),
+        )
+        second = datasets.Dataset.from_dict(
+            {"text": ["second-0"]},
+            features=datasets.Features({"text": datasets.Value("string")}),
+        )
+        normalized = [
+            target_unsloth.normalize_canonical_string_dataset(
+                source,
+                fields=("text",),
+                dataset_type="text",
+                source=f"source-{index}",
+                dataset_index=index,
+            )
+            for index, source in enumerate((first, second))
+        ]
+
+        self.assertEqual(
+            normalized[0].features,
+            datasets.Features({"text": datasets.Value("string")}),
+        )
+        combined = datasets.concatenate_datasets(normalized)
+        self.assertEqual(
+            list(combined["text"]),
+            ["first-0", "first-1", "second-0"],
+        )
+        reversed_combined = datasets.concatenate_datasets(
+            list(reversed(normalized))
+        )
+        self.assertEqual(
+            list(reversed_combined["text"]),
+            ["second-0", "first-0", "first-1"],
+        )
+
+        prompt_source = datasets.Dataset.from_dict(
+            {
+                "prompt": ["p0", "p1"],
+                "completion": ["c0", "c1"],
+                "metadata": [1, 2],
+            },
+            features=datasets.Features(
+                {
+                    "prompt": datasets.Value("large_string"),
+                    "completion": datasets.Value("large_string"),
+                    "metadata": datasets.Value("int64"),
+                }
+            ),
+        )
+        normalized_prompt = target_unsloth.normalize_canonical_string_dataset(
+            prompt_source,
+            fields=("prompt", "completion"),
+            dataset_type="prompt-completion",
+            source="prompt-source",
+            dataset_index=0,
+        )
+        self.assertEqual(
+            normalized_prompt.features,
+            datasets.Features(
+                {
+                    "prompt": datasets.Value("string"),
+                    "completion": datasets.Value("string"),
+                }
+            ),
+        )
+        self.assertEqual(
+            list(normalized_prompt),
+            [
+                {"prompt": "p0", "completion": "c0"},
+                {"prompt": "p1", "completion": "c1"},
+            ],
+        )
 
 
 class ExportPhaseTest(unittest.TestCase):

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -15,6 +15,7 @@ const (
 
 	DatasetAlpaca           = "alpaca"
 	DatasetMessages         = "messages"
+	DatasetPreference       = "preference"
 	DatasetPromptCompletion = "prompt-completion"
 	DatasetShareGPT         = "sharegpt"
 	DatasetText             = "text"
@@ -27,6 +28,11 @@ const (
 
 	SFTLossAll      = "all"
 	SFTLossResponse = "response"
+
+	ObjectiveSFT = "sft"
+	ObjectiveDPO = "dpo"
+
+	DPOLossSigmoid = "sigmoid"
 
 	APIv1alpha1 = "v1alpha1"
 

--- a/test/aikitfile-unsloth-dpo-smoke.yaml
+++ b/test/aikitfile-unsloth-dpo-smoke.yaml
@@ -1,0 +1,32 @@
+#syntax=aikit:test
+apiVersion: v1alpha1
+baseModel: unsloth/Qwen2.5-0.5B-Instruct-bnb-4bit
+objective:
+  type: dpo
+  beta: 0.1
+  lossType: sigmoid
+  maxPromptLength: 96
+datasets:
+  - source: "__AIKIT_SMOKE_DATASET_URL__"
+    type: preference
+    loader:
+      type: json
+      split: train
+      checksum: "__AIKIT_SMOKE_DATASET_CHECKSUM__"
+config:
+  unsloth:
+    packing: false
+    maxSeqLength: 256
+    loadIn4bit: true
+    batchSize: 1
+    gradientAccumulationSteps: 1
+    warmupSteps: 0
+    maxSteps: 1
+    loggingSteps: 1
+    optimizer: adamw_8bit
+    weightDecay: 0.01
+    lrSchedulerType: linear
+    seed: 42
+output:
+  quantize: q4_k_m
+  name: model

--- a/test/aikitfile-unsloth-multiple-datasets-smoke.yaml
+++ b/test/aikitfile-unsloth-multiple-datasets-smoke.yaml
@@ -1,0 +1,26 @@
+#syntax=aikit:test
+apiVersion: v1alpha1
+baseModel: unsloth/tinyllama-chat-bnb-4bit
+datasets:
+  - source: "__AIKIT_SMOKE_DATASET_URL__"
+    type: alpaca
+  - source: "__AIKIT_SMOKE_DATASET_URL_2__"
+    type: text
+config:
+  unsloth:
+    packing: true
+    maxSeqLength: 512
+    loadIn4bit: true
+    batchSize: 1
+    gradientAccumulationSteps: 1
+    warmupSteps: 1
+    maxSteps: 1
+    learningRate: 0.0002
+    loggingSteps: 1
+    optimizer: adamw_8bit
+    weightDecay: 0.01
+    lrSchedulerType: linear
+    seed: 42
+output:
+  quantize: q4_k_m
+  name: model

--- a/test/fixtures/multiple-alpaca-smoke.jsonl
+++ b/test/fixtures/multiple-alpaca-smoke.jsonl
@@ -1,0 +1,2 @@
+{"instruction":"Answer in one word.","input":"What color is a clear daytime sky?","output":"Blue"}
+{"instruction":"Complete the phrase.","input":"Machine learning uses","output":"data"}

--- a/test/fixtures/multiple-text-smoke.jsonl
+++ b/test/fixtures/multiple-text-smoke.jsonl
@@ -1,0 +1,2 @@
+{"text":"AIKit combines deterministic datasets for fine-tuning."}
+{"text":"Configured dataset order is preserved before trainer shuffling."}

--- a/test/fixtures/preference-smoke.jsonl
+++ b/test/fixtures/preference-smoke.jsonl
@@ -1,0 +1,4 @@
+{"prompt":"How should I rotate an API key?","chosen":"Create and deploy a replacement before revoking the old key.","rejected":"Revoke the old key before creating a replacement."}
+{"prompt":"Where should a production secret be stored?","chosen":"Store it in a dedicated secret manager and grant least-privilege access.","rejected":"Commit it to the application repository for convenience."}
+{"prompt":"What should I do before applying a database migration?","chosen":"Back up the data, test the migration, and plan a rollback.","rejected":"Run it directly in production without a backup."}
+{"prompt":"How should a service handle an expired credential?","chosen":"Fail safely, obtain a replacement through the approved flow, and audit the event.","rejected":"Keep retrying the expired credential indefinitely."}

--- a/website/docs/fine-tune.md
+++ b/website/docs/fine-tune.md
@@ -137,6 +137,8 @@ AIKit loads sources sequentially in YAML order, validates every source as nonemp
 
 The locked Unsloth trainer selects one rendered-text `add_special_tokens` setting from the first canonical record. AIKit verifies that every record in a combined full-sequence job produces the same token IDs under that dataset-wide setting as it would under its source-specific setting. If, for example, rendered chat records already contain BOS while Alpaca records rely on the tokenizer to add BOS, AIKit rejects the mix with the failing `datasets[n]` index instead of allowing dataset order to duplicate or omit BOS tokens. A setting difference that does not change token IDs remains valid; reordering sources cannot bypass a real boundary mismatch.
 
+Multiple `prompt-completion` sources receive the same protection. AIKit compares the effective token IDs and completion-mask boundary under each source's own special-token policy with the dataset-wide policy selected from the first source. It rejects only differences that change trained tokens or which tokens are treated as the prompt; no-op policy differences remain valid.
+
 This example combines pinned Alpaca and preformatted-text sources in the full-sequence group while using different loaders:
 
 ```yaml

--- a/website/docs/fine-tune.md
+++ b/website/docs/fine-tune.md
@@ -127,13 +127,15 @@ AIKit supports one or more datasets in an SFT configuration. All entries must re
 
 | SFT mode | Compatible dataset combination |
 | --- | --- |
-| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with global `loss: all` |
+| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with global `loss: all` and compatible tokenizer special-token boundaries |
 | Completion-only | One or more `prompt-completion` datasets |
 | Response-only chat | Any mix of `messages` and `sharegpt` with global `loss: response` and `packing: false` |
 
 Mixing modes is unsupported. For example, `alpaca` cannot be combined with `prompt-completion`, and response-only chat cannot be combined with `text`. `config.unsloth.loss` applies to the whole job; per-dataset loss, weighted sampling, and random interleaving are not supported.
 
 AIKit loads sources sequentially in YAML order, validates every source as nonempty, normalizes each source independently, and concatenates records in configured order while preserving row order within each source. This deterministic order is the input to the SFT trainer; packing, shuffling, or sampling may reorder records afterward. Datasets are not deduplicated, over- or undersampled, so repeating an entry intentionally repeats its rows. A one-source configuration retains the existing single-source path.
+
+The locked Unsloth trainer selects one rendered-text `add_special_tokens` setting from the first canonical record. AIKit verifies that every record in a combined full-sequence job produces the same token IDs under that dataset-wide setting as it would under its source-specific setting. If, for example, rendered chat records already contain BOS while Alpaca records rely on the tokenizer to add BOS, AIKit rejects the mix with the failing `datasets[n]` index instead of allowing dataset order to duplicate or omit BOS tokens. A setting difference that does not change token IDs remains valid; reordering sources cannot bypass a real boundary mismatch.
 
 This example combines pinned Alpaca and preformatted-text sources in the full-sequence group while using different loaders:
 

--- a/website/docs/fine-tune.md
+++ b/website/docs/fine-tune.md
@@ -53,29 +53,67 @@ apiVersion: v1alpha1
 baseModel: "unsloth/llama-2-7b-bnb-4bit" # base model to be fine tuned. this can be any model from Huggingface. For unsloth optimized base models, see https://huggingface.co/unsloth
 datasets:
   - source: "yahma/alpaca-cleaned" # Hugging Face dataset identifier or an HTTP(S) URL
-    type: "alpaca" # record schema: alpaca, messages, sharegpt, prompt-completion, or text
+    type: "alpaca" # record schema: alpaca, messages, sharegpt, prompt-completion, text, or preference
 config:
   unsloth:
 ```
 
 For full configuration, please refer to [Fine Tune API Specifications](./specs-finetune.md).
 
-#### Choose a Dataset Format
+#### Choose SFT or DPO
 
-Multiple-dataset composition currently applies to supervised fine-tuning (SFT). Each `datasets` entry makes two independent choices:
+AIKit's Unsloth target supports supervised fine-tuning (SFT) and Direct Preference Optimization (DPO). Both objectives train from fixed datasets. DPO is offline preference optimization, not an online reinforcement-learning environment loop: AIKit does not collect live rewards or run policy rollouts against an environment.
 
-1. `datasets[].type` selects the **record schema** and determines which tokens contribute to SFT loss.
-2. `datasets[].loader.type` selects the **loader** used to obtain and parse the source.
+| Objective | What the model learns from | Compatible record schemas | Dataset count |
+| --- | --- | --- | --- |
+| SFT (default) | Demonstrated outputs or complete training sequences | `alpaca`, `messages`, `sharegpt`, `prompt-completion`, or `text` | One or more mutually compatible datasets |
+| DPO | A `chosen` response compared with a `rejected` response for the same prompt | `preference` | Exactly one dataset |
 
-A loader does not imply a record schema. For example, a Parquet file can contain `prompt-completion` records, and a Hugging Face dataset can contain `messages` records.
+The training objective, record schema, and loader are independent choices:
 
-| Record schema (`datasets[].type`) | Expected records | SFT behavior |
+| Setting | Selects | Examples |
 | --- | --- | --- |
-| `alpaca` | `instruction`, `input`, and `output` strings | Full-sequence |
-| `messages` | Canonical `role`/`content` conversations | Full-sequence with `loss: all`; assistant-response-only with `loss: response` |
-| `sharegpt` | ShareGPT `from`/`value` conversations | Full-sequence with `loss: all`; assistant-response-only with `loss: response` |
-| `prompt-completion` | Separate `prompt` and non-empty `completion` strings | Completion-only; prompt tokens are masked |
-| `text` | A complete preformatted sequence in `text` | Full-sequence |
+| `objective.type` | Training objective | `sft`, `dpo` |
+| `datasets[].type` | Record schema, required fields, and loss semantics | `messages`, `prompt-completion`, `preference` |
+| `datasets[].loader.type` | Source transport and file parser | `huggingface`, `json`, `csv`, `parquet`, `text` |
+
+For example, `type: preference` describes records with `prompt`, `chosen`, and `rejected` fields, while `loader.type: json` says only that those records are read from JSON. A Parquet file can contain the same `preference` schema. The `text` record schema and the `text` loader are also distinct: the schema requires a `text` field, while the loader turns each line of a remote text file into a `text` record.
+
+If `objective` is omitted, YAML `null`, an empty mapping, or explicitly set to `sft`, AIKit uses SFT and defaults `learningRate` to `0.0002`. Set `objective.type: dpo` to optimize explicit preferences:
+
+```yaml
+objective:
+  type: dpo
+  beta: 0.1
+  lossType: sigmoid
+  maxPromptLength: 512
+datasets:
+  - source: organization/preferences
+    type: preference
+    loader:
+      type: huggingface
+      split: train
+      revision: 0123456789abcdef0123456789abcdef01234567
+config:
+  unsloth:
+    packing: false
+    maxSeqLength: 2048
+```
+
+DPO defaults to `beta: 0.1`, `lossType: sigmoid`, `maxPromptLength: 512`, and `learningRate: 0.000001`. `beta` must be finite and positive, `maxPromptLength` must not exceed `maxSeqLength`, and only sigmoid loss is supported. DPO requires exactly one `preference` dataset, requires `packing: false`, rejects every SFT record schema, and rejects the SFT-only `loss: response` setting. Before training, AIKit rejects a pair when its chosen and rejected responses become token-identical after the trainer's effective tokenization and pinned `keep_end` truncation, because that pair would provide no preference signal.
+
+AIKit constructs a separate DPO trainer with the LoRA policy and `ref_model=None`. The same PEFT model with its adapter disabled supplies reference log probabilities; this is not reference-free DPO. Preference records bypass all SFT formatting and masking paths. The trained adapter and tokenizer use the same save, GGUF export, and inference path as SFT.
+
+#### Dataset Formats
+
+| Record schema (`datasets[].type`) | Expected records | Objective and loss behavior |
+| --- | --- | --- |
+| `alpaca` | `instruction`, `input`, and `output` strings | SFT full-sequence |
+| `messages` | Canonical `role`/`content` conversations | SFT full-sequence with `loss: all`; assistant-response-only with `loss: response` |
+| `sharegpt` | ShareGPT `from`/`value` conversations | SFT full-sequence with `loss: all`; assistant-response-only with `loss: response` |
+| `prompt-completion` | Separate `prompt` and non-empty `completion` strings | SFT completion-only; prompt tokens are masked |
+| `text` | A complete preformatted sequence in `text` | SFT full-sequence |
+| `preference` | Explicit non-empty `prompt`, `chosen`, and `rejected` strings | DPO only; chosen and rejected responses must remain distinct after effective truncation |
 
 | Loader (`datasets[].loader.type`) | Source and parsing behavior |
 | --- | --- |
@@ -83,8 +121,6 @@ A loader does not imply a record schema. For example, a Parquet file can contain
 | `huggingface` | A Hugging Face dataset identifier, with optional subset, split, and pinned revision |
 | `json`, `csv`, or `parquet` | An HTTP(S) file parsed with the corresponding builder |
 | `text` | An HTTP(S) text file; each line becomes one record with a `text` field |
-
-The `text` record schema and the `text` loader are separate settings. A line-oriented text file normally uses both `type: text` and `loader.type: text`.
 
 #### Dataset Loading and Reproducibility
 
@@ -119,11 +155,11 @@ datasets:
 
 Remote files are downloaded into an AIKit-owned content-addressed cache under the persistent Hugging Face Datasets cache. AIKit verifies cached and newly downloaded bytes before invoking the selected Datasets builder or allocating the model. A missing checksum remains allowed but emits a warning and cannot make a BuildKit cache entry immutable. URL credentials, query values, and fragments are not included in AIKit-generated errors or warning logs, cache filenames, or cache metadata. The configured source URL is still part of the training configuration and BuildKit definition, so credential-bearing URLs are not a supported secret mechanism; private-dataset secret mounts remain out of scope.
 
-The loader `split` defaults to `train` and must contain letters, numbers, or underscores in one or more dot-separated segments. It selects the training split only; it does not configure evaluation data or metrics. The `text` loader turns each input line into a `text` record. JSON, CSV, and Parquet loaders can provide any supported record schema whose required columns and values are present. Unknown fields inside `loader` fail instead of being silently ignored.
+The loader `split` defaults to `train` and must contain letters, numbers, or underscores in one or more dot-separated segments. It selects the training split only; it does not configure evaluation data or metrics. The `text` loader turns each input line into a `text` record and therefore cannot provide DPO preference columns. JSON, CSV, and Parquet loaders can provide any record schema compatible with the selected objective when the required columns and values are present. Unknown fields inside `loader` fail instead of being silently ignored.
 
-#### Combining Multiple Datasets
+#### Combining Multiple SFT Datasets
 
-AIKit supports one or more datasets in an SFT configuration. All entries must resolve to the same SFT mode:
+AIKit supports one or more datasets for SFT. DPO is intentionally separate and requires exactly one `preference` dataset. All entries in an SFT job must resolve to the same SFT mode:
 
 | SFT mode | Compatible dataset combination |
 | --- | --- |
@@ -262,6 +298,35 @@ An expected JSON Lines record is:
 The `text` type performs full-sequence supervised fine-tuning (SFT). It is not continued pretraining: AIKit retains the standard LoRA targets and optimizer configuration and does not train embedding or language-model-head parameters.
 :::
 
+##### Preference (DPO)
+
+The `preference` type is valid only with `objective.type: dpo`. Every record must contain explicit, non-empty string `prompt`, `chosen`, and `rejected` values, and the chosen and rejected responses must differ. AIKit does not infer a prompt from response prefixes, accept conversational preference arrays, or normalize preference text.
+
+```yaml
+objective:
+  type: dpo
+  maxPromptLength: 96
+datasets:
+  - source: https://datasets.example.com/preferences.jsonl
+    type: preference
+    loader:
+      type: json
+      split: train
+      checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+config:
+  unsloth:
+    packing: false
+    maxSeqLength: 256
+```
+
+An expected JSON Lines record is:
+
+```json
+{"prompt":"How should I rotate an API key?","chosen":"Deploy a replacement before revoking the old key.","rejected":"Revoke the old key before creating a replacement."}
+```
+
+AIKit drops unrelated metadata columns and passes the three preference strings to the DPO trainer without SFT formatting or EOS-text appending. It validates the trainer-prepared prompt and completion token sequences and rejects chosen/rejected completions that collapse to the same effective tokens after pinned `keep_end` truncation. Multiple preference datasets, implicit prompts, conversational preference arrays, evaluation datasets, alternate DPO losses, custom reference models, reference-free DPO, and online environment interaction are not supported.
+
 :::note
 Please refer to [Unsloth documentation](https://github.com/unslothai/unsloth) for more information about Unsloth configuration.
 :::
@@ -280,6 +345,7 @@ Please make sure to change syntax to `#syntax=ghcr.io/kaito-project/aikit/aikit:
 - [Text smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-text-smoke.yaml)
 - [Checksummed Parquet loader smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-loader-smoke.yaml)
 - [Multiple compatible datasets smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-multiple-datasets-smoke.yaml)
+- [Checksummed DPO preference smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-dpo-smoke.yaml)
 
 
 ## Build

--- a/website/docs/fine-tune.md
+++ b/website/docs/fine-tune.md
@@ -99,7 +99,32 @@ The loader `split` defaults to `train` and must contain letters, numbers, or und
 
 #### Dataset Types
 
-AIKit supports one dataset per fine-tuning configuration. The configured `type` selects the record schema and training loss behavior; unknown types fail instead of falling back to another formatter.
+AIKit supports one or more datasets per fine-tuning configuration. The configured `type` selects each source's record schema and training loss behavior; unknown types fail instead of falling back to another formatter.
+
+AIKit loads sources sequentially in YAML order, validates every source as nonempty, normalizes each one independently to canonical columns and string features, and concatenates records in configured order while preserving row order within each source. This deterministic order exists before SFT trainer packing, shuffling, or sampling. A one-source configuration uses the existing path without a concatenation call. Datasets are not weighted, randomly interleaved, deduplicated, over- or undersampled; duplicate entries intentionally duplicate their rows.
+
+All entries must share one semantic group:
+
+| Group | Compatible dataset types |
+| --- | --- |
+| Full-sequence | `alpaca`, `text`, `messages` with `loss: all`, and `sharegpt` with `loss: all` |
+| Completion-only | One or more `prompt-completion` datasets |
+| Response-only chat | `messages` and `sharegpt` with global `loss: response` and `packing: false` |
+
+Mixing groups fails with the relevant `datasets[n]` indexes instead of coercing records or silently ignoring later entries. `config.unsloth.loss` is global; per-dataset loss and weighted sampling are not supported. Each entry retains its own loader, split, subset, revision, and checksum identity. Changing or reordering any later entry invalidates training and export while leaving dependency installation cacheable.
+
+```yaml
+datasets:
+  - source: organization/instruction-data
+    type: alpaca
+  - source: organization/domain-text
+    type: text
+  - source: organization/chat-data
+    type: messages
+config:
+  unsloth:
+    loss: all
+```
 
 For the chat dataset types `messages` and `sharegpt`, `config.unsloth.loss` controls which tokens are supervised:
 
@@ -216,6 +241,7 @@ Please make sure to change syntax to `#syntax=ghcr.io/kaito-project/aikit/aikit:
 - [Prompt-completion smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-prompt-completion-smoke.yaml)
 - [Text smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-text-smoke.yaml)
 - [Checksummed Parquet loader smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-loader-smoke.yaml)
+- [Multiple compatible datasets smoke test](https://github.com/kaito-project/aikit/blob/main/test/aikitfile-unsloth-multiple-datasets-smoke.yaml)
 
 
 ## Build

--- a/website/docs/fine-tune.md
+++ b/website/docs/fine-tune.md
@@ -60,9 +60,33 @@ config:
 
 For full configuration, please refer to [Fine Tune API Specifications](./specs-finetune.md).
 
-#### Dataset Loading
+#### Choose a Dataset Format
 
-`datasets[].type` describes the records and training loss behavior. The optional `datasets[].loader.type` independently describes how AIKit obtains and parses those records. For example, a Parquet file can contain `prompt-completion` records, while a Hugging Face dataset can contain `messages` records.
+Multiple-dataset composition currently applies to supervised fine-tuning (SFT). Each `datasets` entry makes two independent choices:
+
+1. `datasets[].type` selects the **record schema** and determines which tokens contribute to SFT loss.
+2. `datasets[].loader.type` selects the **loader** used to obtain and parse the source.
+
+A loader does not imply a record schema. For example, a Parquet file can contain `prompt-completion` records, and a Hugging Face dataset can contain `messages` records.
+
+| Record schema (`datasets[].type`) | Expected records | SFT behavior |
+| --- | --- | --- |
+| `alpaca` | `instruction`, `input`, and `output` strings | Full-sequence |
+| `messages` | Canonical `role`/`content` conversations | Full-sequence with `loss: all`; assistant-response-only with `loss: response` |
+| `sharegpt` | ShareGPT `from`/`value` conversations | Full-sequence with `loss: all`; assistant-response-only with `loss: response` |
+| `prompt-completion` | Separate `prompt` and non-empty `completion` strings | Completion-only; prompt tokens are masked |
+| `text` | A complete preformatted sequence in `text` | Full-sequence |
+
+| Loader (`datasets[].loader.type`) | Source and parsing behavior |
+| --- | --- |
+| omitted | Legacy behavior: HTTP(S) uses JSON; other sources are passed to Hugging Face Datasets |
+| `huggingface` | A Hugging Face dataset identifier, with optional subset, split, and pinned revision |
+| `json`, `csv`, or `parquet` | An HTTP(S) file parsed with the corresponding builder |
+| `text` | An HTTP(S) text file; each line becomes one record with a `text` field |
+
+The `text` record schema and the `text` loader are separate settings. A line-oriented text file normally uses both `type: text` and `loader.type: text`.
+
+#### Dataset Loading and Reproducibility
 
 When `loader` is omitted, AIKit preserves the original behavior: HTTP(S) sources use the JSON builder with the `train` split, and every other source is passed to Hugging Face Datasets with the `train` split. These mutable sources remain supported, but AIKit emits a reproducibility warning because their bytes are not pinned.
 
@@ -97,34 +121,44 @@ Remote files are downloaded into an AIKit-owned content-addressed cache under th
 
 The loader `split` defaults to `train` and must contain letters, numbers, or underscores in one or more dot-separated segments. It selects the training split only; it does not configure evaluation data or metrics. The `text` loader turns each input line into a `text` record. JSON, CSV, and Parquet loaders can provide any supported record schema whose required columns and values are present. Unknown fields inside `loader` fail instead of being silently ignored.
 
-#### Dataset Types
+#### Combining Multiple Datasets
 
-AIKit supports one or more datasets per fine-tuning configuration. The configured `type` selects each source's record schema and training loss behavior; unknown types fail instead of falling back to another formatter.
+AIKit supports one or more datasets in an SFT configuration. All entries must resolve to the same SFT mode:
 
-AIKit loads sources sequentially in YAML order, validates every source as nonempty, normalizes each one independently to canonical columns and string features, and concatenates records in configured order while preserving row order within each source. This deterministic order exists before SFT trainer packing, shuffling, or sampling. A one-source configuration uses the existing path without a concatenation call. Datasets are not weighted, randomly interleaved, deduplicated, over- or undersampled; duplicate entries intentionally duplicate their rows.
-
-All entries must share one semantic group:
-
-| Group | Compatible dataset types |
+| SFT mode | Compatible dataset combination |
 | --- | --- |
-| Full-sequence | `alpaca`, `text`, `messages` with `loss: all`, and `sharegpt` with `loss: all` |
+| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with global `loss: all` |
 | Completion-only | One or more `prompt-completion` datasets |
-| Response-only chat | `messages` and `sharegpt` with global `loss: response` and `packing: false` |
+| Response-only chat | Any mix of `messages` and `sharegpt` with global `loss: response` and `packing: false` |
 
-Mixing groups fails with the relevant `datasets[n]` indexes instead of coercing records or silently ignoring later entries. `config.unsloth.loss` is global; per-dataset loss and weighted sampling are not supported. Each entry retains its own loader, split, subset, revision, and checksum identity. Changing or reordering any later entry invalidates training and export while leaving dependency installation cacheable.
+Mixing modes is unsupported. For example, `alpaca` cannot be combined with `prompt-completion`, and response-only chat cannot be combined with `text`. `config.unsloth.loss` applies to the whole job; per-dataset loss, weighted sampling, and random interleaving are not supported.
+
+AIKit loads sources sequentially in YAML order, validates every source as nonempty, normalizes each source independently, and concatenates records in configured order while preserving row order within each source. This deterministic order is the input to the SFT trainer; packing, shuffling, or sampling may reorder records afterward. Datasets are not deduplicated, over- or undersampled, so repeating an entry intentionally repeats its rows. A one-source configuration retains the existing single-source path.
+
+This example combines pinned Alpaca and preformatted-text sources in the full-sequence group while using different loaders:
 
 ```yaml
 datasets:
   - source: organization/instruction-data
     type: alpaca
-  - source: organization/domain-text
+    loader:
+      type: huggingface
+      split: train
+      revision: 0123456789abcdef0123456789abcdef01234567
+  - source: https://datasets.example.com/domain-text.jsonl
     type: text
-  - source: organization/chat-data
-    type: messages
+    loader:
+      type: json
+      split: train
+      checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 config:
   unsloth:
     loss: all
 ```
+
+Each entry retains its own loader, split, subset, revision, and checksum identity. Changing or reordering any entry invalidates training and export while leaving dependency installation cacheable. Incompatible entries fail with the relevant `datasets[n]` indexes instead of being coerced or ignored.
+
+#### Record Schema Details
 
 For the chat dataset types `messages` and `sharegpt`, `config.unsloth.loss` controls which tokens are supervised:
 

--- a/website/docs/specs-finetune.md
+++ b/website/docs/specs-finetune.md
@@ -8,7 +8,7 @@ title: Fine Tuning API Specifications
 #syntax=ghcr.io/kaito-project/aikit/aikit:latest
 apiVersion: # required. only v1alpha1 is supported at the moment
 baseModel: # required. any base model from Huggingface. for unsloth, see for 4bit pre-quantized models: https://huggingface.co/unsloth
-datasets:
+datasets: # required. one or more entries, concatenated in configured order after normalization
   - source: # required. a Hugging Face dataset identifier or an absolute HTTP(S) URL
     type: # required record schema. can be "alpaca", "messages", "sharegpt", "prompt-completion", or "text"
     loader: # optional. omission preserves automatic legacy loading and the train split
@@ -40,7 +40,7 @@ output:
 
 ### Dataset Loaders
 
-The record `type` and `loader.type` are independent. The record type defines required columns and SFT loss behavior; the loader defines source transport and parsing. Loader options are included in the serialized training configuration, so changing `type`, `subset`, `split`, `revision`, or `checksum` invalidates training and downstream export without invalidating dependency installation.
+The record `type` and `loader.type` are independent. The record type defines required columns and SFT loss behavior; the loader defines source transport and parsing. Every dataset entry and its loader options are included in the serialized training configuration, so changing or reordering any entry, or changing its `type`, `subset`, `split`, `revision`, or `checksum`, invalidates training and downstream export without invalidating dependency installation.
 
 | Loader | Source | Loader-specific fields | Reproducibility |
 | --- | --- | --- | --- |
@@ -82,7 +82,30 @@ datasets:
 
 ### Dataset Types
 
-Only one dataset is currently supported. Its `type` determines the required columns and loss behavior.
+One or more datasets are supported. AIKit loads entries sequentially in YAML order, validates and normalizes every source independently, then concatenates their canonical records in configured order while preserving row order within each source. This ordering is the input to trainer preprocessing; packing and trainer-level sampling may reorder records afterward. A single entry bypasses concatenation and retains the established single-source path.
+
+Dataset composition is unweighted: AIKit does not interleave, shuffle, deduplicate, oversample, or infer per-source weights before trainer construction. Repeating an entry intentionally repeats its rows. Every source must contain at least one record. The global `config.unsloth.loss` and every dataset type must resolve to one compatibility group:
+
+| Compatibility group | Supported entries | Training behavior |
+| --- | --- | --- |
+| Full-sequence text | `alpaca`, `text`, `messages` with `loss: all`, `sharegpt` with `loss: all` | Normalizes to a canonical string `text` column and supervises the full sequence. |
+| Completion-only | `prompt-completion` | Preserves canonical string `prompt` and `completion` columns and supervises only completion and EOS tokens. |
+| Response-only chat | `messages` with `loss: response`, `sharegpt` with `loss: response` | Normalizes to canonical rendered `text` and masks non-assistant tokens. Packing remains unsupported. |
+
+Entries from different groups cannot be combined. `loss` is global rather than per dataset. For example, compatible full-sequence sources can be composed as:
+
+```yaml
+datasets:
+  - source: organization/instruction-data
+    type: alpaca
+  - source: organization/domain-corpus
+    type: text
+  - source: organization/chat-data
+    type: messages
+config:
+  unsloth:
+    loss: all
+```
 
 | Type | Required record shape | Loss behavior |
 | --- | --- | --- |
@@ -92,7 +115,7 @@ Only one dataset is currently supported. Its `type` determines the required colu
 | `prompt-completion` | `prompt`, non-empty `completion` | Keeps both columns separate, masks prompt tokens, and supervises completion and EOS tokens. |
 | `text` | non-empty `text` | Preserves the preformatted sequence, normalizes BOS/EOS boundaries, and supervises the full sequence. |
 
-Empty datasets, missing or null fields, values of the wrong type, and unknown dataset types are rejected. Existing `alpaca` configurations retain their current rendering and full-sequence loss behavior.
+Empty sources, missing or null fields, values of the wrong type, incompatible semantic groups, and unknown dataset types are rejected with the failing `datasets[n]` index. Existing single-source `alpaca` and other supported configurations retain their current rendering and loss behavior. URL details remain redacted in indexed errors.
 
 The chat loss setting defaults to `all` for backward compatibility when omitted or set to YAML `null`; an explicit empty string is invalid. `response` is accepted only for `messages` and `sharegpt`; `alpaca`, `prompt-completion`, and `text` retain their fixed loss behavior. Response-only training requires `packing: false` so masking cannot cross conversation boundaries. It derives markers from the model's deterministic chat template and uses Unsloth's response masking after trainer construction. AIKit rejects marker strings or token matches that collide with message content or fail to match the rendered role boundaries, then validates the actual prepared labels before training. If marker derivation fails, labels do not match the response spans, or a prepared dataset has no supervised response tokens, training fails without falling back to `all`. Native assistant-only loss, custom chat templates, custom markers, and per-dataset loss settings are not supported.
 

--- a/website/docs/specs-finetune.md
+++ b/website/docs/specs-finetune.md
@@ -38,9 +38,30 @@ output:
   name: # optional. defaults to "aikit-model"
 ```
 
+### Dataset Format Model
+
+Multiple-dataset composition in this configuration applies to supervised fine-tuning (SFT) only. It does not define a preference record schema, objective selection, or DPO training.
+
+Each `datasets` entry has two independent format dimensions:
+
+- `type` selects the record schema, required fields, and SFT supervision behavior.
+- `loader.type` selects source transport and parsing.
+
+A loader does not select or infer the record schema. The loaded columns must satisfy the configured record `type`.
+
+| Record `type` | Required record shape | SFT supervision | Composition group |
+| --- | --- | --- | --- |
+| `alpaca` | String `instruction`, `input`, and `output` fields | Renders the Alpaca prompt, appends EOS, and supervises the full sequence | Full-sequence |
+| `messages` | Non-empty `messages` list containing text-only `role` and `content` mappings | `loss: all` supervises the rendered sequence; `loss: response` supervises assistant responses | Full-sequence or response-only chat, according to global `loss` |
+| `sharegpt` | Non-empty `conversations` list containing string `from` and `value` mappings | Normalizes fixed ShareGPT roles to messages and applies the same chat loss behavior | Full-sequence or response-only chat, according to global `loss` |
+| `prompt-completion` | String `prompt` and non-empty string `completion` fields | Masks prompt tokens and supervises completion and EOS tokens | Completion-only |
+| `text` | Non-empty string `text` field | Normalizes BOS/EOS boundaries and supervises the full sequence | Full-sequence |
+
+`config.unsloth.loss` is global to the training job. It cannot vary by dataset entry.
+
 ### Dataset Loaders
 
-The record `type` and `loader.type` are independent. The record type defines required columns and SFT loss behavior; the loader defines source transport and parsing. Every dataset entry and its loader options are included in the serialized training configuration, so changing or reordering any entry, or changing its `type`, `subset`, `split`, `revision`, or `checksum`, invalidates training and downstream export without invalidating dependency installation.
+The record `type` and `loader.type` are independent. Every dataset entry and its loader options are included in the serialized training configuration, so changing or reordering any entry, or changing its `type`, `subset`, `split`, `revision`, or `checksum`, invalidates training and downstream export without invalidating dependency installation.
 
 | Loader | Source | Loader-specific fields | Reproducibility |
 | --- | --- | --- | --- |
@@ -57,7 +78,7 @@ A Hugging Face `revision`, when present, must be a lowercase 40-character immuta
 
 Unknown fields, non-mapping values, nulls, and non-string values inside `loader` fail during parsing. Unknown fields elsewhere retain the existing permissive behavior. URL credentials, queries, and fragments are redacted from AIKit-generated warning logs and errors and are not written into cache filenames or cache metadata. The configured URL remains part of the serialized training configuration and BuildKit definition. This redaction therefore does not turn signed URLs into a supported secret channel; private dataset secret mounts are not supported.
 
-The `text` file loader yields one `text` record per line. JSON, CSV, and Parquet files may contain any supported record schema. For example:
+The `text` file loader yields one record with a `text` field per line and is normally paired with record `type: text`. JSON, CSV, and Parquet files may contain any supported record schema whose required fields are present. For example:
 
 ```yaml
 datasets:
@@ -80,40 +101,40 @@ datasets:
       checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
-### Dataset Types
+### Multiple Dataset Composition
 
-One or more datasets are supported. AIKit loads entries sequentially in YAML order, validates and normalizes every source independently, then concatenates their canonical records in configured order while preserving row order within each source. This ordering is the input to trainer preprocessing; packing and trainer-level sampling may reorder records afterward. A single entry bypasses concatenation and retains the established single-source path.
-
-Dataset composition is unweighted: AIKit does not interleave, shuffle, deduplicate, oversample, or infer per-source weights before trainer construction. Repeating an entry intentionally repeats its rows. Every source must contain at least one record. The global `config.unsloth.loss` and every dataset type must resolve to one compatibility group:
+One or more datasets are supported for SFT. The global `config.unsloth.loss` and every dataset type must resolve to one compatibility group:
 
 | Compatibility group | Supported entries | Training behavior |
 | --- | --- | --- |
-| Full-sequence text | `alpaca`, `text`, `messages` with `loss: all`, `sharegpt` with `loss: all` | Normalizes to a canonical string `text` column and supervises the full sequence. |
-| Completion-only | `prompt-completion` | Preserves canonical string `prompt` and `completion` columns and supervises only completion and EOS tokens. |
-| Response-only chat | `messages` with `loss: response`, `sharegpt` with `loss: response` | Normalizes to canonical rendered `text` and masks non-assistant tokens. Packing remains unsupported. |
+| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with `loss: all` | Normalizes to a canonical string `text` column and supervises the full sequence |
+| Completion-only | One or more `prompt-completion` entries | Preserves canonical string `prompt` and `completion` columns and supervises completion and EOS tokens |
+| Response-only chat | Any mix of `messages` and `sharegpt` with `loss: response` | Normalizes to canonical rendered `text`, masks non-assistant tokens, and requires `packing: false` |
 
-Entries from different groups cannot be combined. `loss` is global rather than per dataset. For example, compatible full-sequence sources can be composed as:
+Entries from different groups cannot be combined. In particular, prompt-completion data cannot be mixed with full-sequence data, and response-only chat cannot be mixed with `alpaca`, `prompt-completion`, or `text`. Per-dataset loss, source weights, random interleaving, deduplication, and automatic over- or undersampling are not supported.
+
+AIKit loads entries sequentially in YAML order, validates and normalizes every source independently, then concatenates their canonical records in configured order while preserving row order within each source. This ordering is the input to trainer preprocessing; packing and trainer-level sampling may reorder records afterward. A single entry bypasses concatenation and retains the established single-source path. Repeating an entry intentionally repeats its rows, and every source must contain at least one record.
+
+The following SFT configuration combines two full-sequence schemas with independent pinned loaders:
 
 ```yaml
 datasets:
   - source: organization/instruction-data
     type: alpaca
-  - source: organization/domain-corpus
+    loader:
+      type: huggingface
+      split: train
+      revision: 0123456789abcdef0123456789abcdef01234567
+  - source: https://datasets.example.com/domain-text.jsonl
     type: text
-  - source: organization/chat-data
-    type: messages
+    loader:
+      type: json
+      split: train
+      checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 config:
   unsloth:
     loss: all
 ```
-
-| Type | Required record shape | Loss behavior |
-| --- | --- | --- |
-| `alpaca` | `instruction`, `input`, `output` | Renders the existing Alpaca prompt, appends EOS, and supervises the full sequence. |
-| `messages` | Non-empty `messages` list containing text-only `role` and `content` mappings | Applies the tokenizer's chat template. `loss: all` supervises the full rendered sequence; `loss: response` supervises assistant responses. |
-| `sharegpt` | Non-empty `conversations` list containing string `from` and `value` mappings | Converts fixed ShareGPT roles to canonical messages, then uses the same rendering and loss pipeline as `messages`. |
-| `prompt-completion` | `prompt`, non-empty `completion` | Keeps both columns separate, masks prompt tokens, and supervises completion and EOS tokens. |
-| `text` | non-empty `text` | Preserves the preformatted sequence, normalizes BOS/EOS boundaries, and supervises the full sequence. |
 
 Empty sources, missing or null fields, values of the wrong type, incompatible semantic groups, and unknown dataset types are rejected with the failing `datasets[n]` index. Existing single-source `alpaca` and other supported configurations retain their current rendering and loss behavior. URL details remain redacted in indexed errors.
 

--- a/website/docs/specs-finetune.md
+++ b/website/docs/specs-finetune.md
@@ -117,6 +117,8 @@ AIKit loads entries sequentially in YAML order, validates and normalizes every s
 
 The locked Unsloth SFT path derives one rendered-text `add_special_tokens` value from the first canonical record. Before concatenation, AIKit compares every full-sequence record's token IDs under that dataset-wide value with its token IDs under the source-specific value. A mix in which one source already renders BOS and another relies on tokenizer-added BOS is rejected with the failing `datasets[n]` index when the values change the effective tokens; otherwise dataset order could duplicate BOS on one source or omit it from another. No-op setting differences remain valid, and reordering cannot bypass a real boundary mismatch.
 
+For multiple `prompt-completion` entries, AIKit also compares each source's effective token IDs and completion mask under its source-specific `add_special_tokens` value with the dataset-wide value selected from the first source. A mismatch that changes retained tokens or the prompt/completion boundary is rejected before concatenation; no-op value differences remain valid.
+
 The following SFT configuration combines two full-sequence schemas with independent pinned loaders:
 
 ```yaml

--- a/website/docs/specs-finetune.md
+++ b/website/docs/specs-finetune.md
@@ -8,9 +8,14 @@ title: Fine Tuning API Specifications
 #syntax=ghcr.io/kaito-project/aikit/aikit:latest
 apiVersion: # required. only v1alpha1 is supported at the moment
 baseModel: # required. any base model from Huggingface. for unsloth, see for 4bit pre-quantized models: https://huggingface.co/unsloth
-datasets: # required. one or more entries, concatenated in configured order after normalization
+objective: # optional. omission, null, or an empty mapping defaults to SFT
+  type: # optional. defaults to sft; dpo selects Direct Preference Optimization
+  beta: # DPO only. optional finite positive value; defaults to 0.1
+  lossType: # DPO only. optional; only sigmoid is supported and is the default
+  maxPromptLength: # DPO only. optional; defaults to 512 and must not exceed maxSeqLength
+datasets: # required. one or more compatible entries for SFT; exactly one preference entry for DPO
   - source: # required. a Hugging Face dataset identifier or an absolute HTTP(S) URL
-    type: # required record schema. can be "alpaca", "messages", "sharegpt", "prompt-completion", or "text"
+    type: # required record schema. can be "alpaca", "messages", "sharegpt", "prompt-completion", "text", or "preference"
     loader: # optional. omission preserves automatic legacy loading and the train split
       type: # required when loader is present. huggingface, json, csv, parquet, or text
       subset: # optional. Hugging Face loader only
@@ -19,15 +24,15 @@ datasets: # required. one or more entries, concatenated in configured order afte
       checksum: # optional. remote-file loaders only; sha256:<64 lowercase hex> of raw downloaded bytes
 config:
   unsloth:
-    loss: # optional. omitted or null defaults to all. response is supported only for messages and sharegpt
-    packing: # optional. defaults to false. not supported with loss: response.
+    loss: # optional SFT setting. omitted or null defaults to all. response is supported only for messages and sharegpt and rejected for DPO
+    packing: # optional. defaults to false. not supported with loss: response or objective.type: dpo
     maxSeqLength: # optional. defaults to 2048
     loadIn4bit: # optional. defaults to true
     batchSize: # optional. default to 2
     gradientAccumulationSteps: # optional. defaults to 4
     warmupSteps: # optional. defaults to 10
     maxSteps: # optional. defaults to 60
-    learningRate: # optional. defaults to 0.0002
+    learningRate: # optional. defaults to 0.0002 for SFT and 0.000001 for DPO
     loggingSteps: # optional. defaults to 1
     optimizer: # optional. defaults to adamw_8bit
     weightDecay: # optional. defaults to 0.01
@@ -38,30 +43,51 @@ output:
   name: # optional. defaults to "aikit-model"
 ```
 
-### Dataset Format Model
+### Training Objectives and Dataset Model
 
-Multiple-dataset composition in this configuration applies to supervised fine-tuning (SFT) only. It does not define a preference record schema, objective selection, or DPO training.
+The Unsloth target supports two offline objectives. SFT learns from demonstrated outputs or complete sequences. DPO learns a relative preference between chosen and rejected responses for the same prompt. DPO is not an online reinforcement-learning environment loop; this API does not define environment interaction, policy rollouts, or live reward collection.
 
-Each `datasets` entry has two independent format dimensions:
+The configuration has three independent layers:
 
-- `type` selects the record schema, required fields, and SFT supervision behavior.
-- `loader.type` selects source transport and parsing.
-
-A loader does not select or infer the record schema. The loaded columns must satisfy the configured record `type`.
-
-| Record `type` | Required record shape | SFT supervision | Composition group |
+| Layer | Field | Allowed values | Contract |
 | --- | --- | --- | --- |
-| `alpaca` | String `instruction`, `input`, and `output` fields | Renders the Alpaca prompt, appends EOS, and supervises the full sequence | Full-sequence |
-| `messages` | Non-empty `messages` list containing text-only `role` and `content` mappings | `loss: all` supervises the rendered sequence; `loss: response` supervises assistant responses | Full-sequence or response-only chat, according to global `loss` |
-| `sharegpt` | Non-empty `conversations` list containing string `from` and `value` mappings | Normalizes fixed ShareGPT roles to messages and applies the same chat loss behavior | Full-sequence or response-only chat, according to global `loss` |
-| `prompt-completion` | String `prompt` and non-empty string `completion` fields | Masks prompt tokens and supervises completion and EOS tokens | Completion-only |
-| `text` | Non-empty string `text` field | Normalizes BOS/EOS boundaries and supervises the full sequence | Full-sequence |
+| Training objective | `objective.type` | `sft`, `dpo` | Selects the SFT or DPO trainer. |
+| Record schema | `datasets[].type` | `alpaca`, `messages`, `sharegpt`, `prompt-completion`, `text`, `preference` | Defines required fields and loss semantics. |
+| Loader/parser | `datasets[].loader.type` | `huggingface`, `json`, `csv`, `parquet`, `text` | Defines how the source is located and parsed; it does not select the objective or schema. |
 
-`config.unsloth.loss` is global to the training job. It cannot vary by dataset entry.
+The record schema `type: text` and loader `loader.type: text` are distinct. The record schema requires a `text` field; the loader parses a remote text file into one `text` record per line.
+
+| Objective | Training signal | Allowed datasets | Defaults | Restrictions |
+| --- | --- | --- | --- | --- |
+| omitted, YAML `null`, empty mapping, or `sft` | Demonstrated outputs or complete sequences | One or more compatible `alpaca`, `messages`, `sharegpt`, `prompt-completion`, or `text` entries | `learningRate: 0.0002` | Rejects `preference`; all entries must belong to one SFT compatibility group. |
+| `dpo` | A `chosen` response preferred over a `rejected` response for one prompt | Exactly one `preference` entry | `beta: 0.1`, `lossType: sigmoid`, `maxPromptLength: 512`, `learningRate: 0.000001` | Requires `packing: false`, rejects `loss: response`, and requires `maxPromptLength <= maxSeqLength`. |
+
+DPO `beta` must be finite and greater than zero. Only `lossType: sigmoid` is supported. DPO uses the LoRA policy with `ref_model=None`; the same PEFT model with its adapter disabled supplies reference log probabilities. This is not reference-free DPO and does not accept a user-selected reference model. Preference records bypass every SFT formatter and masking path.
+
+A complete DPO objective and dataset declaration is:
+
+```yaml
+objective:
+  type: dpo
+  beta: 0.1
+  lossType: sigmoid
+  maxPromptLength: 512
+datasets:
+  - source: organization/preferences
+    type: preference
+    loader:
+      type: huggingface
+      split: train
+      revision: 0123456789abcdef0123456789abcdef01234567
+config:
+  unsloth:
+    packing: false
+    maxSeqLength: 2048
+```
 
 ### Dataset Loaders
 
-The record `type` and `loader.type` are independent. Every dataset entry and its loader options are included in the serialized training configuration, so changing or reordering any entry, or changing its `type`, `subset`, `split`, `revision`, or `checksum`, invalidates training and downstream export without invalidating dependency installation.
+The training `objective`, record `type`, and `loader.type` are independent. Objective and loader options are included in the serialized training configuration, so changing the objective, changing or reordering an SFT entry, or changing an entry's `type`, `subset`, `split`, `revision`, or `checksum` invalidates training and downstream export without invalidating dependency installation.
 
 | Loader | Source | Loader-specific fields | Reproducibility |
 | --- | --- | --- | --- |
@@ -78,7 +104,7 @@ A Hugging Face `revision`, when present, must be a lowercase 40-character immuta
 
 Unknown fields, non-mapping values, nulls, and non-string values inside `loader` fail during parsing. Unknown fields elsewhere retain the existing permissive behavior. URL credentials, queries, and fragments are redacted from AIKit-generated warning logs and errors and are not written into cache filenames or cache metadata. The configured URL remains part of the serialized training configuration and BuildKit definition. This redaction therefore does not turn signed URLs into a supported secret channel; private dataset secret mounts are not supported.
 
-The `text` file loader yields one record with a `text` field per line and is normally paired with record `type: text`. JSON, CSV, and Parquet files may contain any supported record schema whose required fields are present. For example:
+The `text` file loader yields one record with a `text` field per line and is normally paired with record `type: text`; it cannot supply DPO preference records. JSON, CSV, and Parquet files may contain any record schema compatible with the selected objective when the required fields are present. For example:
 
 ```yaml
 datasets:
@@ -101,9 +127,9 @@ datasets:
       checksum: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
-### Multiple Dataset Composition
+### SFT Dataset Composition
 
-One or more datasets are supported for SFT. The global `config.unsloth.loss` and every dataset type must resolve to one compatibility group:
+One or more datasets are supported for SFT. DPO does not use this composition path and requires exactly one `preference` dataset. The global `config.unsloth.loss` and every SFT dataset type must resolve to one compatibility group:
 
 | Compatibility group | Supported entries | Training behavior |
 | --- | --- | --- |
@@ -143,6 +169,18 @@ config:
 Empty sources, missing or null fields, values of the wrong type, incompatible semantic groups, and unknown dataset types are rejected with the failing `datasets[n]` index. Existing single-source `alpaca` and other supported configurations retain their current rendering and loss behavior. URL details remain redacted in indexed errors.
 
 The chat loss setting defaults to `all` for backward compatibility when omitted or set to YAML `null`; an explicit empty string is invalid. `response` is accepted only for `messages` and `sharegpt`; `alpaca`, `prompt-completion`, and `text` retain their fixed loss behavior. Response-only training requires `packing: false` so masking cannot cross conversation boundaries. It derives markers from the model's deterministic chat template and uses Unsloth's response masking after trainer construction. AIKit rejects marker strings or token matches that collide with message content or fail to match the rendered role boundaries, then validates the actual prepared labels before training. If marker derivation fails, labels do not match the response spans, or a prepared dataset has no supervised response tokens, training fails without falling back to `all`. Native assistant-only loss, custom chat templates, custom markers, and per-dataset loss settings are not supported.
+
+### DPO Preference Records
+
+A `preference` record must contain explicit, non-empty string `prompt`, `chosen`, and `rejected` values. `chosen` and `rejected` must differ. AIKit drops unrelated columns, projects exactly these three fields before model allocation, and does not append SFT EOS text or run Alpaca, prompt-completion, text, messages, or ShareGPT preprocessing.
+
+```json
+{"prompt":"How should I rotate an API key?","chosen":"Deploy a replacement before revoking the old key.","rejected":"Revoke the old key before creating a replacement."}
+```
+
+The pinned DPO trainer tokenizes each pair and uses `keep_end` truncation within `maxSeqLength`. AIKit validates the trainer-prepared prompt and completion token sequences and rejects a record if the effective chosen and rejected completion tokens become identical after truncation. Distinct source strings that collapse to the same trained tokens provide no preference signal and are invalid.
+
+Multiple preference datasets, implicit prompt extraction, conversational preference arrays, evaluation datasets, alternate DPO losses, custom reference models, reference-free DPO, preference-quality metrics, and online environment interaction are unsupported.
 
 For example, a prompt-completion dataset entry and record are:
 

--- a/website/docs/specs-finetune.md
+++ b/website/docs/specs-finetune.md
@@ -107,13 +107,15 @@ One or more datasets are supported for SFT. The global `config.unsloth.loss` and
 
 | Compatibility group | Supported entries | Training behavior |
 | --- | --- | --- |
-| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with `loss: all` | Normalizes to a canonical string `text` column and supervises the full sequence |
+| Full-sequence | Any mix of `alpaca`, `text`, `messages`, and `sharegpt` with `loss: all` and compatible tokenizer special-token boundaries | Normalizes to a canonical string `text` column and supervises the full sequence |
 | Completion-only | One or more `prompt-completion` entries | Preserves canonical string `prompt` and `completion` columns and supervises completion and EOS tokens |
 | Response-only chat | Any mix of `messages` and `sharegpt` with `loss: response` | Normalizes to canonical rendered `text`, masks non-assistant tokens, and requires `packing: false` |
 
 Entries from different groups cannot be combined. In particular, prompt-completion data cannot be mixed with full-sequence data, and response-only chat cannot be mixed with `alpaca`, `prompt-completion`, or `text`. Per-dataset loss, source weights, random interleaving, deduplication, and automatic over- or undersampling are not supported.
 
 AIKit loads entries sequentially in YAML order, validates and normalizes every source independently, then concatenates their canonical records in configured order while preserving row order within each source. This ordering is the input to trainer preprocessing; packing and trainer-level sampling may reorder records afterward. A single entry bypasses concatenation and retains the established single-source path. Repeating an entry intentionally repeats its rows, and every source must contain at least one record.
+
+The locked Unsloth SFT path derives one rendered-text `add_special_tokens` value from the first canonical record. Before concatenation, AIKit compares every full-sequence record's token IDs under that dataset-wide value with its token IDs under the source-specific value. A mix in which one source already renders BOS and another relies on tokenizer-added BOS is rejected with the failing `datasets[n]` index when the values change the effective tokens; otherwise dataset order could duplicate BOS on one source or omit it from another. No-op setting differences remain valid, and reordering cannot bypass a real boundary mismatch.
 
 The following SFT configuration combines two full-sequence schemas with independent pinned loaders:
 


### PR DESCRIPTION
Stacked on #833. This PR targets `issue-824` and should be merged after #833.

## Summary

- support multiple SFT datasets with deterministic YAML-order loading and source-row-order concatenation
- validate every source independently and reject empty or incompatible datasets before model allocation
- enforce compatible full-sequence, prompt-completion, and response-only semantic groups
- preserve each source's loader, split, subset, revision, checksum, and URL-redaction behavior
- normalize sources to canonical string features before ordered `datasets.concatenate_datasets`
- preserve the existing single-source path without concatenation
- aggregate prepared-data fingerprints across sources while retaining duplicates and tolerating BFD reorder
- apply response-only masking once to the combined trainer
- invalidate training/export when later datasets change or reorder without invalidating dependency installation
- add exact Datasets 4.3.0 unit coverage, two-source GPU smoke coverage, fixtures, and documentation

## Tests

- `make test`
- Python suite with exact `datasets==4.3.0` and `pyarrow==25.0.0` (141 tests, no skips)
- focused Go config/build/LLB tests
- exact-lock check with uv 0.12.1
- changed-lines `golangci-lint` (0 issues)
- actionlint/ShellCheck integration and workflow fixture rendering
- `go mod tidy` clean
- independent compatibility/order/cache-boundary review

The `multiple-datasets-smoke` GPU fine-tune workflow will be dispatched on this branch.

Closes #825


## GPU validation

- `multiple-datasets-smoke` passed the two-source fine-tune, GGUF export, image build, and inference path on final branch head `afede84`: [run 31177395921](https://github.com/kaito-project/aikit/actions/runs/31177395921).
- The GitHub-hosted unit-test job also passes with the exact Datasets/PyArrow test environment after switching dependency installation to a repository-local uv virtual environment.

