### PR TITLE
feat(inference): load configured models at startup

### DIFF
--- a/pkg/aikit/config/inference_specs.go
+++ b/pkg/aikit/config/inference_specs.go
@@ -1,12 +1,13 @@
 package config
 
 type InferenceConfig struct {
-	APIVersion string   `yaml:"apiVersion"`
-	Debug      bool     `yaml:"debug"`
-	Runtime    string   `yaml:"runtime"`
-	Backends   []string `yaml:"backends"`
-	Models     []Model  `yaml:"models"`
-	Config     string   `yaml:"config"`
+	APIVersion   string   `yaml:"apiVersion"`
+	Debug        bool     `yaml:"debug"`
+	Runtime      string   `yaml:"runtime"`
+	Backends     []string `yaml:"backends"`
+	Models       []Model  `yaml:"models"`
+	Config       string   `yaml:"config"`
+	LoadToMemory []string `yaml:"loadToMemory"`
 }
 
 type Model struct {

--- a/pkg/aikit/config/specs_test.go
+++ b/pkg/aikit/config/specs_test.go
@@ -24,6 +24,9 @@ apiVersion: v1alpha1
 runtime: cuda
 backends:
 - diffusers
+loadToMemory:
+- test
+- embeddings
 models:
 - name: test
   source: foo
@@ -34,6 +37,7 @@ models:
 				Backends: []string{
 					utils.BackendDiffusers,
 				},
+				LoadToMemory: []string{"test", "embeddings"},
 				Models: []Model{
 					{
 						Name:   "test",
@@ -47,6 +51,24 @@ models:
 			name: "invalid yaml",
 			args: args{b: []byte(`
 foo
+`)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory boolean is invalid",
+			args: args{b: []byte(`
+apiVersion: v1alpha1
+loadToMemory: true
+`)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory string is invalid",
+			args: args{b: []byte(`
+apiVersion: v1alpha1
+loadToMemory: test
 `)},
 			want:    nil,
 			wantErr: true,

--- a/pkg/aikit2llb/inference/image.go
+++ b/pkg/aikit2llb/inference/image.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	localAIEntrypointCommand = "local-ai"
+	localAILoadToMemoryEnv   = "LOCALAI_LOAD_TO_MEMORY="
 	runnerEntrypointPath     = "/usr/local/bin/aikit-runner"
 	runnerHFHomeEnv          = "HF_HOME=/models/.cache/huggingface"
 )
@@ -63,6 +64,9 @@ func emptyImage(c *config.InferenceConfig, platform *specs.Platform) *specs.Imag
 	img.Config.Env = []string{
 		"PATH=" + system.DefaultPathEnv(utils.PlatformLinux),
 		"CONFIG_FILE=/config.yaml",
+	}
+	if len(c.LoadToMemory) > 0 {
+		img.Config.Env = append(img.Config.Env, localAILoadToMemoryEnv+strings.Join(c.LoadToMemory, ","))
 	}
 
 	cudaEnv := []string{

--- a/pkg/aikit2llb/inference/image_test.go
+++ b/pkg/aikit2llb/inference/image_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	imageTestInferenceModel  = "test"
-	imageTestInferenceSource = "http://test"
+	imageTestDebugArgument     = "--debug"
+	imageTestInferenceModel    = "test"
+	imageTestInferenceSource   = "http://test"
+	imageTestLoadToMemoryModel = "model"
 )
 
 func TestNewImageConfigEntrypoint(t *testing.T) {
@@ -133,11 +135,27 @@ func TestNewImageConfigEnvironment(t *testing.T) {
 			wantEnv: append([]string{}, defaultEnv...),
 		},
 		{
+			name: "standard image loads configured models at startup",
+			config: &config.InferenceConfig{
+				Models:       []config.Model{{Name: imageTestInferenceModel, Source: imageTestInferenceSource}},
+				LoadToMemory: []string{"chat", "embeddings"},
+			},
+			wantEnv: append(append([]string{}, defaultEnv...), localAILoadToMemoryEnv+"chat,embeddings"),
+		},
+		{
 			name: "CPU runner adds Hugging Face cache on models volume",
 			config: &config.InferenceConfig{
 				Backends: []string{utils.BackendLlamaCpp},
 			},
 			wantEnv: append(append([]string{}, defaultEnv...), runnerHFHomeEnv),
+		},
+		{
+			name: "runner loads configured model at startup",
+			config: &config.InferenceConfig{
+				Backends:     []string{utils.BackendLlamaCpp},
+				LoadToMemory: []string{imageTestLoadToMemoryModel},
+			},
+			wantEnv: append(append(append([]string{}, defaultEnv...), localAILoadToMemoryEnv+imageTestLoadToMemoryModel), runnerHFHomeEnv),
 		},
 	}
 
@@ -152,6 +170,44 @@ func TestNewImageConfigEnvironment(t *testing.T) {
 				if strings.Contains(env, "/usr/local/cuda") || strings.HasPrefix(env, "CUDA_HOME=") {
 					t.Errorf("environment should not assume a system CUDA installation: %q", env)
 				}
+			}
+		})
+	}
+}
+
+func TestNewImageConfigCommandWithLoadToMemory(t *testing.T) {
+	platform := &specs.Platform{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux}
+
+	tests := []struct {
+		name    string
+		config  *config.InferenceConfig
+		wantCmd []string
+	}{
+		{
+			name: "standard image command is unchanged",
+			config: &config.InferenceConfig{
+				Debug:        true,
+				Config:       "config",
+				Models:       []config.Model{{Name: imageTestInferenceModel, Source: imageTestInferenceSource}},
+				LoadToMemory: []string{imageTestLoadToMemoryModel},
+			},
+			wantCmd: []string{imageTestDebugArgument, "--config-file=/config.yaml"},
+		},
+		{
+			name: "runner command remains empty",
+			config: &config.InferenceConfig{
+				Backends:     []string{utils.BackendLlamaCpp},
+				LoadToMemory: []string{imageTestLoadToMemoryModel},
+			},
+			wantCmd: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img := NewImageConfig(tt.config, platform)
+			if !reflect.DeepEqual(img.Config.Cmd, tt.wantCmd) {
+				t.Errorf("command = %v, want %v", img.Config.Cmd, tt.wantCmd)
 			}
 		})
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -565,6 +565,26 @@ func validateInferenceConfig(c *config.InferenceConfig) error {
 		return errors.Errorf("apiVersion %s is not supported", c.APIVersion)
 	}
 
+	loadToMemoryNames := make(map[string]struct{}, len(c.LoadToMemory))
+	for _, name := range c.LoadToMemory {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("loadToMemory model names cannot be empty")
+		}
+		if strings.ContainsRune(name, '\x00') {
+			return errors.New("loadToMemory model names cannot contain null characters")
+		}
+		if strings.Contains(name, ",") {
+			return errors.New("loadToMemory model names cannot contain commas")
+		}
+		if strings.Contains(name, `\`) {
+			return errors.New("loadToMemory model names cannot contain backslashes")
+		}
+		if _, exists := loadToMemoryNames[name]; exists {
+			return errors.Errorf("loadToMemory model name %q is duplicated", name)
+		}
+		loadToMemoryNames[name] = struct{}{}
+	}
+
 	if len(c.Backends) > 1 {
 		return errors.New("only one backend is supported at this time")
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"github.com/kaito-project/aikit/pkg/aikit/config"
+	"github.com/kaito-project/aikit/pkg/utils"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+const loadToMemoryTestModelName = "model"
 
 func Test_validateConfig(t *testing.T) {
 	type args struct {
@@ -127,8 +130,9 @@ func Test_validateConfig(t *testing.T) {
 		{
 			name: "valid runner mode - backends with no models (llama-cpp cpu)",
 			args: args{c: &config.InferenceConfig{
-				APIVersion: "v1alpha1",
-				Backends:   []string{"llama-cpp"},
+				APIVersion:   "v1alpha1",
+				Backends:     []string{utils.BackendLlamaCpp},
+				LoadToMemory: []string{loadToMemoryTestModelName},
 			}},
 			wantErr: false,
 		},
@@ -165,6 +169,54 @@ func Test_validateConfig(t *testing.T) {
 				APIVersion: "v1alpha1",
 				Runtime:    "applesilicon",
 				Backends:   []string{"llama-cpp"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects an empty model name",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{""},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects a whitespace-only model name",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{" \t"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects a null character",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{"model\x00name"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects a comma",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{"chat,embeddings"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects a backslash",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{`model\`, "embeddings"},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "loadToMemory rejects duplicate model names",
+			args: args{c: &config.InferenceConfig{
+				APIVersion:   "v1alpha1",
+				LoadToMemory: []string{loadToMemoryTestModelName, loadToMemoryTestModelName},
 			}},
 			wantErr: true,
 		},

--- a/website/docs/specs-inference.md
+++ b/website/docs/specs-inference.md
@@ -9,6 +9,8 @@ apiVersion: # required. only v1alpha1 is supported at the moment
 debug: # optional. if set to true, debug logs will be printed
 runtime: # optional. omit for the default CPU runtime. can be "cuda", "rocm", or "applesilicon"
 backends: # optional. list of additional backends. can be "llama-cpp" (default), "diffusers", "vllm"
+loadToMemory: # optional. list of LocalAI model config names to load when the container starts
+  - model-name
 models: # optional. list of models to build. omit for runner mode (see runners.md)
   - name: # required. name of the model
     source: # required. source of the model. can be a url or a local file
@@ -27,6 +29,21 @@ If omitted, `runtime` uses the default CPU runtime. `rocm` currently supports on
 When `backends` is specified without `models`, a **runner image** is created that downloads models at container startup. See [Runner Images](runners.md) for details.
 :::
 
+### Loading models at startup
+
+`loadToMemory` opts models into loading before LocalAI starts serving requests:
+
+```yaml
+loadToMemory:
+  - llama
+```
+
+Each item is an exact, case-sensitive LocalAI model-config name. For a baked `config`, use its `config[].name`; configs discovered or generated at runtime use the name declared in that config. Do not use a filename from the top-level `models` list. Names must be non-empty and unique, and cannot contain commas or backslashes. A model composed of several files, such as weight shards or a model plus an `mmproj` file, still has one logical name and needs one entry. Multiple names are loaded in the listed order.
+
+Runner images generate their LocalAI config after resolving the runtime model argument. The `llama-cpp` runner derives the name from the selected GGUF filename without the `.gguf` extension; Diffusers and vLLM runners use the normalized final component of the model source. Avoid a baked `loadToMemory` setting when a runner source can resolve to several GGUF files because the selected name is ambiguous.
+
+Loading blocks server startup and can fail if the model does not exist or there is insufficient memory, so health probes must allow enough startup time. It warms the model but does not prevent LocalAI from unloading it later, and LocalAI skips startup loading when `LOCALAI_SINGLE_ACTIVE_BACKEND=true`. The setting is disabled when omitted. At runtime, `LOCALAI_LOAD_TO_MEMORY` can replace the image default; set it to an empty value to disable startup loading.
+
 Example:
 
 ```yaml
@@ -34,6 +51,8 @@ Example:
 apiVersion: v1alpha1
 debug: true
 runtime: cuda
+loadToMemory:
+  - llama-2-7b-chat
 models:
   - name: llama-2-7b-chat
     source: https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_K_M.gguf


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an opt-in, list-only `loadToMemory` inference setting for logical LocalAI model-config names.

- forwards configured names through the overridable `LOCALAI_LOAD_TO_MEMORY` image environment for standard and runner images
- validates empty, duplicate, null-containing, comma-containing, and backslash-containing names
- keeps startup loading disabled when the field is omitted
- documents multi-file models, runner-derived names, startup behavior, and runtime overrides
- adds parsing, validation, standard-image, and runner-image coverage

**Which issue(s) this PR fixes**:

Fixes #613

**Special notes for your reviewer**:

`loadToMemory` names refer to LocalAI config names, not top-level artifact filenames. Commas and backslashes are rejected because both shipped LocalAI versions parse the environment value as an escape-aware comma-separated slice.

Verification:

- `make test`
- `golangci-lint run ./... --timeout 5m --new-from-rev=HEAD`