### PR TITLE
feat(inference): add vllm.cpp CPU and CUDA backends

### DIFF
--- a/.github/workflows/mirror-localai.yml
+++ b/.github/workflows/mirror-localai.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "LocalAI version tag (e.g. v4.7.1)"
+        description: "LocalAI version tag (e.g. v4.8.2)"
         required: true
-        default: v4.7.1
+        default: v4.8.2
 
 permissions:
   contents: read

--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -38,6 +38,14 @@ jobs:
             file: runners/vllm-cuda.yaml
             platforms: linux/amd64
             max-compressed-mib: 5600
+          - runner: vllm-cpp-cpu
+            file: runners/vllm-cpp-cpu.yaml
+            platforms: linux/amd64,linux/arm64
+            max-compressed-mib: 250
+          - runner: vllm-cpp-cuda
+            file: runners/vllm-cpp-cuda.yaml
+            platforms: linux/amd64
+            max-compressed-mib: 1800
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -29,11 +29,20 @@ jobs:
           - runner: llama-cpp-cpu
             model_ref: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
             model_name: gemma-3-1b-it-Q2_K
+            prompt: explain kubernetes in a sentence
+            max_tokens: 64
+            expected_content: ""
           - runner: vllm-cpp-cpu
             model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
             model_name: Qwen3-0.6B
+            prompt: What is the capital of France? Reply with only the city name. /no_think
+            max_tokens: 256
+            expected_content: Paris
     env:
+      EXPECTED_CONTENT: ${{ matrix.expected_content }}
+      MAX_TOKENS: ${{ matrix.max_tokens }}
       MODEL_NAME: ${{ matrix.model_name }}
+      MODEL_PROMPT: ${{ matrix.prompt }}
       MODEL_REF: ${{ matrix.model_ref }}
       RUNNER: ${{ matrix.runner }}
     steps:
@@ -141,7 +150,11 @@ jobs:
 
       - name: run chat completion test
         run: |
-          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, messages: [{role: "user", content: "explain kubernetes in a sentence"}], max_tokens: 64, temperature: 0}')
+          payload=$(jq -n \
+            --arg model "$MODEL_NAME" \
+            --arg prompt "$MODEL_PROMPT" \
+            --argjson max_tokens "$MAX_TOKENS" \
+            '{model: $model, messages: [{role: "user", content: $prompt}], max_tokens: $max_tokens, temperature: 0}')
           response=""
           for i in $(seq 1 30); do
             response=$(curl --fail --silent --show-error --max-time 300 http://127.0.0.1:8080/v1/chat/completions \
@@ -157,9 +170,16 @@ jobs:
           echo "$response"
           echo "$response" | jq -e --arg model "$MODEL_NAME" \
             '.error == null and .object == "chat.completion" and .model == $model and (.choices | length > 0) and
-             .choices[0].message.role == "assistant" and
-             (((.choices[0].message.content // "") | type == "string" and length > 0) or
-              ((.choices[0].message.reasoning_content // .choices[0].message.reasoning // "") | type == "string" and length > 0))'
+             .choices[0].message.role == "assistant"'
+          if [[ -n "$EXPECTED_CONTENT" ]]; then
+            echo "$response" | jq -e --arg expected "$EXPECTED_CONTENT" \
+              '.choices[0].finish_reason == "stop" and
+               ((.choices[0].message.content // "") | gsub("^\\s+|\\s+$"; "") == $expected)'
+          else
+            echo "$response" | jq -e \
+              '(((.choices[0].message.content // "") | type == "string" and length > 0) or
+               ((.choices[0].message.reasoning_content // .choices[0].message.reasoning // "") | type == "string" and length > 0))'
+          fi
 
       - name: save logs
         if: always()

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -18,9 +18,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  runner:
+    name: test (${{ matrix.runner }})
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: llama-cpp-cpu
+            model_url: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
+            model_name: gemma-3-1b-it-Q2_K
+            api: chat
+          - runner: vllm-cpp-cpu
+            model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q3_K_S.gguf
+            model_name: Qwen3.5-0.8B-Q3_K_S
+            api: completion
+    env:
+      MODEL_NAME: ${{ matrix.model_name }}
+      MODEL_URL: ${{ matrix.model_url }}
+      RUNNER: ${{ matrix.runner }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -75,7 +92,7 @@ jobs:
       - name: build runner image
         run: |
           docker buildx build . -t runner-test:test \
-            -f runners/llama-cpp-cpu.yaml \
+            -f "runners/${RUNNER}.yaml" \
             --build-arg BUILDKIT_SYNTAX=aikit:test \
             --load --provenance=false --progress plain
 
@@ -95,14 +112,16 @@ jobs:
           '
 
       - name: run runner with model
-        run: docker run --name runner-test -d -p 8080:8080 runner-test:test https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q2_K.gguf
+        run: docker run --name runner-test -d -p 8080:8080 runner-test:test "$MODEL_URL" --context-size 1024
 
       - name: wait for model download
         run: |
           echo "Waiting for runner container to download model and start..."
+          ready=false
           for i in $(seq 1 60); do
             if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/readyz 2>/dev/null | grep -q "200"; then
               echo "Server is ready!"
+              ready=true
               break
             fi
             if ! docker ps --format '{{.Names}}' | grep -q runner-test; then
@@ -111,36 +130,74 @@ jobs:
               exit 1
             fi
             if [ $((i % 10)) -eq 0 ]; then
-              echo "Still waiting... (${i}s elapsed)"
+              echo "Still waiting... ($((i * 10))s elapsed)"
               docker logs --tail 5 runner-test 2>&1 || true
             fi
             sleep 10
           done
+          if [[ "$ready" != "true" ]]; then
+            echo "Runner did not become ready within 10 minutes" >&2
+            docker logs runner-test 2>&1 || true
+            exit 1
+          fi
 
       - name: run chat completion test
+        if: matrix.api == 'chat'
         run: |
+          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, messages: [{role: "user", content: "explain kubernetes in a sentence"}]}')
+          response=""
           for i in $(seq 1 30); do
-            response=$(curl -sf http://127.0.0.1:8080/v1/chat/completions \
+            response=$(curl --fail --silent --show-error --max-time 300 http://127.0.0.1:8080/v1/chat/completions \
               -H "Content-Type: application/json" \
-              -d '{"model": "gemma-3-1b-it-Q2_K", "messages": [{"role": "user", "content": "explain kubernetes in a sentence"}]}' 2>/dev/null) && break
+              -d "$payload") && break
             echo "Attempt $i failed, retrying in 10s..."
             sleep 10
           done
+          if [[ -z "$response" ]]; then
+            echo "Chat completion did not return a response" >&2
+            exit 1
+          fi
           echo "$response"
           echo "$response" | jq -e '.choices | length > 0'
 
+      - name: run completion test
+        if: matrix.api == 'completion'
+        run: |
+          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, prompt: "The capital of France is", max_tokens: 8, temperature: 0}')
+          response=$(curl --fail --show-error --max-time 600 \
+            http://127.0.0.1:8080/v1/completions \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          echo "$response"
+          echo "$response" | jq -e --arg model "$MODEL_NAME" \
+            '.error == null and .object == "text_completion" and .model == $model and (.choices[0].text | type == "string" and length > 0)'
+
       - name: save logs
         if: always()
-        run: docker logs runner-test > /tmp/docker-runner-llama-cpp-cpu.log 2>&1
+        run: docker logs runner-test > "/tmp/docker-runner-${RUNNER}.log" 2>&1 || true
 
-      - name: stop container
+      - name: remove container
         if: always()
-        run: docker stop runner-test || true
+        run: docker rm -f runner-test || true
 
       - name: publish test artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-runner-llama-cpp-cpu
-          path: |
-            /tmp/*.log
+          name: test-runner-${{ matrix.runner }}
+          path: /tmp/docker-runner-${{ matrix.runner }}.log
+
+  test:
+    name: test
+    if: always()
+    needs: runner
+    runs-on: ubuntu-latest
+    steps:
+      - name: verify runner tests
+        env:
+          RESULT: ${{ needs.runner.result }}
+        run: |
+          if [[ "$RESULT" != "success" ]]; then
+            echo "Runner test matrix result: $RESULT" >&2
+            exit 1
+          fi

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -159,7 +159,7 @@ jobs:
             '.error == null and .object == "chat.completion" and .model == $model and (.choices | length > 0) and
              .choices[0].message.role == "assistant" and
              (((.choices[0].message.content // "") | type == "string" and length > 0) or
-              ((.choices[0].message.reasoning_content // "") | type == "string" and length > 0))'
+              ((.choices[0].message.reasoning_content // .choices[0].message.reasoning // "") | type == "string" and length > 0))'
 
       - name: save logs
         if: always()

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -27,16 +27,16 @@ jobs:
       matrix:
         include:
           - runner: llama-cpp-cpu
-            model_url: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
+            model_ref: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
             model_name: gemma-3-1b-it-Q2_K
             api: chat
           - runner: vllm-cpp-cpu
-            model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q3_K_S.gguf
-            model_name: Qwen3.5-0.8B-Q3_K_S
+            model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+            model_name: Qwen3-0.6B
             api: completion
     env:
       MODEL_NAME: ${{ matrix.model_name }}
-      MODEL_URL: ${{ matrix.model_url }}
+      MODEL_REF: ${{ matrix.model_ref }}
       RUNNER: ${{ matrix.runner }}
     steps:
       - name: Harden Runner
@@ -112,7 +112,7 @@ jobs:
           '
 
       - name: run runner with model
-        run: docker run --name runner-test -d -p 8080:8080 runner-test:test "$MODEL_URL" --context-size 1024
+        run: docker run --name runner-test -d -p 8080:8080 runner-test:test "$MODEL_REF" --context-size 1024
 
       - name: wait for model download
         run: |

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -29,11 +29,9 @@ jobs:
           - runner: llama-cpp-cpu
             model_ref: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
             model_name: gemma-3-1b-it-Q2_K
-            api: chat
           - runner: vllm-cpp-cpu
             model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
             model_name: Qwen3-0.6B
-            api: completion
     env:
       MODEL_NAME: ${{ matrix.model_name }}
       MODEL_REF: ${{ matrix.model_ref }}
@@ -142,9 +140,8 @@ jobs:
           fi
 
       - name: run chat completion test
-        if: matrix.api == 'chat'
         run: |
-          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, messages: [{role: "user", content: "explain kubernetes in a sentence"}]}')
+          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, messages: [{role: "user", content: "explain kubernetes in a sentence"}], max_tokens: 64, temperature: 0}')
           response=""
           for i in $(seq 1 30); do
             response=$(curl --fail --silent --show-error --max-time 300 http://127.0.0.1:8080/v1/chat/completions \
@@ -158,19 +155,11 @@ jobs:
             exit 1
           fi
           echo "$response"
-          echo "$response" | jq -e '.choices | length > 0'
-
-      - name: run completion test
-        if: matrix.api == 'completion'
-        run: |
-          payload=$(jq -n --arg model "$MODEL_NAME" '{model: $model, prompt: "The capital of France is", max_tokens: 8, temperature: 0}')
-          response=$(curl --fail --show-error --max-time 600 \
-            http://127.0.0.1:8080/v1/completions \
-            -H "Content-Type: application/json" \
-            -d "$payload")
-          echo "$response"
           echo "$response" | jq -e --arg model "$MODEL_NAME" \
-            '.error == null and .object == "text_completion" and .model == $model and (.choices[0].text | type == "string" and length > 0)'
+            '.error == null and .object == "chat.completion" and .model == $model and (.choices | length > 0) and
+             .choices[0].message.role == "assistant" and
+             (((.choices[0].message.content // "") | type == "string" and length > 0) or
+              ((.choices[0].message.reasoning_content // "") | type == "string" and length > 0))'
 
       - name: save logs
         if: always()

--- a/.github/workflows/test-docker.yaml
+++ b/.github/workflows/test-docker.yaml
@@ -34,6 +34,7 @@ jobs:
         backend:
           - llama
           - llama-cuda # this tests cpu inference with cuda libraries present in the image
+          - vllm-cpp-cpu
         arch:
           - amd64
           - arm64
@@ -117,6 +118,7 @@ jobs:
         run: docker run --name testmodel -d -p 8080:8080 --platform "linux/${{ matrix.arch }}" testmodel:test
 
       - name: run llama test
+        if: matrix.backend != 'vllm-cpp-cpu'
         run: |
           result=$(curl --fail --retry 10 --retry-all-errors http://127.0.0.1:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
             "model": "llama-3.2-1b-instruct",
@@ -130,6 +132,7 @@ jobs:
           fi
 
       - name: run tool calling test
+        if: matrix.backend != 'vllm-cpp-cpu'
         run: |
           result=$(curl --fail --retry 10 --retry-all-errors http://127.0.0.1:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
             "model": "llama-3.2-1b-instruct",
@@ -158,6 +161,21 @@ jobs:
           fi
 
           echo "Tool calling test passed"
+
+      - name: run vllm-cpp test
+        if: matrix.backend == 'vllm-cpp-cpu'
+        run: |
+          result=$(curl --fail --show-error --max-time 300 --retry 10 --retry-all-errors \
+            http://127.0.0.1:8080/v1/completions \
+            -H "Content-Type: application/json" \
+            -d '{
+              "model": "qwen35-vllmcpp-smoke",
+              "prompt": "The capital of France is",
+              "max_tokens": 8,
+              "temperature": 0
+            }')
+          echo "$result"
+          echo "$result" | jq -e '.choices[0].text | type == "string" and length > 0'
 
       - name: save logs
         if: always()

--- a/.github/workflows/test-docker.yaml
+++ b/.github/workflows/test-docker.yaml
@@ -162,20 +162,27 @@ jobs:
 
           echo "Tool calling test passed"
 
-      - name: run vllm-cpp test
+      - name: run vllm-cpp chat correctness test
         if: matrix.backend == 'vllm-cpp-cpu'
         run: |
           result=$(curl --fail --show-error --max-time 300 --retry 10 --retry-all-errors \
-            http://127.0.0.1:8080/v1/completions \
+            http://127.0.0.1:8080/v1/chat/completions \
             -H "Content-Type: application/json" \
             -d '{
               "model": "qwen35-vllmcpp-smoke",
-              "prompt": "The capital of France is",
-              "max_tokens": 8,
+              "messages": [{"role": "user", "content": "What is the capital of France? Reply with only the city name."}],
+              "max_tokens": 256,
               "temperature": 0
             }')
           echo "$result"
-          echo "$result" | jq -e '.choices[0].text | type == "string" and length > 0'
+          echo "$result" | jq -e '
+            .error == null and
+            .object == "chat.completion" and
+            .model == "qwen35-vllmcpp-smoke" and
+            (.choices | length > 0) and
+            .choices[0].finish_reason == "stop" and
+            .choices[0].message.role == "assistant" and
+            ((.choices[0].message.content // "") | gsub("^\\s+|\\s+$"; "") == "Paris")'
 
       - name: save logs
         if: always()

--- a/pkg/aikit2llb/inference/backend.go
+++ b/pkg/aikit2llb/inference/backend.go
@@ -12,13 +12,15 @@ import (
 const (
 	defaultBackendName    = "llama-cpp"
 	cpuLlamaCppBackend    = "cpu-llama-cpp"
+	cpuVLLMCppBackend     = "cpu-vllm-cpp"
 	cuda12LlamaCppBackend = "cuda12-llama-cpp"
+	cuda13VLLMCppBackend  = "cuda13-vllm-cpp"
 	vulkanLlamaCppBackend = "gpu-vulkan-llama-cpp"
 )
 
 func normalizeBackend(backend string) string {
 	switch backend {
-	case utils.BackendDiffusers, utils.BackendLlamaCpp, utils.BackendVLLM:
+	case utils.BackendDiffusers, utils.BackendLlamaCpp, utils.BackendVLLM, utils.BackendVLLMCpp:
 		return backend
 	default:
 		return defaultBackendName
@@ -37,6 +39,10 @@ func getEffectiveBackend(backend, runtime string, platform specs.Platform) strin
 	if runtime == utils.RuntimeNVIDIA && platform.Architecture == utils.PlatformAMD64 {
 		return normalizedBackend
 	}
+	if runtime == "" && normalizedBackend == utils.BackendVLLMCpp &&
+		(platform.Architecture == utils.PlatformAMD64 || platform.Architecture == utils.PlatformARM64) {
+		return normalizedBackend
+	}
 
 	return defaultBackendName
 }
@@ -52,7 +58,7 @@ func getBackendVersion(backend, runtime string, platform specs.Platform) string 
 	switch getEffectiveBackend(backend, runtime, platform) {
 	case utils.BackendDiffusers:
 		return localAILegacyBackendVersion
-	case utils.BackendVLLM:
+	case utils.BackendVLLM, utils.BackendVLLMCpp:
 		return localAIBinaryVersion
 	default:
 		return localAILlamaCppBackendVersion
@@ -94,6 +100,8 @@ func getBackendTag(backend, runtime string, platform specs.Platform) string {
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-12-diffusers", baseTag)
 		case "vllm":
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-12-vllm", baseTag)
+		case utils.BackendVLLMCpp:
+			return fmt.Sprintf("%s-gpu-nvidia-cuda-13-vllm-cpp", baseTag)
 		case defaultBackendName:
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-12-llama-cpp", baseTag)
 		default:
@@ -108,6 +116,9 @@ func getBackendTag(backend, runtime string, platform specs.Platform) string {
 	}
 
 	// Handle CPU runtime (default).
+	if backendName == utils.BackendVLLMCpp {
+		return fmt.Sprintf("%s-cpu-vllm-cpp", baseTag)
+	}
 	return fmt.Sprintf("%s-cpu-llama-cpp", baseTag)
 }
 
@@ -130,6 +141,8 @@ func getBackendName(backend, runtime string, platform specs.Platform) string {
 			return "cuda12-diffusers"
 		case utils.BackendVLLM:
 			return "cuda12-vllm"
+		case utils.BackendVLLMCpp:
+			return cuda13VLLMCppBackend
 		case defaultBackendName:
 			return cuda12LlamaCppBackend
 		default:
@@ -145,6 +158,9 @@ func getBackendName(backend, runtime string, platform specs.Platform) string {
 	}
 
 	// Handle CPU runtime (default)
+	if getEffectiveBackend(backend, runtime, platform) == utils.BackendVLLMCpp {
+		return cpuVLLMCppBackend
+	}
 	return cpuLlamaCppBackend
 }
 

--- a/pkg/aikit2llb/inference/backend_test.go
+++ b/pkg/aikit2llb/inference/backend_test.go
@@ -50,6 +50,24 @@ func TestGetBackendTag(t *testing.T) {
 			want: fmt.Sprintf("%s-cpu-llama-cpp", localAILlamaCppBackendVersion),
 		},
 		{
+			name:    "CPU vllm-cpp amd64",
+			backend: utils.BackendVLLMCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: fmt.Sprintf("%s-cpu-vllm-cpp", localAIBinaryVersion),
+		},
+		{
+			name:    "CPU vllm-cpp arm64",
+			backend: utils.BackendVLLMCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: fmt.Sprintf("%s-cpu-vllm-cpp", localAIBinaryVersion),
+		},
+		{
 			name:    "CUDA llama-cpp",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeNVIDIA,
@@ -75,6 +93,15 @@ func TestGetBackendTag(t *testing.T) {
 				Architecture: utils.PlatformAMD64,
 			},
 			want: fmt.Sprintf("%s-gpu-nvidia-cuda-12-vllm", localAIBinaryVersion),
+		},
+		{
+			name:    "CUDA vllm-cpp",
+			backend: utils.BackendVLLMCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: fmt.Sprintf("%s-gpu-nvidia-cuda-13-vllm-cpp", localAIBinaryVersion),
 		},
 		{
 			name:    "Apple Silicon llama-cpp",
@@ -196,6 +223,24 @@ func TestGetBackendVersion(t *testing.T) {
 			want: localAIBinaryVersion,
 		},
 		{
+			name:    "CPU vllm-cpp uses current backend tags",
+			backend: utils.BackendVLLMCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name:    "CUDA vllm-cpp uses current backend tags",
+			backend: utils.BackendVLLMCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
 			name:    "apple silicon stays on legacy backend tags",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeAppleSilicon,
@@ -238,6 +283,27 @@ func TestGetLocalAIArtifactVersion(t *testing.T) {
 			config: &config.InferenceConfig{
 				Runtime:  utils.RuntimeNVIDIA,
 				Backends: []string{utils.BackendVLLM},
+			},
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name: "CPU vllm-cpp uses current LocalAI binary",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendVLLMCpp},
+			},
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name: "CUDA vllm-cpp uses current LocalAI binary",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendVLLMCpp},
 			},
 			platform: specs.Platform{
 				Architecture: utils.PlatformAMD64,
@@ -387,6 +453,100 @@ func TestInstallBackendVLLMHasOptimizedCopyWithoutCompatibilityPatch(t *testing.
 	}
 }
 
+func TestInstallBackendVLLMCppIsSelfContained(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *config.InferenceConfig
+		platform    specs.Platform
+		wantImage   string
+		wantBackend string
+	}{
+		{
+			name: "CPU arm64",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendVLLMCpp},
+			},
+			platform: specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformARM64},
+			wantImage: fmt.Sprintf(
+				"%s:%s-cpu-vllm-cpp",
+				utils.BackendOCIRegistry,
+				localAIBinaryVersion,
+			),
+			wantBackend: cpuVLLMCppBackend,
+		},
+		{
+			name: "CUDA amd64",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendVLLMCpp},
+			},
+			platform: specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformAMD64},
+			wantImage: fmt.Sprintf(
+				"%s:%s-gpu-nvidia-cuda-13-vllm-cpp",
+				utils.BackendOCIRegistry,
+				localAIBinaryVersion,
+			),
+			wantBackend: cuda13VLLMCppBackend,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := llb.Image(utils.UbuntuBase, llb.Platform(tt.platform))
+			state := installBackend(utils.BackendVLLMCpp, tt.config, tt.platform, base, base)
+			definition, err := state.Marshal(context.Background())
+			if err != nil {
+				t.Fatalf("marshal vllm-cpp backend definition: %v", err)
+			}
+
+			var foundImage, foundMetadata bool
+			for _, data := range definition.Def {
+				op := new(pb.Op)
+				if err := op.Unmarshal(data); err != nil {
+					t.Fatalf("unmarshal LLB op: %v", err)
+				}
+
+				if source := op.GetSource(); source != nil && strings.Contains(source.Identifier, tt.wantImage) {
+					foundImage = true
+				}
+				if exec := op.GetExec(); exec != nil {
+					command := strings.Join(exec.Meta.Args, "\x00")
+					for _, unexpected := range []string{"gcc libc6-dev", "python3", "pip install", "cuda-keyring"} {
+						if strings.Contains(command, unexpected) {
+							t.Fatalf("self-contained vllm-cpp backend installs %q in command %q", unexpected, command)
+						}
+					}
+				}
+
+				fileOp := op.GetFile()
+				if fileOp == nil {
+					continue
+				}
+				metadataPath := "/backends/" + tt.wantBackend + "/metadata.json"
+				for _, action := range fileOp.Actions {
+					mkfile := action.GetMkfile()
+					if mkfile == nil || mkfile.Path != metadataPath {
+						continue
+					}
+					metadata := string(mkfile.Data)
+					if !strings.Contains(metadata, `"alias": "vllm-cpp"`) ||
+						!strings.Contains(metadata, `"name": "`+tt.wantBackend+`"`) {
+						t.Fatalf("vllm-cpp metadata = %q", metadata)
+					}
+					foundMetadata = true
+				}
+			}
+
+			if !foundImage {
+				t.Errorf("backend image %q is missing", tt.wantImage)
+			}
+			if !foundMetadata {
+				t.Errorf("backend metadata for %q is missing", tt.wantBackend)
+			}
+		})
+	}
+}
+
 func TestGetDefaultBackends(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -448,6 +608,11 @@ func TestGetBackendAlias(t *testing.T) {
 			want:    "vllm",
 		},
 		{
+			name:    "vllm-cpp backend",
+			backend: utils.BackendVLLMCpp,
+			want:    "vllm-cpp",
+		},
+		{
 			name:    "unknown backend defaults to llama-cpp",
 			backend: "unknown",
 			want:    "llama-cpp",
@@ -487,6 +652,24 @@ func TestGetBackendName(t *testing.T) {
 			want: "cpu-llama-cpp",
 		},
 		{
+			name:    "CPU vllm-cpp amd64",
+			backend: utils.BackendVLLMCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: "cpu-vllm-cpp",
+		},
+		{
+			name:    "CPU vllm-cpp arm64",
+			backend: utils.BackendVLLMCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: "cpu-vllm-cpp",
+		},
+		{
 			name:    "CUDA llama-cpp",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeNVIDIA,
@@ -512,6 +695,15 @@ func TestGetBackendName(t *testing.T) {
 				Architecture: utils.PlatformAMD64,
 			},
 			want: "cuda12-vllm",
+		},
+		{
+			name:    "CUDA vllm-cpp",
+			backend: utils.BackendVLLMCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: "cuda13-vllm-cpp",
 		},
 		{
 			name:    "Apple Silicon llama-cpp",

--- a/pkg/aikit2llb/inference/convert.go
+++ b/pkg/aikit2llb/inference/convert.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	distrolessBase                = "ghcr.io/kaito-project/aikit/base:latest"
-	localAIBinaryVersion          = "v4.7.1"
+	localAIBinaryVersion          = "v4.8.2"
 	localAILlamaCppBackendVersion = localAIBinaryVersion
 	localAILegacyBackendVersion   = "v3.12.1"
 	localAIROCmBackendVersion     = "rocm7"
@@ -92,10 +92,12 @@ func getBaseImage(c *config.InferenceConfig, platform *specs.Platform) llb.State
 		return llb.Image(utils.UbuntuBase, llb.Platform(*platform))
 	}
 
-	// LocalAI and the llama-cpp backend are self-contained. Keep the full Ubuntu
+	// LocalAI, llama-cpp, and vllm-cpp are self-contained. Keep the full Ubuntu
 	// base only for Python backends whose portable environments still rely on
 	// additional system runtime libraries.
-	if len(c.Backends) > 1 || (len(c.Backends) == 1 && c.Backends[0] != utils.BackendLlamaCpp) {
+	selfContainedBackend := len(c.Backends) == 0 ||
+		(len(c.Backends) == 1 && slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendVLLMCpp}, c.Backends[0]))
+	if !selfContainedBackend {
 		return llb.Image(utils.UbuntuBase, llb.Platform(*platform))
 	}
 

--- a/pkg/aikit2llb/inference/convert_test.go
+++ b/pkg/aikit2llb/inference/convert_test.go
@@ -191,6 +191,14 @@ func TestGetBaseImageUsesMinimalCompatibleRuntime(t *testing.T) {
 			want: utils.UbuntuBase,
 		},
 		{
+			name: "standard vllm-cpp",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendVLLMCpp},
+				Models:   []config.Model{{Name: testInferenceModelName, Source: "model.gguf"}},
+			},
+			want: distrolessBase,
+		},
+		{
 			name:   "Apple Silicon",
 			config: &config.InferenceConfig{Runtime: utils.RuntimeAppleSilicon},
 			want:   utils.AppleSiliconBase,

--- a/pkg/aikit2llb/inference/image.go
+++ b/pkg/aikit2llb/inference/image.go
@@ -1,6 +1,7 @@
 package inference
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/kaito-project/aikit/pkg/aikit/config"
@@ -69,8 +70,12 @@ func emptyImage(c *config.InferenceConfig, platform *specs.Platform) *specs.Imag
 		img.Config.Env = append(img.Config.Env, localAILoadToMemoryEnv+strings.Join(c.LoadToMemory, ","))
 	}
 
+	minimumCUDAVersion := "12.0"
+	if slices.Contains(c.Backends, utils.BackendVLLMCpp) {
+		minimumCUDAVersion = "13.0"
+	}
 	cudaEnv := []string{
-		"NVIDIA_REQUIRE_CUDA=cuda>=12.0",
+		"NVIDIA_REQUIRE_CUDA=cuda>=" + minimumCUDAVersion,
 		"NVIDIA_DRIVER_CAPABILITIES=compute,utility",
 		"NVIDIA_VISIBLE_DEVICES=all",
 		"BUILD_TYPE=cublas",

--- a/pkg/aikit2llb/inference/image_test.go
+++ b/pkg/aikit2llb/inference/image_test.go
@@ -105,6 +105,12 @@ func TestNewImageConfigEnvironment(t *testing.T) {
 		"NVIDIA_VISIBLE_DEVICES=all",
 		"BUILD_TYPE=cublas",
 	}
+	vllmCppNVIDIAEnv := []string{
+		"NVIDIA_REQUIRE_CUDA=cuda>=13.0",
+		"NVIDIA_DRIVER_CAPABILITIES=compute,utility",
+		"NVIDIA_VISIBLE_DEVICES=all",
+		"BUILD_TYPE=cublas",
+	}
 
 	tests := []struct {
 		name    string
@@ -126,6 +132,15 @@ func TestNewImageConfigEnvironment(t *testing.T) {
 				Backends: []string{utils.BackendVLLM},
 			},
 			wantEnv: append(append(append([]string{}, defaultEnv...), nvidiaEnv...), runnerHFHomeEnv),
+		},
+		{
+			name: "vllm-cpp NVIDIA image requires CUDA 13",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendVLLMCpp},
+				Models:   []config.Model{{Name: imageTestInferenceModel, Source: imageTestInferenceSource}},
+			},
+			wantEnv: append(append([]string{}, defaultEnv...), vllmCppNVIDIAEnv...),
 		},
 		{
 			name: "standard CPU image does not add runner cache",

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -153,8 +153,6 @@ if [[ -z "$MODEL" ]]; then
   exit 1
 fi
 
-echo "AIKit Runner: backend=$BACKEND model=$MODEL"
-
 # Keep the one active generated config separate from cached model payloads and
 # user-provided files. This also makes a shared volume safe to reuse with a
 # different runner backend: LocalAI scans only the config generated below.
@@ -164,6 +162,28 @@ RUNNER_CONFIG="` + runnerConfigPath + `"
 # Strip URI scheme prefixes (e.g. huggingface://org/repo -> org/repo)
 # kubeairunway passes model IDs with the huggingface:// prefix.
 MODEL="${MODEL#huggingface://}"
+
+# Cache markers contain only a digest so authenticated URLs are never persisted.
+# Logs omit URL queries/fragments and redact URI userinfo for the same reason.
+MODEL_CACHE_KEY="$(printf '%s' "$MODEL" | sha256sum)"
+MODEL_CACHE_KEY="${MODEL_CACHE_KEY%% *}"
+MODEL_SCHEME=""
+if [[ "$MODEL" == *://* ]]; then
+  MODEL_SCHEME="${MODEL%%://*}"
+  MODEL_SCHEME="$(printf '%s' "$MODEL_SCHEME" | tr '[:upper:]' '[:lower:]')"
+fi
+MODEL_LOG_REF="$MODEL"
+if [[ -n "$MODEL_SCHEME" ]]; then
+  MODEL_LOG_REF="${MODEL_LOG_REF%%\#*}"
+  MODEL_LOG_REF="${MODEL_LOG_REF%%\?*}"
+  MODEL_LOG_REF="${MODEL_LOG_REF#*://}"
+  if [[ "$MODEL_LOG_REF" == *@* ]]; then
+    MODEL_LOG_REF="[redacted]@${MODEL_LOG_REF##*@}"
+  fi
+  MODEL_LOG_REF="${MODEL_SCHEME}://${MODEL_LOG_REF}"
+fi
+
+echo "AIKit Runner: backend=$BACKEND model=$MODEL_LOG_REF"
 
 `)
 
@@ -214,35 +234,35 @@ MODEL_MARKER="` + runnerLlamaCppModelMarker + `"
 LEGACY_MODEL_MARKER="` + runnerLegacyModelMarker + `"
 LLAMA_CPP_MODEL_DIR="` + runnerLlamaCppModelDir + `"
 CACHED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit 2>/dev/null || true)
-if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]] &&
+if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL_CACHE_KEY" ]] &&
   [[ -n "$CACHED_GGUF" ]]; then
-  echo "Found cached model matching $MODEL in $LLAMA_CPP_MODEL_DIR, skipping download"
+  echo "Found cached model matching $MODEL_LOG_REF in $LLAMA_CPP_MODEL_DIR, skipping download"
 else
   # Different model requested, missing payload, or a legacy marker — clean and
   # re-download only the runner-owned cache. Legacy root files have no reliable
   # ownership metadata, so leave them untouched and outside LocalAI's config path.
   if [[ -f "$MODEL_MARKER" ]]; then
-    echo "Cached model data for $(cat "$MODEL_MARKER") is missing or does not match requested model ($MODEL), re-downloading"
+    echo "Cached model data is missing or does not match requested model ($MODEL_LOG_REF), re-downloading"
   elif [[ -f "$LEGACY_MODEL_MARKER" ]]; then
-    echo "Migrating legacy cached model ($(cat "$LEGACY_MODEL_MARKER")) for requested model ($MODEL)"
+    echo "Migrating legacy cached model for requested model ($MODEL_LOG_REF)"
   fi
   rm -rf "$LLAMA_CPP_MODEL_DIR"
   rm -f "$MODEL_MARKER" "$LEGACY_MODEL_MARKER" "$RUNNER_CONFIG"
   mkdir -p "$LLAMA_CPP_MODEL_DIR"
-  if [[ "$MODEL" == http://* ]] || [[ "$MODEL" == https://* ]]; then
+  if [[ "$MODEL_SCHEME" == "http" ]] || [[ "$MODEL_SCHEME" == "https" ]]; then
     # Direct HTTP/HTTPS download
-    echo "Downloading model from URL: $MODEL"
+    echo "Downloading model from URL: $MODEL_LOG_REF"
     MODEL_URL_PATH="${MODEL%%\#*}"
     MODEL_URL_PATH="${MODEL_URL_PATH%%\?*}"
     FILENAME="${MODEL_URL_PATH##*/}"
     if [[ -z "$FILENAME" ]] || [[ "$FILENAME" == "." ]] || [[ "$FILENAME" == ".." ]]; then
-      echo "Error: cannot derive a model filename from $MODEL" >&2
+      echo "Error: cannot derive a model filename from $MODEL_LOG_REF" >&2
       exit 1
     fi
     curl -fL --progress-bar -o "$LLAMA_CPP_MODEL_DIR/$FILENAME" "$MODEL"
   else
     # HuggingFace repo - download GGUF files
-    echo "Downloading GGUF files from HuggingFace: $MODEL"
+    echo "Downloading GGUF files from HuggingFace: $MODEL_LOG_REF"
     HF_ARGS=("$MODEL" "--local-dir" "$LLAMA_CPP_MODEL_DIR" "--include" "*.gguf")
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
@@ -251,10 +271,10 @@ else
   fi
   DOWNLOADED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
   if [[ -z "$DOWNLOADED_GGUF" ]]; then
-    echo "Error: no GGUF file was downloaded for $MODEL" >&2
+    echo "Error: no GGUF file was downloaded for $MODEL_LOG_REF" >&2
     exit 1
   fi
-  printf '%s\n' "$MODEL" > "$MODEL_MARKER"
+  printf '%s\n' "$MODEL_CACHE_KEY" > "$MODEL_MARKER"
   echo "Download complete"
 fi
 
@@ -262,7 +282,7 @@ fi
 # Without this, LocalAI looks for the model name as a filename (without .gguf extension).
 GGUF_FILE=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
 if [[ -z "$GGUF_FILE" ]]; then
-  echo "Error: cached GGUF file for $MODEL is missing" >&2
+  echo "Error: cached GGUF file for $MODEL_LOG_REF is missing" >&2
   exit 1
 fi
 GGUF_BASENAME=$(basename "$GGUF_FILE")
@@ -296,8 +316,42 @@ VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"
 MODEL_KIND=""
 LOCAL_MODEL_PATH=""
 
-case "$MODEL" in
-  http://*|https://*)
+validate_vllm_cpp_repository() {
+  [[ -f "$VLLM_CPP_MODEL_DIR/config.json" ]] || return 1
+
+  local index_path="$VLLM_CPP_MODEL_DIR/model.safetensors.index.json"
+  if [[ -f "$index_path" ]]; then
+    python3 - "$VLLM_CPP_MODEL_DIR" "$index_path" <<'PYEOF'
+import json
+import os
+import sys
+
+root = os.path.realpath(sys.argv[1])
+with open(sys.argv[2], encoding="utf-8") as index_file:
+    weight_map = json.load(index_file).get("weight_map")
+
+if not isinstance(weight_map, dict) or not weight_map:
+    raise SystemExit(1)
+
+for relative_path in set(weight_map.values()):
+    if (
+        not isinstance(relative_path, str)
+        or not relative_path.endswith(".safetensors")
+        or os.path.basename(relative_path) != relative_path
+    ):
+        raise SystemExit(1)
+    candidate = os.path.join(root, relative_path)
+    if not os.path.isfile(candidate):
+        raise SystemExit(1)
+PYEOF
+    return
+  fi
+
+  [[ -n "$(find "$VLLM_CPP_MODEL_DIR" -maxdepth 1 -type f -name "*.safetensors" -print -quit)" ]]
+}
+
+case "$MODEL_SCHEME" in
+  http|https)
     # Direct URLs are supported only for a single GGUF file. Strip query and
     # fragment components before validating and deriving the local filename.
     MODEL_URL_PATH="${MODEL%%\#*}"
@@ -311,11 +365,11 @@ case "$MODEL" in
     MODEL_NAME="${GGUF_FILENAME%.gguf}"
     LOCAL_MODEL_PATH="${VLLM_CPP_MODEL_DIR}/${GGUF_FILENAME}"
     ;;
-  *://*)
+  ?*)
     echo "Error: vllm-cpp supports only huggingface:// repository references or HTTP(S) .gguf URLs" >&2
     exit 1
     ;;
-  *)
+  "")
     # Restrict repository IDs to safe Hugging Face path components. Besides
     # rejecting unsupported URLs, this prevents option and YAML injection.
     if [[ ! "$MODEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]]; then
@@ -331,20 +385,19 @@ esac
 # Reuse a materialized model only when both its source marker and local payload
 # match. This keeps a mounted /models volume model-aware across runner restarts.
 CACHE_HIT="false"
-if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]]; then
+if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL_CACHE_KEY" ]]; then
   if [[ "$MODEL_KIND" == "gguf" ]] && [[ -f "$LOCAL_MODEL_PATH" ]]; then
     CACHE_HIT="true"
-  elif [[ "$MODEL_KIND" == "repository" ]] && [[ -f "$VLLM_CPP_MODEL_DIR/config.json" ]] &&
-    [[ -n "$(find "$VLLM_CPP_MODEL_DIR" -type f -name "*.safetensors" -print -quit)" ]]; then
+  elif [[ "$MODEL_KIND" == "repository" ]] && validate_vllm_cpp_repository; then
     CACHE_HIT="true"
   fi
 fi
 
 if [[ "$CACHE_HIT" == "true" ]]; then
-  echo "Found cached vllm-cpp model matching $MODEL in $VLLM_CPP_MODEL_DIR, skipping download"
+  echo "Found cached vllm-cpp model matching $MODEL_LOG_REF in $VLLM_CPP_MODEL_DIR, skipping download"
 else
   if [[ -f "$MODEL_MARKER" ]]; then
-    echo "Cached model ($(cat "$MODEL_MARKER")) does not match requested vllm-cpp model ($MODEL), re-downloading"
+    echo "Cached model does not match requested vllm-cpp model ($MODEL_LOG_REF), re-downloading"
   fi
 
   # This fixed runner-owned directory avoids deriving filesystem paths from
@@ -354,26 +407,25 @@ else
   mkdir -p "$VLLM_CPP_MODEL_DIR"
 
   if [[ "$MODEL_KIND" == "gguf" ]]; then
-    echo "Downloading vllm-cpp GGUF model from URL: $MODEL"
+    echo "Downloading vllm-cpp GGUF model from URL: $MODEL_LOG_REF"
     PARTIAL_PATH="${LOCAL_MODEL_PATH}.part"
     curl -fL --progress-bar --output "$PARTIAL_PATH" "$MODEL"
     mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
   else
-    echo "Downloading Hugging Face repository for vllm-cpp: $MODEL"
+    echo "Downloading Hugging Face repository for vllm-cpp: $MODEL_LOG_REF"
     HF_ARGS=("$MODEL" "--local-dir" "$VLLM_CPP_MODEL_DIR" "--exclude" "*.gguf")
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
     fi
     hf download "${HF_ARGS[@]}"
 
-    if [[ ! -f "$VLLM_CPP_MODEL_DIR/config.json" ]] ||
-      [[ -z "$(find "$VLLM_CPP_MODEL_DIR" -type f -name "*.safetensors" -print -quit)" ]]; then
+    if ! validate_vllm_cpp_repository; then
       echo "Error: vllm-cpp Hugging Face repositories must contain config.json and safetensors weights; use a direct HTTP(S) .gguf URL for GGUF models" >&2
       exit 1
     fi
   fi
 
-  printf '%s\n' "$MODEL" > "$MODEL_MARKER"
+  printf '%s\n' "$MODEL_CACHE_KEY" > "$MODEL_MARKER"
   echo "Download complete"
 fi
 

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -443,7 +443,20 @@ else
     mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
   else
     echo "Downloading Hugging Face repository for vllm-cpp: $MODEL_LOG_REF"
-    HF_ARGS=("$HF_REPOSITORY" "--local-dir" "$VLLM_CPP_PAYLOAD_DIR" "--exclude" "*.gguf")
+    # Download only the native vllm.cpp weight, configuration, and tokenizer
+    # assets. This avoids materializing alternate PyTorch, ONNX, Flax, or GGUF
+    # weights that can coexist in the same repository.
+    HF_ARGS=(
+      "$HF_REPOSITORY"
+      "--local-dir" "$VLLM_CPP_PAYLOAD_DIR"
+      "--include" "*.json"
+      "--include" "*.safetensors"
+      "--include" "*.model"
+      "--include" "*.txt"
+      "--include" "*.tiktoken"
+      "--include" "*.jinja"
+      "--exclude" "*.gguf"
+    )
     if [[ -n "$HF_REVISION" ]]; then
       HF_ARGS+=("--revision" "$HF_REVISION")
     fi

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -14,7 +14,8 @@ import (
 const (
 	runnerHuggingFaceHubVersion = "1.26.0"
 	runnerConfigDir             = "/models/aikit-runner"
-	runnerConfigPath            = runnerConfigDir + "/model.yaml"
+	runnerConfigFilename        = "model.yaml"
+	runnerConfigPath            = runnerConfigDir + "/" + runnerConfigFilename
 	runnerLegacyModelMarker     = "/models/.aikit-model-ref"
 	runnerLlamaCppModelDir      = "/models/llama-cpp-model"
 	runnerLlamaCppModelMarker   = "/models/.aikit-llama-cpp-model-ref"
@@ -153,11 +154,19 @@ if [[ -z "$MODEL" ]]; then
   exit 1
 fi
 
-# Keep the one active generated config separate from cached model payloads and
-# user-provided files. This also makes a shared volume safe to reuse with a
-# different runner backend: LocalAI scans only the config generated below.
+# Keep generated configs and payloads inside backend-owned directories. Native
+# backends scan their cache directory because LocalAI requires model paths to be
+# relative to --models-path; other backends use the config-only directory.
 RUNNER_CONFIG_DIR="` + runnerConfigDir + `"
-RUNNER_CONFIG="` + runnerConfigPath + `"
+case "$BACKEND" in
+  llama-cpp)
+    RUNNER_CONFIG_DIR="` + runnerLlamaCppModelDir + `"
+    ;;
+  vllm-cpp)
+    RUNNER_CONFIG_DIR="` + runnerVLLMCppModelDir + `"
+    ;;
+esac
+RUNNER_CONFIG="$RUNNER_CONFIG_DIR/` + runnerConfigFilename + `"
 
 # Strip URI scheme prefixes (e.g. huggingface://org/repo -> org/repo)
 # kubeairunway passes model IDs with the huggingface:// prefix.
@@ -233,7 +242,8 @@ func generateLlamaCppDownload() string {
 MODEL_MARKER="` + runnerLlamaCppModelMarker + `"
 LEGACY_MODEL_MARKER="` + runnerLegacyModelMarker + `"
 LLAMA_CPP_MODEL_DIR="` + runnerLlamaCppModelDir + `"
-CACHED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit 2>/dev/null || true)
+LLAMA_CPP_PAYLOAD_DIR="$LLAMA_CPP_MODEL_DIR/payload"
+CACHED_GGUF=$(find "$LLAMA_CPP_PAYLOAD_DIR" -type f -name "*.gguf" -print -quit 2>/dev/null || true)
 if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL_CACHE_KEY" ]] &&
   [[ -n "$CACHED_GGUF" ]]; then
   echo "Found cached model matching $MODEL_LOG_REF in $LLAMA_CPP_MODEL_DIR, skipping download"
@@ -248,7 +258,7 @@ else
   fi
   rm -rf "$LLAMA_CPP_MODEL_DIR"
   rm -f "$MODEL_MARKER" "$LEGACY_MODEL_MARKER" "$RUNNER_CONFIG"
-  mkdir -p "$LLAMA_CPP_MODEL_DIR"
+  mkdir -p "$LLAMA_CPP_PAYLOAD_DIR"
   if [[ "$MODEL_SCHEME" == "http" ]] || [[ "$MODEL_SCHEME" == "https" ]]; then
     # Direct HTTP/HTTPS download
     echo "Downloading model from URL: $MODEL_LOG_REF"
@@ -259,17 +269,17 @@ else
       echo "Error: cannot derive a model filename from $MODEL_LOG_REF" >&2
       exit 1
     fi
-    curl -fL --progress-bar -o "$LLAMA_CPP_MODEL_DIR/$FILENAME" "$MODEL"
+    curl -fL --progress-bar -o "$LLAMA_CPP_PAYLOAD_DIR/$FILENAME" "$MODEL"
   else
     # HuggingFace repo - download GGUF files
     echo "Downloading GGUF files from HuggingFace: $MODEL_LOG_REF"
-    HF_ARGS=("$MODEL" "--local-dir" "$LLAMA_CPP_MODEL_DIR" "--include" "*.gguf")
+    HF_ARGS=("$MODEL" "--local-dir" "$LLAMA_CPP_PAYLOAD_DIR" "--include" "*.gguf")
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
     fi
     hf download "${HF_ARGS[@]}"
   fi
-  DOWNLOADED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
+  DOWNLOADED_GGUF=$(find "$LLAMA_CPP_PAYLOAD_DIR" -type f -name "*.gguf" -print -quit)
   if [[ -z "$DOWNLOADED_GGUF" ]]; then
     echo "Error: no GGUF file was downloaded for $MODEL_LOG_REF" >&2
     exit 1
@@ -280,7 +290,7 @@ fi
 
 # Generate a minimal config file so LocalAI can map the model name to the GGUF file.
 # Without this, LocalAI looks for the model name as a filename (without .gguf extension).
-GGUF_FILE=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
+GGUF_FILE=$(find "$LLAMA_CPP_PAYLOAD_DIR" -type f -name "*.gguf" -print -quit)
 if [[ -z "$GGUF_FILE" ]]; then
   echo "Error: cached GGUF file for $MODEL_LOG_REF is missing" >&2
   exit 1
@@ -291,8 +301,13 @@ if [[ -z "$MODEL_NAME" ]]; then
   echo "Error: cannot derive a LocalAI model name from $GGUF_BASENAME" >&2
   exit 1
 fi
+MODEL_RELATIVE_PATH="${GGUF_FILE#"$LLAMA_CPP_MODEL_DIR"/}"
+if [[ -z "$MODEL_RELATIVE_PATH" ]] || [[ "$MODEL_RELATIVE_PATH" == "$GGUF_FILE" ]]; then
+  echo "Error: cached GGUF file is outside $LLAMA_CPP_MODEL_DIR" >&2
+  exit 1
+fi
 YAML_MODEL_NAME=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$MODEL_NAME")
-YAML_MODEL_PATH=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$GGUF_FILE")
+YAML_MODEL_PATH=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$MODEL_RELATIVE_PATH")
 mkdir -p "$RUNNER_CONFIG_DIR"
 echo "Generating config for model: $MODEL_NAME -> $GGUF_FILE"
 CONFIG_TMP=$(mktemp "$RUNNER_CONFIG_DIR/.model.yaml.XXXXXX")
@@ -313,15 +328,17 @@ func generateVLLMCppDownload() string {
 	return `# vllm.cpp requires the model to be materialized locally before startup.
 MODEL_MARKER="` + runnerVLLMCppModelMarker + `"
 VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"
+VLLM_CPP_PAYLOAD_DIR="$VLLM_CPP_MODEL_DIR/payload"
 MODEL_KIND=""
 LOCAL_MODEL_PATH=""
+CONFIG_MODEL_PATH=""
 
 validate_vllm_cpp_repository() {
-  [[ -f "$VLLM_CPP_MODEL_DIR/config.json" ]] || return 1
+  [[ -f "$VLLM_CPP_PAYLOAD_DIR/config.json" ]] || return 1
 
-  local index_path="$VLLM_CPP_MODEL_DIR/model.safetensors.index.json"
+  local index_path="$VLLM_CPP_PAYLOAD_DIR/model.safetensors.index.json"
   if [[ -f "$index_path" ]]; then
-    python3 - "$VLLM_CPP_MODEL_DIR" "$index_path" <<'PYEOF'
+    python3 - "$VLLM_CPP_PAYLOAD_DIR" "$index_path" <<'PYEOF'
 import json
 import os
 import sys
@@ -347,7 +364,7 @@ PYEOF
     return
   fi
 
-  [[ -n "$(find "$VLLM_CPP_MODEL_DIR" -maxdepth 1 -type f -name "*.safetensors" -print -quit)" ]]
+  [[ -n "$(find "$VLLM_CPP_PAYLOAD_DIR" -maxdepth 1 -type f -name "*.safetensors" -print -quit)" ]]
 }
 
 case "$MODEL_SCHEME" in
@@ -363,7 +380,8 @@ case "$MODEL_SCHEME" in
     fi
     MODEL_KIND="gguf"
     MODEL_NAME="${GGUF_FILENAME%.gguf}"
-    LOCAL_MODEL_PATH="${VLLM_CPP_MODEL_DIR}/${GGUF_FILENAME}"
+    LOCAL_MODEL_PATH="${VLLM_CPP_PAYLOAD_DIR}/${GGUF_FILENAME}"
+    CONFIG_MODEL_PATH="payload/$GGUF_FILENAME"
     ;;
   ?*)
     echo "Error: vllm-cpp supports only huggingface:// repository references or HTTP(S) .gguf URLs" >&2
@@ -378,7 +396,8 @@ case "$MODEL_SCHEME" in
     fi
     MODEL_KIND="repository"
     MODEL_NAME="${MODEL##*/}"
-    LOCAL_MODEL_PATH="$VLLM_CPP_MODEL_DIR"
+    LOCAL_MODEL_PATH="$VLLM_CPP_PAYLOAD_DIR"
+    CONFIG_MODEL_PATH="payload"
     ;;
 esac
 
@@ -404,7 +423,7 @@ else
   # untrusted model references and makes cache replacement deterministic.
   rm -rf ` + runnerVLLMCppModelDir + `
   rm -f "$MODEL_MARKER" "$RUNNER_CONFIG"
-  mkdir -p "$VLLM_CPP_MODEL_DIR"
+  mkdir -p "$VLLM_CPP_PAYLOAD_DIR"
 
   if [[ "$MODEL_KIND" == "gguf" ]]; then
     echo "Downloading vllm-cpp GGUF model from URL: $MODEL_LOG_REF"
@@ -413,7 +432,7 @@ else
     mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
   else
     echo "Downloading Hugging Face repository for vllm-cpp: $MODEL_LOG_REF"
-    HF_ARGS=("$MODEL" "--local-dir" "$VLLM_CPP_MODEL_DIR" "--exclude" "*.gguf")
+    HF_ARGS=("$MODEL" "--local-dir" "$VLLM_CPP_PAYLOAD_DIR" "--exclude" "*.gguf")
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
     fi
@@ -437,7 +456,7 @@ cat > "$CONFIG_TMP" <<MODELEOF
 name: '${MODEL_NAME}'
 backend: vllm-cpp
 parameters:
-  model: '${LOCAL_MODEL_PATH}'
+  model: '${CONFIG_MODEL_PATH}'
 template:
   use_tokenizer_template: true
 MODELEOF

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -140,7 +140,7 @@ if [[ -z "$MODEL" ]]; then
   echo ""
   echo "Examples:"
   if [[ "$BACKEND" == "vllm-cpp" ]]; then
-    echo "  docker run -p 8080:8080 <image> org/safetensors-model"
+    echo "  docker run -p 8080:8080 <image> org/safetensors-model@0123456789abcdef0123456789abcdef01234567"
     echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
     echo "  docker run -p 8080:8080 <image> --model org/safetensors-model"
   else
@@ -332,9 +332,12 @@ VLLM_CPP_PAYLOAD_DIR="$VLLM_CPP_MODEL_DIR/payload"
 MODEL_KIND=""
 LOCAL_MODEL_PATH=""
 CONFIG_MODEL_PATH=""
+HF_REPOSITORY=""
+HF_REVISION=""
 
 validate_vllm_cpp_repository() {
   [[ -f "$VLLM_CPP_PAYLOAD_DIR/config.json" ]] || return 1
+  [[ -f "$VLLM_CPP_PAYLOAD_DIR/tokenizer.json" ]] || return 1
 
   local index_path="$VLLM_CPP_PAYLOAD_DIR/model.safetensors.index.json"
   if [[ -f "$index_path" ]]; then
@@ -388,14 +391,22 @@ case "$MODEL_SCHEME" in
     exit 1
     ;;
   "")
-    # Restrict repository IDs to safe Hugging Face path components. Besides
-    # rejecting unsupported URLs, this prevents option and YAML injection.
-    if [[ ! "$MODEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]]; then
+    # Accept an optional immutable Hugging Face commit after @. Restrict both
+    # repository IDs and revisions before passing them to the hf CLI.
+    HF_REPOSITORY="${MODEL%%@*}"
+    if [[ "$MODEL" == *@* ]]; then
+      HF_REVISION="${MODEL#*@}"
+      if [[ ! "$HF_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "Error: Hugging Face revisions for vllm-cpp must be 40-character lowercase commit SHAs" >&2
+        exit 1
+      fi
+    fi
+    if [[ ! "$HF_REPOSITORY" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]]; then
       echo "Error: invalid Hugging Face repository ID for vllm-cpp: $MODEL" >&2
       exit 1
     fi
     MODEL_KIND="repository"
-    MODEL_NAME="${MODEL##*/}"
+    MODEL_NAME="${HF_REPOSITORY##*/}"
     LOCAL_MODEL_PATH="$VLLM_CPP_PAYLOAD_DIR"
     CONFIG_MODEL_PATH="payload"
     ;;
@@ -432,14 +443,17 @@ else
     mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
   else
     echo "Downloading Hugging Face repository for vllm-cpp: $MODEL_LOG_REF"
-    HF_ARGS=("$MODEL" "--local-dir" "$VLLM_CPP_PAYLOAD_DIR" "--exclude" "*.gguf")
+    HF_ARGS=("$HF_REPOSITORY" "--local-dir" "$VLLM_CPP_PAYLOAD_DIR" "--exclude" "*.gguf")
+    if [[ -n "$HF_REVISION" ]]; then
+      HF_ARGS+=("--revision" "$HF_REVISION")
+    fi
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
     fi
     hf download "${HF_ARGS[@]}"
 
     if ! validate_vllm_cpp_repository; then
-      echo "Error: vllm-cpp Hugging Face repositories must contain config.json and safetensors weights; use a direct HTTP(S) .gguf URL for GGUF models" >&2
+      echo "Error: vllm-cpp Hugging Face repositories must contain config.json and safetensors weights, plus tokenizer.json; use a direct HTTP(S) .gguf URL for GGUF models" >&2
       exit 1
     fi
   fi

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -13,6 +13,10 @@ import (
 
 const (
 	runnerHuggingFaceHubVersion = "1.26.0"
+	runnerLegacyModelMarker     = "/models/.aikit-model-ref"
+	runnerLlamaCppModelMarker   = "/models/.aikit-llama-cpp-model-ref"
+	runnerVLLMCppModelDir       = "/models/vllm-cpp-model"
+	runnerVLLMCppModelMarker    = "/models/.aikit-vllm-cpp-model-ref"
 	runnerDependenciesCommand   = "sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; " +
 		"s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && " +
 		"apt-get -o Acquire::Retries=5 -o APT::Update::Error-Mode=any update && " +
@@ -30,7 +34,7 @@ func isRunnerMode(c *config.InferenceConfig) bool {
 
 // installRunnerDependencies installs packages needed for runtime model downloading.
 func installRunnerDependencies(c *config.InferenceConfig, s llb.State, merge llb.State, platform specs.Platform) (llb.State, llb.State) {
-	if runnerBackend(c) != utils.BackendLlamaCpp {
+	if !slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendVLLMCpp}, runnerBackend(c)) {
 		return s, merge
 	}
 
@@ -131,9 +135,15 @@ if [[ -z "$MODEL" ]]; then
   echo "Usage: docker run <image> <model-ref>"
   echo ""
   echo "Examples:"
-  echo "  docker run -p 8080:8080 <image> unsloth/gemma-3-1b-it-GGUF"
-  echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
-  echo "  docker run -p 8080:8080 <image> --model unsloth/gemma-3-1b-it-GGUF"
+  if [[ "$BACKEND" == "vllm-cpp" ]]; then
+    echo "  docker run -p 8080:8080 <image> org/safetensors-model"
+    echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
+    echo "  docker run -p 8080:8080 <image> --model org/safetensors-model"
+  else
+    echo "  docker run -p 8080:8080 <image> org/model"
+    echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
+    echo "  docker run -p 8080:8080 <image> --model org/model"
+  fi
   echo ""
   echo "Environment variables:"
   echo "  HF_TOKEN    - HuggingFace token for gated models"
@@ -149,9 +159,12 @@ MODEL="${MODEL#huggingface://}"
 `)
 
 	// Backend-specific download logic
-	if backend == utils.BackendLlamaCpp {
+	switch backend {
+	case utils.BackendLlamaCpp:
 		sb.WriteString(generateLlamaCppDownload())
-	} else if slices.Contains([]string{utils.BackendDiffusers, utils.BackendVLLM}, backend) {
+	case utils.BackendVLLMCpp:
+		sb.WriteString(generateVLLMCppDownload())
+	case utils.BackendDiffusers, utils.BackendVLLM:
 		sb.WriteString(generateHFModelConfig(backend))
 	}
 
@@ -188,15 +201,21 @@ exec /usr/bin/local-ai "${LOCAL_AI_ARGS[@]}"
 func generateLlamaCppDownload() string {
 	return `# Check if the requested model already exists (volume mount caching)
 # Write a marker file so we can detect model mismatches on reuse.
-MODEL_MARKER="/models/.aikit-model-ref"
-if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]]; then
+MODEL_MARKER="` + runnerLlamaCppModelMarker + `"
+LEGACY_MODEL_MARKER="` + runnerLegacyModelMarker + `"
+if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]] &&
+  [[ -n "$(find /models -maxdepth 1 -name "*.gguf" -type f -print -quit)" ]]; then
   echo "Found cached model matching $MODEL in /models, skipping download"
 else
-  # Different model requested or no marker — clean and re-download
+  # Different model requested, missing payload, or a legacy marker — clean and
+  # re-download. Clearing root GGUF files unconditionally on a cache miss keeps
+  # upgraded persistent volumes from selecting a stale file.
   if [[ -f "$MODEL_MARKER" ]]; then
-    echo "Cached model ($(cat "$MODEL_MARKER")) does not match requested model ($MODEL), re-downloading"
-    rm -f /models/*.gguf "$MODEL_MARKER"
+    echo "Cached model data for $(cat "$MODEL_MARKER") is missing or does not match requested model ($MODEL), re-downloading"
+  elif [[ -f "$LEGACY_MODEL_MARKER" ]]; then
+    echo "Migrating legacy cached model ($(cat "$LEGACY_MODEL_MARKER")) for requested model ($MODEL)"
   fi
+  rm -f /models/*.gguf "$MODEL_MARKER" "$LEGACY_MODEL_MARKER"
   if [[ "$MODEL" == http://* ]] || [[ "$MODEL" == https://* ]]; then
     # Direct HTTP/HTTPS download
     echo "Downloading model from URL: $MODEL"
@@ -217,7 +236,7 @@ fi
 
 # Generate a minimal config file so LocalAI can map the model name to the GGUF file.
 # Without this, LocalAI looks for the model name as a filename (without .gguf extension).
-GGUF_FILE=$(find /models -name "*.gguf" -type f | head -1)
+GGUF_FILE=$(find /models -maxdepth 1 -name "*.gguf" -type f | head -1)
 if [[ -n "$GGUF_FILE" ]]; then
   GGUF_BASENAME=$(basename "$GGUF_FILE")
   MODEL_NAME="${GGUF_BASENAME%.gguf}"
@@ -231,6 +250,112 @@ parameters:
 CFGEOF
   fi
 fi
+`
+}
+
+// generateVLLMCppDownload generates download and configuration logic for the
+// vllm.cpp backend. Unlike the Python vLLM backend, vllm.cpp requires a local
+// model path rather than a Hugging Face repository ID.
+func generateVLLMCppDownload() string {
+	return `# vllm.cpp requires the model to be materialized locally before startup.
+MODEL_MARKER="` + runnerVLLMCppModelMarker + `"
+VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"
+VLLM_CPP_CONFIG="/models/aikit-model.yaml"
+MODEL_KIND=""
+LOCAL_MODEL_PATH=""
+
+case "$MODEL" in
+  http://*|https://*)
+    # Direct URLs are supported only for a single GGUF file. Strip query and
+    # fragment components before validating and deriving the local filename.
+    MODEL_URL_PATH="${MODEL%%\#*}"
+    MODEL_URL_PATH="${MODEL_URL_PATH%%\?*}"
+    GGUF_FILENAME="${MODEL_URL_PATH##*/}"
+    if [[ ! "$GGUF_FILENAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.gguf$ ]]; then
+      echo "Error: vllm-cpp direct URLs must point to a .gguf file with a safe filename" >&2
+      exit 1
+    fi
+    MODEL_KIND="gguf"
+    MODEL_NAME="${GGUF_FILENAME%.gguf}"
+    LOCAL_MODEL_PATH="${VLLM_CPP_MODEL_DIR}/${GGUF_FILENAME}"
+    ;;
+  *://*)
+    echo "Error: vllm-cpp supports only huggingface:// repository references or HTTP(S) .gguf URLs" >&2
+    exit 1
+    ;;
+  *)
+    # Restrict repository IDs to safe Hugging Face path components. Besides
+    # rejecting unsupported URLs, this prevents option and YAML injection.
+    if [[ ! "$MODEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]]; then
+      echo "Error: invalid Hugging Face repository ID for vllm-cpp: $MODEL" >&2
+      exit 1
+    fi
+    MODEL_KIND="repository"
+    MODEL_NAME="${MODEL##*/}"
+    LOCAL_MODEL_PATH="$VLLM_CPP_MODEL_DIR"
+    ;;
+esac
+
+# Reuse a materialized model only when both its source marker and local payload
+# match. This keeps a mounted /models volume model-aware across runner restarts.
+CACHE_HIT="false"
+if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]]; then
+  if [[ "$MODEL_KIND" == "gguf" ]] && [[ -f "$LOCAL_MODEL_PATH" ]]; then
+    CACHE_HIT="true"
+  elif [[ "$MODEL_KIND" == "repository" ]] && [[ -f "$VLLM_CPP_MODEL_DIR/config.json" ]] &&
+    [[ -n "$(find "$VLLM_CPP_MODEL_DIR" -type f -name "*.safetensors" -print -quit)" ]]; then
+    CACHE_HIT="true"
+  fi
+fi
+
+if [[ "$CACHE_HIT" == "true" ]]; then
+  echo "Found cached vllm-cpp model matching $MODEL in $VLLM_CPP_MODEL_DIR, skipping download"
+else
+  if [[ -f "$MODEL_MARKER" ]]; then
+    echo "Cached model ($(cat "$MODEL_MARKER")) does not match requested vllm-cpp model ($MODEL), re-downloading"
+  fi
+
+  # This fixed runner-owned directory avoids deriving filesystem paths from
+  # untrusted model references and makes cache replacement deterministic.
+  rm -rf ` + runnerVLLMCppModelDir + `
+  rm -f "$MODEL_MARKER" "$VLLM_CPP_CONFIG"
+  mkdir -p "$VLLM_CPP_MODEL_DIR"
+
+  if [[ "$MODEL_KIND" == "gguf" ]]; then
+    echo "Downloading vllm-cpp GGUF model from URL: $MODEL"
+    PARTIAL_PATH="${LOCAL_MODEL_PATH}.part"
+    curl -fL --progress-bar --output "$PARTIAL_PATH" "$MODEL"
+    mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
+  else
+    echo "Downloading Hugging Face repository for vllm-cpp: $MODEL"
+    HF_ARGS=("$MODEL" "--local-dir" "$VLLM_CPP_MODEL_DIR" "--exclude" "*.gguf")
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+      HF_ARGS+=("--token" "$HF_TOKEN")
+    fi
+    hf download "${HF_ARGS[@]}"
+
+    if [[ ! -f "$VLLM_CPP_MODEL_DIR/config.json" ]] ||
+      [[ -z "$(find "$VLLM_CPP_MODEL_DIR" -type f -name "*.safetensors" -print -quit)" ]]; then
+      echo "Error: vllm-cpp Hugging Face repositories must contain config.json and safetensors weights; use a direct HTTP(S) .gguf URL for GGUF models" >&2
+      exit 1
+    fi
+  fi
+
+  printf '%s\n' "$MODEL" > "$MODEL_MARKER"
+  echo "Download complete"
+fi
+
+# Always point LocalAI at the validated local payload. A bare Hugging Face ID
+# is valid for the Python vLLM backend but is not valid for vllm.cpp.
+cat > "$VLLM_CPP_CONFIG" <<MODELEOF
+name: ${MODEL_NAME}
+backend: vllm-cpp
+parameters:
+  model: ${LOCAL_MODEL_PATH}
+template:
+  use_tokenizer_template: true
+MODELEOF
+echo "Config generated at $VLLM_CPP_CONFIG"
 `
 }
 

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -13,7 +13,10 @@ import (
 
 const (
 	runnerHuggingFaceHubVersion = "1.26.0"
+	runnerConfigDir             = "/models/aikit-runner"
+	runnerConfigPath            = runnerConfigDir + "/model.yaml"
 	runnerLegacyModelMarker     = "/models/.aikit-model-ref"
+	runnerLlamaCppModelDir      = "/models/llama-cpp-model"
 	runnerLlamaCppModelMarker   = "/models/.aikit-llama-cpp-model-ref"
 	runnerVLLMCppModelDir       = "/models/vllm-cpp-model"
 	runnerVLLMCppModelMarker    = "/models/.aikit-vllm-cpp-model-ref"
@@ -152,6 +155,12 @@ fi
 
 echo "AIKit Runner: backend=$BACKEND model=$MODEL"
 
+# Keep the one active generated config separate from cached model payloads and
+# user-provided files. This also makes a shared volume safe to reuse with a
+# different runner backend: LocalAI scans only the config generated below.
+RUNNER_CONFIG_DIR="` + runnerConfigDir + `"
+RUNNER_CONFIG="` + runnerConfigPath + `"
+
 # Strip URI scheme prefixes (e.g. huggingface://org/repo -> org/repo)
 # kubeairunway passes model IDs with the huggingface:// prefix.
 MODEL="${MODEL#huggingface://}"
@@ -171,7 +180,7 @@ MODEL="${MODEL#huggingface://}"
 	// Start LocalAI
 	sb.WriteString(`
 # Start local-ai
-LOCAL_AI_ARGS=("--models-path" "/models")
+LOCAL_AI_ARGS=("--models-path" "$RUNNER_CONFIG_DIR")
 `)
 
 	// If config was baked in at build time, use it
@@ -203,53 +212,77 @@ func generateLlamaCppDownload() string {
 # Write a marker file so we can detect model mismatches on reuse.
 MODEL_MARKER="` + runnerLlamaCppModelMarker + `"
 LEGACY_MODEL_MARKER="` + runnerLegacyModelMarker + `"
+LLAMA_CPP_MODEL_DIR="` + runnerLlamaCppModelDir + `"
+CACHED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit 2>/dev/null || true)
 if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL" ]] &&
-  [[ -n "$(find /models -maxdepth 1 -name "*.gguf" -type f -print -quit)" ]]; then
-  echo "Found cached model matching $MODEL in /models, skipping download"
+  [[ -n "$CACHED_GGUF" ]]; then
+  echo "Found cached model matching $MODEL in $LLAMA_CPP_MODEL_DIR, skipping download"
 else
   # Different model requested, missing payload, or a legacy marker — clean and
-  # re-download. Clearing root GGUF files unconditionally on a cache miss keeps
-  # upgraded persistent volumes from selecting a stale file.
+  # re-download only the runner-owned cache. Legacy root files have no reliable
+  # ownership metadata, so leave them untouched and outside LocalAI's config path.
   if [[ -f "$MODEL_MARKER" ]]; then
     echo "Cached model data for $(cat "$MODEL_MARKER") is missing or does not match requested model ($MODEL), re-downloading"
   elif [[ -f "$LEGACY_MODEL_MARKER" ]]; then
     echo "Migrating legacy cached model ($(cat "$LEGACY_MODEL_MARKER")) for requested model ($MODEL)"
   fi
-  rm -f /models/*.gguf "$MODEL_MARKER" "$LEGACY_MODEL_MARKER"
+  rm -rf "$LLAMA_CPP_MODEL_DIR"
+  rm -f "$MODEL_MARKER" "$LEGACY_MODEL_MARKER" "$RUNNER_CONFIG"
+  mkdir -p "$LLAMA_CPP_MODEL_DIR"
   if [[ "$MODEL" == http://* ]] || [[ "$MODEL" == https://* ]]; then
     # Direct HTTP/HTTPS download
     echo "Downloading model from URL: $MODEL"
-    FILENAME=$(basename "$MODEL")
-    curl -fL --progress-bar -o "/models/$FILENAME" "$MODEL"
+    MODEL_URL_PATH="${MODEL%%\#*}"
+    MODEL_URL_PATH="${MODEL_URL_PATH%%\?*}"
+    FILENAME="${MODEL_URL_PATH##*/}"
+    if [[ -z "$FILENAME" ]] || [[ "$FILENAME" == "." ]] || [[ "$FILENAME" == ".." ]]; then
+      echo "Error: cannot derive a model filename from $MODEL" >&2
+      exit 1
+    fi
+    curl -fL --progress-bar -o "$LLAMA_CPP_MODEL_DIR/$FILENAME" "$MODEL"
   else
     # HuggingFace repo - download GGUF files
     echo "Downloading GGUF files from HuggingFace: $MODEL"
-    HF_ARGS=("$MODEL" "--local-dir" "/models" "--include" "*.gguf")
+    HF_ARGS=("$MODEL" "--local-dir" "$LLAMA_CPP_MODEL_DIR" "--include" "*.gguf")
     if [[ -n "${HF_TOKEN:-}" ]]; then
       HF_ARGS+=("--token" "$HF_TOKEN")
     fi
     hf download "${HF_ARGS[@]}"
   fi
-  echo "$MODEL" > "$MODEL_MARKER"
+  DOWNLOADED_GGUF=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
+  if [[ -z "$DOWNLOADED_GGUF" ]]; then
+    echo "Error: no GGUF file was downloaded for $MODEL" >&2
+    exit 1
+  fi
+  printf '%s\n' "$MODEL" > "$MODEL_MARKER"
   echo "Download complete"
 fi
 
 # Generate a minimal config file so LocalAI can map the model name to the GGUF file.
 # Without this, LocalAI looks for the model name as a filename (without .gguf extension).
-GGUF_FILE=$(find /models -maxdepth 1 -name "*.gguf" -type f | head -1)
-if [[ -n "$GGUF_FILE" ]]; then
-  GGUF_BASENAME=$(basename "$GGUF_FILE")
-  MODEL_NAME="${GGUF_BASENAME%.gguf}"
-  if [[ ! -f "/models/${MODEL_NAME}.yaml" ]]; then
-    echo "Generating config for model: $MODEL_NAME -> $GGUF_BASENAME"
-    cat > "/models/${MODEL_NAME}.yaml" <<CFGEOF
-name: ${MODEL_NAME}
+GGUF_FILE=$(find "$LLAMA_CPP_MODEL_DIR" -type f -name "*.gguf" -print -quit)
+if [[ -z "$GGUF_FILE" ]]; then
+  echo "Error: cached GGUF file for $MODEL is missing" >&2
+  exit 1
+fi
+GGUF_BASENAME=$(basename "$GGUF_FILE")
+MODEL_NAME="${GGUF_BASENAME%.gguf}"
+if [[ -z "$MODEL_NAME" ]]; then
+  echo "Error: cannot derive a LocalAI model name from $GGUF_BASENAME" >&2
+  exit 1
+fi
+YAML_MODEL_NAME=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$MODEL_NAME")
+YAML_MODEL_PATH=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$GGUF_FILE")
+mkdir -p "$RUNNER_CONFIG_DIR"
+echo "Generating config for model: $MODEL_NAME -> $GGUF_FILE"
+CONFIG_TMP=$(mktemp "$RUNNER_CONFIG_DIR/.model.yaml.XXXXXX")
+cat > "$CONFIG_TMP" <<CFGEOF
+name: ${YAML_MODEL_NAME}
 backend: llama-cpp
 parameters:
-  model: ${GGUF_BASENAME}
+  model: ${YAML_MODEL_PATH}
 CFGEOF
-  fi
-fi
+mv "$CONFIG_TMP" "$RUNNER_CONFIG"
 `
 }
 
@@ -260,7 +293,6 @@ func generateVLLMCppDownload() string {
 	return `# vllm.cpp requires the model to be materialized locally before startup.
 MODEL_MARKER="` + runnerVLLMCppModelMarker + `"
 VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"
-VLLM_CPP_CONFIG="/models/aikit-model.yaml"
 MODEL_KIND=""
 LOCAL_MODEL_PATH=""
 
@@ -318,7 +350,7 @@ else
   # This fixed runner-owned directory avoids deriving filesystem paths from
   # untrusted model references and makes cache replacement deterministic.
   rm -rf ` + runnerVLLMCppModelDir + `
-  rm -f "$MODEL_MARKER" "$VLLM_CPP_CONFIG"
+  rm -f "$MODEL_MARKER" "$RUNNER_CONFIG"
   mkdir -p "$VLLM_CPP_MODEL_DIR"
 
   if [[ "$MODEL_KIND" == "gguf" ]]; then
@@ -347,15 +379,18 @@ fi
 
 # Always point LocalAI at the validated local payload. A bare Hugging Face ID
 # is valid for the Python vLLM backend but is not valid for vllm.cpp.
-cat > "$VLLM_CPP_CONFIG" <<MODELEOF
-name: ${MODEL_NAME}
+mkdir -p "$RUNNER_CONFIG_DIR"
+CONFIG_TMP=$(mktemp "$RUNNER_CONFIG_DIR/.model.yaml.XXXXXX")
+cat > "$CONFIG_TMP" <<MODELEOF
+name: '${MODEL_NAME}'
 backend: vllm-cpp
 parameters:
-  model: ${LOCAL_MODEL_PATH}
+  model: '${LOCAL_MODEL_PATH}'
 template:
   use_tokenizer_template: true
 MODELEOF
-echo "Config generated at $VLLM_CPP_CONFIG"
+mv "$CONFIG_TMP" "$RUNNER_CONFIG"
+echo "Config generated at $RUNNER_CONFIG"
 `
 }
 
@@ -375,24 +410,27 @@ fi`
 func generateHFModelConfig(backend string) string {
 	return fmt.Sprintf(`# Check if model config matches the requested name, backend, and source (volume mount caching)
 %[1]s
-if [[ -f "/models/aikit-model.yaml" ]] &&
-  grep -qxF "name: ${MODEL_NAME}" /models/aikit-model.yaml 2>/dev/null &&
-  grep -qxF "backend: %[2]s" /models/aikit-model.yaml 2>/dev/null &&
-  grep -qxF "  model: ${MODEL}" /models/aikit-model.yaml 2>/dev/null; then
+if [[ -f "$RUNNER_CONFIG" ]] &&
+  grep -qxF "name: ${MODEL_NAME}" "$RUNNER_CONFIG" 2>/dev/null &&
+  grep -qxF "backend: %[2]s" "$RUNNER_CONFIG" 2>/dev/null &&
+  grep -qxF "  model: ${MODEL}" "$RUNNER_CONFIG" 2>/dev/null; then
   echo "Found existing %[2]s model config matching $MODEL in /models, skipping setup"
 else
-  if [[ -f "/models/aikit-model.yaml" ]]; then
+  if [[ -f "$RUNNER_CONFIG" ]]; then
     echo "Cached config does not match requested backend/model (%[2]s, $MODEL), regenerating"
   fi
   # For %[2]s backend, generate a LocalAI model config pointing to the HF model
   echo "Generating LocalAI config for %[2]s backend with model: $MODEL"
-  cat > /models/aikit-model.yaml <<MODELEOF
+  mkdir -p "$RUNNER_CONFIG_DIR"
+  CONFIG_TMP=$(mktemp "$RUNNER_CONFIG_DIR/.model.yaml.XXXXXX")
+  cat > "$CONFIG_TMP" <<MODELEOF
 name: ${MODEL_NAME}
 backend: %[2]s
 parameters:
   model: ${MODEL}
 MODELEOF
-  echo "Config generated at /models/aikit-model.yaml"
+  mv "$CONFIG_TMP" "$RUNNER_CONFIG"
+  echo "Config generated at $RUNNER_CONFIG"
 fi
 `, runnerModelNameScript, backend)
 }

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -186,6 +186,7 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="llama-cpp"`,
+				runnerLlamaCppModelDir,
 				runnerLlamaCppModelMarker,
 				runnerHFCLIInvocation,
 				runnerCurlInvocation,
@@ -204,7 +205,7 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="diffusers"`,
-				"aikit-model.yaml",
+				runnerConfigPath,
 				"backend: diffusers",
 				runnerLocalAIExec,
 			},
@@ -223,7 +224,7 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="vllm"`,
-				"aikit-model.yaml",
+				runnerConfigPath,
 				"backend: vllm",
 				runnerLocalAIExec,
 			},
@@ -293,6 +294,16 @@ func TestGenerateRunnerScript(t *testing.T) {
 				if strings.Contains(script, missing) {
 					t.Errorf("generateRunnerScript() script should not contain %q\nScript:\n%s", missing, script)
 				}
+			}
+
+			if !strings.Contains(script, `LOCAL_AI_ARGS=("--models-path" "$RUNNER_CONFIG_DIR")`) {
+				t.Error("runner should scan only its owned config directory")
+			}
+
+			cmd := exec.Command("bash", "-n")
+			cmd.Stdin = strings.NewReader(script)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("runner script has invalid shell syntax: %v: %s", err, output)
 			}
 		})
 	}
@@ -417,6 +428,12 @@ func TestGenerateLlamaCppDownload(t *testing.T) {
 	if strings.Contains(script, runnerLegacyHFCLICommand) {
 		t.Error("should not use the legacy huggingface-cli command")
 	}
+	if strings.Contains(script, "| head") {
+		t.Error("should use find's native early exit instead of a pipe that can fail under pipefail")
+	}
+	if !strings.Contains(script, `find "$LLAMA_CPP_MODEL_DIR"`) || !strings.Contains(script, "-print -quit") {
+		t.Error("should discover nested GGUF files only inside the llama-cpp-owned cache")
+	}
 
 	// Should respect HF_TOKEN
 	if !strings.Contains(script, "HF_TOKEN") {
@@ -436,11 +453,96 @@ func TestLlamaCppRunnerMigratesLegacyModelCache(t *testing.T) {
 
 	legacyMarker := filepath.Join(modelsDir, filepath.Base(runnerLegacyModelMarker))
 	staleModel := filepath.Join(modelsDir, "stale.gguf")
+	staleConfig := filepath.Join(modelsDir, "stale.yaml")
+	userConfig := filepath.Join(modelsDir, "user.yaml")
 	if err := os.WriteFile(legacyMarker, []byte("https://example.com/stale.gguf\n"), 0o600); err != nil {
 		t.Fatalf("write legacy marker: %v", err)
 	}
 	if err := os.WriteFile(staleModel, []byte("stale"), 0o600); err != nil {
 		t.Fatalf("write stale model: %v", err)
+	}
+	if err := os.WriteFile(staleConfig, []byte("name: stale\nbackend: llama-cpp\nparameters:\n  model: stale.gguf\n"), 0o600); err != nil {
+		t.Fatalf("write stale generated config: %v", err)
+	}
+	if err := os.WriteFile(userConfig, []byte("name: user-owned\n"), 0o600); err != nil {
+		t.Fatalf("write user config: %v", err)
+	}
+
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'fresh' > "$output"
+`)
+
+	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendLlamaCpp}})
+	script = strings.ReplaceAll(script, "/models", modelsDir)
+	script = strings.Replace(script, "exec /usr/bin/local-ai", "printf 'LOCAL_AI_ARG=%s\\n'", 1)
+	model := "https://example.com/fresh.gguf"
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("run llama-cpp legacy cache migration: %v: %s", err, output)
+	}
+
+	if _, err := os.Stat(staleModel); err != nil {
+		t.Fatalf("legacy GGUF without reliable ownership metadata should be preserved: %v", err)
+	}
+	if _, err := os.Stat(legacyMarker); !os.IsNotExist(err) {
+		t.Fatalf("legacy marker remains after migration; stat error = %v", err)
+	}
+	for _, preserved := range []string{staleConfig, userConfig} {
+		if _, err := os.Stat(preserved); err != nil {
+			t.Fatalf("runner should preserve YAML outside its owned config directory %q: %v", preserved, err)
+		}
+	}
+	freshModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/fresh.gguf")
+	assertRunnerFileContent(t, freshModel, "fresh")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), model+"\n")
+	configPath := runnerPathInTestModels(modelsDir, runnerConfigPath)
+	wantConfig := "name: \"fresh\"\n" +
+		"backend: llama-cpp\n" +
+		"parameters:\n" +
+		"  model: \"" + freshModel + "\"\n"
+	assertRunnerFileContent(t, configPath, wantConfig)
+	if !strings.Contains(string(output), "LOCAL_AI_ARG="+filepath.Dir(configPath)) {
+		t.Fatalf("LocalAI does not scan the isolated runner config directory: %s", output)
+	}
+}
+
+func TestLlamaCppRunnerReplacesOnlyOwnedCacheAndConfig(t *testing.T) {
+	testRoot := t.TempDir()
+	modelsDir := filepath.Join(testRoot, "models")
+	binDir := filepath.Join(testRoot, "bin")
+	llamaModelDir := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir)
+	activeConfig := runnerPathInTestModels(modelsDir, runnerConfigPath)
+	for _, dir := range []string{modelsDir, binDir, llamaModelDir, filepath.Dir(activeConfig)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create runner test directory %q: %v", dir, err)
+		}
+	}
+
+	oldOwnedModel := filepath.Join(llamaModelDir, "old.gguf")
+	userModel := filepath.Join(modelsDir, "user.gguf")
+	userConfig := filepath.Join(modelsDir, "user.yaml")
+	seedFiles := map[string]string{
+		oldOwnedModel: "old",
+		userModel:     "user",
+		userConfig:    "name: user-owned\n",
+		activeConfig:  "name: old\nbackend: llama-cpp\nparameters:\n  model: old.gguf\n",
+		filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)): "https://example.com/old.gguf\n",
+	}
+	for path, content := range seedFiles {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("seed runner file %q: %v", path, err)
+		}
 	}
 
 	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
@@ -464,18 +566,76 @@ printf 'fresh' > "$output"
 	model := "https://example.com/fresh.gguf"
 	output, err := executeRunnerScript(t, script, binDir, model)
 	if err != nil {
-		t.Fatalf("run llama-cpp legacy cache migration: %v: %s", err, output)
+		t.Fatalf("replace llama-cpp cache: %v: %s", err, output)
 	}
 
-	if _, err := os.Stat(staleModel); !os.IsNotExist(err) {
-		t.Fatalf("stale GGUF remains after legacy cache migration; stat error = %v", err)
+	if _, err := os.Stat(oldOwnedModel); !os.IsNotExist(err) {
+		t.Fatalf("old runner-owned GGUF remains after replacement; stat error = %v", err)
 	}
-	if _, err := os.Stat(legacyMarker); !os.IsNotExist(err) {
-		t.Fatalf("legacy marker remains after migration; stat error = %v", err)
+	for _, preserved := range []string{userModel, userConfig} {
+		if _, err := os.Stat(preserved); err != nil {
+			t.Fatalf("runner should preserve unrelated file %q: %v", preserved, err)
+		}
 	}
-	assertRunnerFileContent(t, filepath.Join(modelsDir, "fresh.gguf"), "fresh")
-	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), model+"\n")
-	assertRunnerFileContent(t, filepath.Join(modelsDir, "fresh.yaml"), "name: fresh\nbackend: llama-cpp\nparameters:\n  model: fresh.gguf\n")
+	freshModel := filepath.Join(llamaModelDir, "fresh.gguf")
+	assertRunnerFileContent(t, freshModel, "fresh")
+	wantConfig := "name: \"fresh\"\n" +
+		"backend: llama-cpp\n" +
+		"parameters:\n" +
+		"  model: \"" + freshModel + "\"\n"
+	assertRunnerFileContent(t, activeConfig, wantConfig)
+}
+
+func TestLlamaCppRunnerDiscoversNestedGGUF(t *testing.T) {
+	testRoot := t.TempDir()
+	modelsDir := filepath.Join(testRoot, "models")
+	binDir := filepath.Join(testRoot, "bin")
+	for _, dir := range []string{modelsDir, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create runner test directory %q: %v", dir, err)
+		}
+	}
+
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir/quantized/q3"
+printf 'GGUF' > "$local_dir/quantized/q3/nested.gguf"
+`)
+
+	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendLlamaCpp}})
+	script = strings.ReplaceAll(script, "/models", modelsDir)
+	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
+	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/nested-repo")
+	if err != nil {
+		t.Fatalf("run llama-cpp nested GGUF flow: %v: %s", err, output)
+	}
+
+	nestedModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/quantized/q3/nested.gguf")
+	wantConfig := "name: \"nested\"\n" +
+		"backend: llama-cpp\n" +
+		"parameters:\n" +
+		"  model: \"" + nestedModel + "\"\n"
+	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), "org/nested-repo\n")
+
+	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 91\n")
+	output, err = executeRunnerScript(t, script, binDir, "huggingface://org/nested-repo")
+	if err != nil {
+		t.Fatalf("reuse cached nested llama-cpp GGUF: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "Found cached model matching org/nested-repo") {
+		t.Fatalf("nested GGUF cache hit was not detected: %s", output)
+	}
 }
 
 func TestGenerateVLLMCppDownload(t *testing.T) {
@@ -489,7 +649,8 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 		runnerCurlInvocation,
 		`\.gguf$`,
 		`backend: vllm-cpp`,
-		`model: ${LOCAL_MODEL_PATH}`,
+		`name: '${MODEL_NAME}'`,
+		`model: '${LOCAL_MODEL_PATH}'`,
 		`use_tokenizer_template: true`,
 	} {
 		if !strings.Contains(script, expected) {
@@ -527,8 +688,8 @@ func TestRunnerBackendsUseSeparateModelMarkers(t *testing.T) {
 	if !strings.Contains(vllmCppScript, runnerVLLMCppModelMarker) || strings.Contains(vllmCppScript, runnerLlamaCppModelMarker) {
 		t.Fatal("vllm-cpp download script does not use only its backend-scoped marker")
 	}
-	if !strings.Contains(llamaScript, "find /models -maxdepth 1") {
-		t.Fatal("llama-cpp cache lookup must ignore nested payloads owned by other backends")
+	if !strings.Contains(llamaScript, `find "$LLAMA_CPP_MODEL_DIR"`) || strings.Contains(llamaScript, "| head") {
+		t.Fatal("llama-cpp lookup must recursively search only its owned cache and avoid pipelines")
 	}
 }
 
@@ -560,13 +721,13 @@ printf 'weights\n' > "$local_dir/model.safetensors"
 	}
 
 	localModelDir := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"))
-	wantConfig := "name: repo\n" +
+	wantConfig := "name: 'repo'\n" +
 		"backend: vllm-cpp\n" +
 		"parameters:\n" +
-		"  model: " + localModelDir + "\n" +
+		"  model: '" + localModelDir + "'\n" +
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
-	assertRunnerFileContent(t, filepath.Join(modelsDir, "aikit-model.yaml"), wantConfig)
+	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
 	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), "org/repo\n")
 
 	hfArgs, err := os.ReadFile(hfArgsLog)
@@ -612,21 +773,78 @@ done
 printf 'GGUF' > "$output"
 `)
 
-	model := "https://example.com/model.gguf?download=1#weights"
+	model := "https://example.com/null.gguf?download=1#weights"
 	output, err := executeRunnerScript(t, script, binDir, model)
 	if err != nil {
 		t.Fatalf("run vllm-cpp GGUF flow: %v: %s", err, output)
 	}
 
-	localModelPath := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"), "model.gguf")
-	wantConfig := "name: model\n" +
+	localModelPath := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"), "null.gguf")
+	wantConfig := "name: 'null'\n" +
 		"backend: vllm-cpp\n" +
 		"parameters:\n" +
-		"  model: " + localModelPath + "\n" +
+		"  model: '" + localModelPath + "'\n" +
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
-	assertRunnerFileContent(t, filepath.Join(modelsDir, "aikit-model.yaml"), wantConfig)
+	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
 	assertRunnerFileContent(t, localModelPath, "GGUF")
+}
+
+func TestVLLMCppRunnerIsolatesConfigFromStaleLlamaArtifacts(t *testing.T) {
+	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
+	script = strings.Replace(script, "exec true", "printf 'LOCAL_AI_ARG=%s\\n'", 1)
+
+	staleModel := filepath.Join(modelsDir, "stale.gguf")
+	staleConfig := filepath.Join(modelsDir, "stale.yaml")
+	activeConfig := runnerPathInTestModels(modelsDir, runnerConfigPath)
+	if err := os.MkdirAll(filepath.Dir(activeConfig), 0o755); err != nil {
+		t.Fatalf("create active config directory: %v", err)
+	}
+	if err := os.WriteFile(staleModel, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale llama model: %v", err)
+	}
+	if err := os.WriteFile(staleConfig, []byte("name: stale\nbackend: llama-cpp\nparameters:\n  model: stale.gguf\n"), 0o600); err != nil {
+		t.Fatalf("write stale llama config: %v", err)
+	}
+	if err := os.WriteFile(activeConfig, []byte("name: stale\nbackend: llama-cpp\n"), 0o600); err != nil {
+		t.Fatalf("write previous active config: %v", err)
+	}
+
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'GGUF' > "$output"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, "https://example.com/fresh.gguf")
+	if err != nil {
+		t.Fatalf("run vllm-cpp with stale llama artifacts: %v: %s", err, output)
+	}
+
+	for _, preserved := range []string{staleModel, staleConfig} {
+		if _, err := os.Stat(preserved); err != nil {
+			t.Fatalf("vllm-cpp should preserve unrelated llama artifact %q: %v", preserved, err)
+		}
+	}
+	if !strings.Contains(string(output), "LOCAL_AI_ARG="+filepath.Dir(activeConfig)) {
+		t.Fatalf("LocalAI does not scan only the isolated active config directory: %s", output)
+	}
+	wantConfig := "name: 'fresh'\n" +
+		"backend: vllm-cpp\n" +
+		"parameters:\n" +
+		"  model: '" + runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir+"/fresh.gguf") + "'\n" +
+		"template:\n" +
+		"  use_tokenizer_template: true\n"
+	assertRunnerFileContent(t, activeConfig, wantConfig)
 }
 
 func TestVLLMCppRunnerRejectsRepositoryWithoutSafetensors(t *testing.T) {
@@ -727,9 +945,9 @@ func TestGenerateHFModelConfig(t *testing.T) {
 			}
 
 			// Cached configs should match the alias, backend, and requested model source.
-			if !strings.Contains(script, `grep -qxF "name: ${MODEL_NAME}"`) ||
-				!strings.Contains(script, `grep -qxF "backend: `+tt.backend+`"`) ||
-				!strings.Contains(script, `grep -qxF "  model: ${MODEL}"`) {
+			if !strings.Contains(script, `grep -qxF "name: ${MODEL_NAME}" "$RUNNER_CONFIG"`) ||
+				!strings.Contains(script, `grep -qxF "backend: `+tt.backend+`" "$RUNNER_CONFIG"`) ||
+				!strings.Contains(script, `grep -qxF "  model: ${MODEL}" "$RUNNER_CONFIG"`) {
 				t.Error("should validate the cached model name, backend, and source")
 			}
 
@@ -814,6 +1032,10 @@ func prepareVLLMCppRunnerScript(t *testing.T) (string, string, string) {
 	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
 
 	return script, modelsDir, binDir
+}
+
+func runnerPathInTestModels(modelsDir, runnerPath string) string {
+	return filepath.Join(modelsDir, strings.TrimPrefix(runnerPath, "/models/"))
 }
 
 func executeRunnerScript(t *testing.T, script, binDir, model string, extraEnv ...string) ([]byte, error) {

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -2,7 +2,9 @@ package inference
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -17,6 +19,7 @@ const (
 	runnerHFArgsAssignment    = "HF_ARGS="
 	runnerHFCLIInvocation     = "hf download"
 	runnerLegacyHFCLICommand  = "huggingface-cli"
+	runnerCurlInvocation      = "curl -fL"
 	runnerLocalAIExec         = "exec /usr/bin/local-ai"
 	runnerLocalDirFlag        = "--local-dir"
 	runnerPredownloadMessage  = "Pre-downloading model"
@@ -75,6 +78,13 @@ func TestIsRunnerMode(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "runner mode - vllm-cpp backend with no models",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendVLLMCpp},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -106,6 +116,11 @@ func TestInstallRunnerDependencies(t *testing.T) {
 		{
 			name:    "vllm uses bundled downloader",
 			backend: utils.BackendVLLM,
+		},
+		{
+			name:             "vllm-cpp installs downloader dependencies",
+			backend:          utils.BackendVLLMCpp,
+			wantDependencies: true,
 		},
 	}
 
@@ -171,9 +186,9 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="llama-cpp"`,
-				".aikit-model-ref",
+				runnerLlamaCppModelMarker,
 				runnerHFCLIInvocation,
-				"curl -fL",
+				runnerCurlInvocation,
 				runnerLocalAIExec,
 			},
 			expectMissing: []string{
@@ -218,6 +233,26 @@ func TestGenerateRunnerScript(t *testing.T) {
 				runnerPredownloadMessage,
 				runnerHFArgsAssignment,
 				runnerLocalDirFlag,
+			},
+		},
+		{
+			name: "vllm-cpp backend script",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendVLLMCpp},
+			},
+			expectContains: []string{
+				`BACKEND="vllm-cpp"`,
+				runnerVLLMCppModelDir,
+				runnerVLLMCppModelMarker,
+				runnerHFCLIInvocation,
+				runnerCurlInvocation,
+				"backend: vllm-cpp",
+				"use_tokenizer_template: true",
+				runnerLocalAIExec,
+			},
+			expectMissing: []string{
+				runnerLegacyHFCLICommand,
+				`model: ${MODEL}`,
 			},
 		},
 		{
@@ -308,18 +343,49 @@ func TestGenerateRunnerScriptModelConfig(t *testing.T) {
 }
 
 func TestGenerateRunnerScriptUsageMessage(t *testing.T) {
-	config := &config.InferenceConfig{
-		Backends: []string{utils.BackendLlamaCpp},
+	tests := []struct {
+		name          string
+		backend       string
+		wantExample   string
+		rejectExample string
+	}{
+		{
+			name:        utils.BackendLlamaCpp,
+			backend:     utils.BackendLlamaCpp,
+			wantExample: "--model org/model",
+		},
+		{
+			name:          "vllm-cpp",
+			backend:       utils.BackendVLLMCpp,
+			wantExample:   "--model org/safetensors-model",
+			rejectExample: "--model org/model\n",
+		},
 	}
 
-	script := generateRunnerScript(config)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := generateRunnerScript(&config.InferenceConfig{Backends: []string{tt.backend}})
+			cmd := exec.Command("bash")
+			cmd.Stdin = strings.NewReader(script)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatal("runner without a model unexpectedly succeeded")
+			}
 
-	// Verify the usage message is present
-	if !strings.Contains(script, "Usage: docker run") {
-		t.Error("script should contain usage instructions")
-	}
-	if !strings.Contains(script, "HF_TOKEN") {
-		t.Error("script should mention HF_TOKEN environment variable")
+			usage := string(output)
+			if !strings.Contains(usage, "Usage: docker run") {
+				t.Error("script should contain usage instructions")
+			}
+			if !strings.Contains(usage, "HF_TOKEN") {
+				t.Error("script should mention HF_TOKEN environment variable")
+			}
+			if !strings.Contains(usage, tt.wantExample) {
+				t.Errorf("usage does not contain backend-compatible example %q: %s", tt.wantExample, usage)
+			}
+			if tt.rejectExample != "" && strings.Contains(usage, tt.rejectExample) {
+				t.Errorf("usage contains incompatible example %q: %s", tt.rejectExample, usage)
+			}
+		})
 	}
 }
 
@@ -327,8 +393,11 @@ func TestGenerateLlamaCppDownload(t *testing.T) {
 	script := generateLlamaCppDownload()
 
 	// Should use marker file for model-aware caching
-	if !strings.Contains(script, ".aikit-model-ref") {
+	if !strings.Contains(script, runnerLlamaCppModelMarker) {
 		t.Error("should use marker file for model-aware caching")
+	}
+	if !strings.Contains(script, runnerLegacyModelMarker) {
+		t.Error("should migrate the legacy model marker")
 	}
 
 	// Should detect model mismatch and re-download
@@ -352,6 +421,281 @@ func TestGenerateLlamaCppDownload(t *testing.T) {
 	// Should respect HF_TOKEN
 	if !strings.Contains(script, "HF_TOKEN") {
 		t.Error("should respect HF_TOKEN")
+	}
+}
+
+func TestLlamaCppRunnerMigratesLegacyModelCache(t *testing.T) {
+	testRoot := t.TempDir()
+	modelsDir := filepath.Join(testRoot, "models")
+	binDir := filepath.Join(testRoot, "bin")
+	for _, dir := range []string{modelsDir, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create runner test directory %q: %v", dir, err)
+		}
+	}
+
+	legacyMarker := filepath.Join(modelsDir, filepath.Base(runnerLegacyModelMarker))
+	staleModel := filepath.Join(modelsDir, "stale.gguf")
+	if err := os.WriteFile(legacyMarker, []byte("https://example.com/stale.gguf\n"), 0o600); err != nil {
+		t.Fatalf("write legacy marker: %v", err)
+	}
+	if err := os.WriteFile(staleModel, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale model: %v", err)
+	}
+
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'fresh' > "$output"
+`)
+
+	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendLlamaCpp}})
+	script = strings.ReplaceAll(script, "/models", modelsDir)
+	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
+	model := "https://example.com/fresh.gguf"
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("run llama-cpp legacy cache migration: %v: %s", err, output)
+	}
+
+	if _, err := os.Stat(staleModel); !os.IsNotExist(err) {
+		t.Fatalf("stale GGUF remains after legacy cache migration; stat error = %v", err)
+	}
+	if _, err := os.Stat(legacyMarker); !os.IsNotExist(err) {
+		t.Fatalf("legacy marker remains after migration; stat error = %v", err)
+	}
+	assertRunnerFileContent(t, filepath.Join(modelsDir, "fresh.gguf"), "fresh")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), model+"\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, "fresh.yaml"), "name: fresh\nbackend: llama-cpp\nparameters:\n  model: fresh.gguf\n")
+}
+
+func TestGenerateVLLMCppDownload(t *testing.T) {
+	script := generateVLLMCppDownload()
+
+	for _, expected := range []string{
+		runnerVLLMCppModelMarker,
+		`VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"`,
+		`hf download`,
+		`--local-dir`,
+		runnerCurlInvocation,
+		`\.gguf$`,
+		`backend: vllm-cpp`,
+		`model: ${LOCAL_MODEL_PATH}`,
+		`use_tokenizer_template: true`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Errorf("vllm-cpp download script does not contain %q", expected)
+		}
+	}
+
+	for _, unexpected := range []string{
+		`model: ${MODEL}`,
+		runnerLegacyHFCLICommand,
+		`--include`,
+	} {
+		if strings.Contains(script, unexpected) {
+			t.Errorf("vllm-cpp download script should not contain %q", unexpected)
+		}
+	}
+
+	cmd := exec.Command("bash", "-n")
+	cmd.Stdin = strings.NewReader(generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendVLLMCpp}}))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("vllm-cpp runner script has invalid shell syntax: %v: %s", err, output)
+	}
+}
+
+func TestRunnerBackendsUseSeparateModelMarkers(t *testing.T) {
+	if runnerLlamaCppModelMarker == runnerVLLMCppModelMarker {
+		t.Fatal("llama-cpp and vllm-cpp must not share a model cache marker")
+	}
+
+	llamaScript := generateLlamaCppDownload()
+	vllmCppScript := generateVLLMCppDownload()
+	if !strings.Contains(llamaScript, runnerLlamaCppModelMarker) || strings.Contains(llamaScript, runnerVLLMCppModelMarker) {
+		t.Fatal("llama-cpp download script does not use only its backend-scoped marker")
+	}
+	if !strings.Contains(vllmCppScript, runnerVLLMCppModelMarker) || strings.Contains(vllmCppScript, runnerLlamaCppModelMarker) {
+		t.Fatal("vllm-cpp download script does not use only its backend-scoped marker")
+	}
+	if !strings.Contains(llamaScript, "find /models -maxdepth 1") {
+		t.Fatal("llama-cpp cache lookup must ignore nested payloads owned by other backends")
+	}
+}
+
+func TestVLLMCppRunnerDownloadsHuggingFaceRepositoryLocally(t *testing.T) {
+	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
+	hfArgsLog := filepath.Join(t.TempDir(), "hf-args")
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" > "$HF_ARGS_LOG"
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir"
+printf '{}\n' > "$local_dir/config.json"
+printf 'weights\n' > "$local_dir/model.safetensors"
+`)
+
+	model := "huggingface://org/repo"
+	output, err := executeRunnerScript(t, script, binDir, model, "HF_ARGS_LOG="+hfArgsLog, "HF_TOKEN=test-token")
+	if err != nil {
+		t.Fatalf("run vllm-cpp Hugging Face flow: %v: %s", err, output)
+	}
+
+	localModelDir := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"))
+	wantConfig := "name: repo\n" +
+		"backend: vllm-cpp\n" +
+		"parameters:\n" +
+		"  model: " + localModelDir + "\n" +
+		"template:\n" +
+		"  use_tokenizer_template: true\n"
+	assertRunnerFileContent(t, filepath.Join(modelsDir, "aikit-model.yaml"), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), "org/repo\n")
+
+	hfArgs, err := os.ReadFile(hfArgsLog)
+	if err != nil {
+		t.Fatalf("read hf arguments: %v", err)
+	}
+	for _, expected := range []string{"download\n", "org/repo\n", "--local-dir\n", localModelDir + "\n", "--exclude\n", "*.gguf\n", "--token\n", "test-token\n"} {
+		if !strings.Contains(string(hfArgs), expected) {
+			t.Errorf("hf arguments do not contain %q: %s", expected, hfArgs)
+		}
+	}
+
+	if err := os.Remove(hfArgsLog); err != nil {
+		t.Fatalf("remove first-run hf log: %v", err)
+	}
+	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 91\n")
+	output, err = executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("reuse cached vllm-cpp Hugging Face model: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "Found cached vllm-cpp model matching org/repo") {
+		t.Errorf("cache-hit output missing expected message: %s", output)
+	}
+	if _, err := os.Stat(hfArgsLog); !os.IsNotExist(err) {
+		t.Errorf("hf downloader ran on cache hit; stat error = %v", err)
+	}
+}
+
+func TestVLLMCppRunnerDownloadsDirectGGUFLocally(t *testing.T) {
+	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'GGUF' > "$output"
+`)
+
+	model := "https://example.com/model.gguf?download=1#weights"
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("run vllm-cpp GGUF flow: %v: %s", err, output)
+	}
+
+	localModelPath := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"), "model.gguf")
+	wantConfig := "name: model\n" +
+		"backend: vllm-cpp\n" +
+		"parameters:\n" +
+		"  model: " + localModelPath + "\n" +
+		"template:\n" +
+		"  use_tokenizer_template: true\n"
+	assertRunnerFileContent(t, filepath.Join(modelsDir, "aikit-model.yaml"), wantConfig)
+	assertRunnerFileContent(t, localModelPath, "GGUF")
+}
+
+func TestVLLMCppRunnerRejectsRepositoryWithoutSafetensors(t *testing.T) {
+	script, _, binDir := prepareVLLMCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir"
+printf '{}\n' > "$local_dir/config.json"
+printf 'GGUF' > "$local_dir/model.gguf"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/gguf-repo")
+	if err == nil {
+		t.Fatalf("GGUF-only Hugging Face repository unexpectedly succeeded: %s", output)
+	}
+	if !strings.Contains(string(output), "must contain config.json and safetensors weights") {
+		t.Fatalf("unexpected GGUF-only repository error: %s", output)
+	}
+}
+
+func TestVLLMCppRunnerRejectsUnsupportedModelReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantError string
+	}{
+		{
+			name:      "non-GGUF direct URL",
+			model:     "https://example.com/model.safetensors",
+			wantError: "direct URLs must point to a .gguf file",
+		},
+		{
+			name:      "unsafe GGUF filename",
+			model:     "https://example.com/model name.gguf",
+			wantError: "direct URLs must point to a .gguf file",
+		},
+		{
+			name:      "unsupported URL scheme",
+			model:     "s3://bucket/model.gguf",
+			wantError: "supports only huggingface:// repository references or HTTP(S) .gguf URLs",
+		},
+		{
+			name:      "unsafe repository ID",
+			model:     "org/repo/extra",
+			wantError: "invalid Hugging Face repository ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, _, binDir := prepareVLLMCppRunnerScript(t)
+			output, err := executeRunnerScript(t, script, binDir, tt.model)
+			if err == nil {
+				t.Fatalf("model reference %q unexpectedly succeeded: %s", tt.model, output)
+			}
+			if !strings.Contains(string(output), tt.wantError) {
+				t.Errorf("error output does not contain %q: %s", tt.wantError, output)
+			}
+		})
 	}
 }
 
@@ -450,6 +794,55 @@ func TestRunnerModelNameScript(t *testing.T) {
 				t.Fatalf("normalize model %q = %q, want %q", tt.model, got, tt.want)
 			}
 		})
+	}
+}
+
+func prepareVLLMCppRunnerScript(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	testRoot := t.TempDir()
+	modelsDir := filepath.Join(testRoot, "models")
+	binDir := filepath.Join(testRoot, "bin")
+	for _, dir := range []string{modelsDir, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create runner test directory %q: %v", dir, err)
+		}
+	}
+
+	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendVLLMCpp}})
+	script = strings.ReplaceAll(script, "/models", modelsDir)
+	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
+
+	return script, modelsDir, binDir
+}
+
+func executeRunnerScript(t *testing.T, script, binDir, model string, extraEnv ...string) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "-c", script, "aikit-runner", model)
+	cmd.Env = append([]string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH")}, extraEnv...)
+
+	return cmd.CombinedOutput()
+}
+
+func writeRunnerStub(t *testing.T, binDir, name, content string) {
+	t.Helper()
+
+	//nolint:gosec // Runner command stubs must be executable by the test shell.
+	if err := os.WriteFile(filepath.Join(binDir, name), []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s runner stub: %v", name, err)
+	}
+}
+
+func assertRunnerFileContent(t *testing.T, path, want string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runner file %q: %v", path, err)
+	}
+	if got := string(content); got != want {
+		t.Fatalf("runner file %q = %q, want %q", path, got, want)
 	}
 }
 

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -721,10 +721,12 @@ done
 mkdir -p "$local_dir"
 printf '{}\n' > "$local_dir/config.json"
 printf 'weights\n' > "$local_dir/model.safetensors"
+printf '{}\n' > "$local_dir/tokenizer.json"
 printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 `)
 
-	model := "huggingface://org/repo"
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+	model := "huggingface://org/repo@" + revision
 	output, err := executeRunnerScript(t, script, binDir, model, "HF_ARGS_LOG="+hfArgsLog, "HF_TOKEN=test-token")
 	if err != nil {
 		t.Fatalf("run vllm-cpp Hugging Face flow: %v: %s", err, output)
@@ -740,7 +742,7 @@ printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 		"  use_tokenizer_template: true\n"
 	assertRunnerFileContent(t, filepath.Join(localModelDir, runnerConfigFilename), wantConfig)
 	assertRunnerFileContent(t, filepath.Join(localPayloadDir, "repository.yaml"), "name: repository-owned\n")
-	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), runnerModelCacheKey("org/repo")+"\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), runnerModelCacheKey("org/repo@"+revision)+"\n")
 	modelRootEntries, err := os.ReadDir(localModelDir)
 	if err != nil {
 		t.Fatalf("read vllm-cpp model root: %v", err)
@@ -755,7 +757,18 @@ printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 	if err != nil {
 		t.Fatalf("read hf arguments: %v", err)
 	}
-	for _, expected := range []string{"download\n", "org/repo\n", "--local-dir\n", localPayloadDir + "\n", "--exclude\n", "*.gguf\n", "--token\n", "test-token\n"} {
+	for _, expected := range []string{
+		"download\n",
+		"org/repo\n",
+		"--local-dir\n",
+		localPayloadDir + "\n",
+		"--exclude\n",
+		"*.gguf\n",
+		"--revision\n",
+		revision + "\n",
+		"--token\n",
+		"test-token\n",
+	} {
 		if !strings.Contains(string(hfArgs), expected) {
 			t.Errorf("hf arguments do not contain %q: %s", expected, hfArgs)
 		}
@@ -769,11 +782,52 @@ printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 	if err != nil {
 		t.Fatalf("reuse cached vllm-cpp Hugging Face model: %v: %s", err, output)
 	}
-	if !strings.Contains(string(output), "Found cached vllm-cpp model matching org/repo") {
+	if !strings.Contains(string(output), "Found cached vllm-cpp model matching org/repo@"+revision) {
 		t.Errorf("cache-hit output missing expected message: %s", output)
 	}
 	if _, err := os.Stat(hfArgsLog); !os.IsNotExist(err) {
 		t.Errorf("hf downloader ran on cache hit; stat error = %v", err)
+	}
+
+	const updatedRevision = "fedcba9876543210fedcba9876543210fedcba98"
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" > "$HF_ARGS_LOG"
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir"
+printf '{}\n' > "$local_dir/config.json"
+printf 'updated weights\n' > "$local_dir/model.safetensors"
+printf '{}\n' > "$local_dir/tokenizer.json"
+printf 'revision b\n' > "$local_dir/revision-b"
+`)
+	updatedModel := "huggingface://org/repo@" + updatedRevision
+	output, err = executeRunnerScript(t, script, binDir, updatedModel, "HF_ARGS_LOG="+hfArgsLog)
+	if err != nil {
+		t.Fatalf("replace cached vllm-cpp revision: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "does not match requested vllm-cpp model") {
+		t.Errorf("revision-change output missing cache mismatch message: %s", output)
+	}
+	if _, err := os.Stat(filepath.Join(localPayloadDir, "repository.yaml")); !os.IsNotExist(err) {
+		t.Errorf("old revision payload remains after replacement; stat error = %v", err)
+	}
+	assertRunnerFileContent(t, filepath.Join(localPayloadDir, "revision-b"), "revision b\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), runnerModelCacheKey("org/repo@"+updatedRevision)+"\n")
+	updatedHFArgs, err := os.ReadFile(hfArgsLog)
+	if err != nil {
+		t.Fatalf("read updated hf arguments: %v", err)
+	}
+	if !strings.Contains(string(updatedHFArgs), "--revision\n"+updatedRevision+"\n") {
+		t.Errorf("updated hf arguments do not contain revision %q: %s", updatedRevision, updatedHFArgs)
 	}
 }
 
@@ -883,6 +937,7 @@ func TestVLLMCppRunnerRepairsIncompleteShardedRepository(t *testing.T) {
 		filepath.Join(modelDir, "config.json"):                            "{}\n",
 		filepath.Join(modelDir, "model.safetensors.index.json"):           `{"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}`,
 		filepath.Join(modelDir, "model-00001-of-00002.safetensors"):       "first shard\n",
+		filepath.Join(modelDir, "tokenizer.json"):                         "{}\n",
 		filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)): runnerModelCacheKey(model) + "\n",
 	}
 	for path, content := range seedFiles {
@@ -910,6 +965,7 @@ printf '{}\n' > "$local_dir/config.json"
 printf '%s\n' '{"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}' > "$local_dir/model.safetensors.index.json"
 printf 'first shard\n' > "$local_dir/model-00001-of-00002.safetensors"
 printf 'second shard\n' > "$local_dir/model-00002-of-00002.safetensors"
+printf '{}\n' > "$local_dir/tokenizer.json"
 `)
 
 	output, err := executeRunnerScript(t, script, binDir, model, "HF_LOG="+hfLog)
@@ -1004,6 +1060,7 @@ done
 mkdir -p "$local_dir"
 printf '{}\n' > "$local_dir/config.json"
 printf 'GGUF' > "$local_dir/model.gguf"
+printf '{}\n' > "$local_dir/tokenizer.json"
 `)
 
 	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/gguf-repo")
@@ -1032,6 +1089,7 @@ done
 mkdir -p "$local_dir/weights"
 printf '{}\n' > "$local_dir/config.json"
 printf 'weights\n' > "$local_dir/weights/model.safetensors"
+printf '{}\n' > "$local_dir/tokenizer.json"
 `)
 
 	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/nested-safetensors")
@@ -1040,6 +1098,34 @@ printf 'weights\n' > "$local_dir/weights/model.safetensors"
 	}
 	if !strings.Contains(string(output), "must contain config.json and safetensors weights") {
 		t.Fatalf("unexpected nested safetensors repository error: %s", output)
+	}
+}
+
+func TestVLLMCppRunnerRejectsRepositoryWithoutTokenizer(t *testing.T) {
+	script, _, binDir := prepareVLLMCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir"
+printf '{}\n' > "$local_dir/config.json"
+printf 'weights\n' > "$local_dir/model.safetensors"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/missing-tokenizer")
+	if err == nil {
+		t.Fatalf("Hugging Face repository without tokenizer.json unexpectedly succeeded: %s", output)
+	}
+	if !strings.Contains(string(output), "plus tokenizer.json") {
+		t.Fatalf("unexpected missing-tokenizer error: %s", output)
 	}
 }
 
@@ -1068,6 +1154,16 @@ func TestVLLMCppRunnerRejectsUnsupportedModelReferences(t *testing.T) {
 			name:      "unsafe repository ID",
 			model:     "org/repo/extra",
 			wantError: "invalid Hugging Face repository ID",
+		},
+		{
+			name:      "mutable named revision",
+			model:     "org/repo@main",
+			wantError: "revisions for vllm-cpp must be 40-character lowercase commit SHAs",
+		},
+		{
+			name:      "uppercase commit revision",
+			model:     "org/repo@0123456789ABCDEF0123456789abcdef01234567",
+			wantError: "revisions for vllm-cpp must be 40-character lowercase commit SHAs",
 		},
 	}
 

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -207,7 +207,8 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="diffusers"`,
-				runnerConfigPath,
+				runnerConfigDir,
+				`RUNNER_CONFIG="$RUNNER_CONFIG_DIR/` + runnerConfigFilename + `"`,
 				"backend: diffusers",
 				runnerLocalAIExec,
 			},
@@ -226,7 +227,8 @@ func TestGenerateRunnerScript(t *testing.T) {
 			},
 			expectContains: []string{
 				`BACKEND="vllm"`,
-				runnerConfigPath,
+				runnerConfigDir,
+				`RUNNER_CONFIG="$RUNNER_CONFIG_DIR/` + runnerConfigFilename + `"`,
 				"backend: vllm",
 				runnerLocalAIExec,
 			},
@@ -433,7 +435,7 @@ func TestGenerateLlamaCppDownload(t *testing.T) {
 	if strings.Contains(script, "| head") {
 		t.Error("should use find's native early exit instead of a pipe that can fail under pipefail")
 	}
-	if !strings.Contains(script, `find "$LLAMA_CPP_MODEL_DIR"`) || !strings.Contains(script, "-print -quit") {
+	if !strings.Contains(script, `find "$LLAMA_CPP_PAYLOAD_DIR"`) || !strings.Contains(script, "-print -quit") {
 		t.Error("should discover nested GGUF files only inside the llama-cpp-owned cache")
 	}
 
@@ -505,14 +507,14 @@ printf 'fresh' > "$output"
 			t.Fatalf("runner should preserve YAML outside its owned config directory %q: %v", preserved, err)
 		}
 	}
-	freshModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/fresh.gguf")
+	freshModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/payload/fresh.gguf")
 	assertRunnerFileContent(t, freshModel, "fresh")
 	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), runnerModelCacheKey(model)+"\n")
-	configPath := runnerPathInTestModels(modelsDir, runnerConfigPath)
+	configPath := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/"+runnerConfigFilename)
 	wantConfig := "name: \"fresh\"\n" +
 		"backend: llama-cpp\n" +
 		"parameters:\n" +
-		"  model: \"" + freshModel + "\"\n"
+		"  model: \"payload/fresh.gguf\"\n"
 	assertRunnerFileContent(t, configPath, wantConfig)
 	if !strings.Contains(string(output), "LOCAL_AI_ARG="+filepath.Dir(configPath)) {
 		t.Fatalf("LocalAI does not scan the isolated runner config directory: %s", output)
@@ -524,14 +526,15 @@ func TestLlamaCppRunnerReplacesOnlyOwnedCacheAndConfig(t *testing.T) {
 	modelsDir := filepath.Join(testRoot, "models")
 	binDir := filepath.Join(testRoot, "bin")
 	llamaModelDir := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir)
-	activeConfig := runnerPathInTestModels(modelsDir, runnerConfigPath)
-	for _, dir := range []string{modelsDir, binDir, llamaModelDir, filepath.Dir(activeConfig)} {
+	llamaPayloadDir := filepath.Join(llamaModelDir, "payload")
+	activeConfig := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/"+runnerConfigFilename)
+	for _, dir := range []string{modelsDir, binDir, llamaPayloadDir, filepath.Dir(activeConfig)} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("create runner test directory %q: %v", dir, err)
 		}
 	}
 
-	oldOwnedModel := filepath.Join(llamaModelDir, "old.gguf")
+	oldOwnedModel := filepath.Join(llamaPayloadDir, "old.gguf")
 	userModel := filepath.Join(modelsDir, "user.gguf")
 	userConfig := filepath.Join(modelsDir, "user.yaml")
 	seedFiles := map[string]string{
@@ -579,12 +582,12 @@ printf 'fresh' > "$output"
 			t.Fatalf("runner should preserve unrelated file %q: %v", preserved, err)
 		}
 	}
-	freshModel := filepath.Join(llamaModelDir, "fresh.gguf")
+	freshModel := filepath.Join(llamaPayloadDir, "fresh.gguf")
 	assertRunnerFileContent(t, freshModel, "fresh")
 	wantConfig := "name: \"fresh\"\n" +
 		"backend: llama-cpp\n" +
 		"parameters:\n" +
-		"  model: \"" + freshModel + "\"\n"
+		"  model: \"payload/fresh.gguf\"\n"
 	assertRunnerFileContent(t, activeConfig, wantConfig)
 }
 
@@ -622,12 +625,13 @@ printf 'GGUF' > "$local_dir/quantized/q3/nested.gguf"
 		t.Fatalf("run llama-cpp nested GGUF flow: %v: %s", err, output)
 	}
 
-	nestedModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/quantized/q3/nested.gguf")
+	nestedModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/payload/quantized/q3/nested.gguf")
+	assertRunnerFileContent(t, nestedModel, "GGUF")
 	wantConfig := "name: \"nested\"\n" +
 		"backend: llama-cpp\n" +
 		"parameters:\n" +
-		"  model: \"" + nestedModel + "\"\n"
-	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
+		"  model: \"payload/quantized/q3/nested.gguf\"\n"
+	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/"+runnerConfigFilename), wantConfig)
 	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), runnerModelCacheKey("org/nested-repo")+"\n")
 
 	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 91\n")
@@ -646,13 +650,14 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 	for _, expected := range []string{
 		runnerVLLMCppModelMarker,
 		`VLLM_CPP_MODEL_DIR="` + runnerVLLMCppModelDir + `"`,
+		`VLLM_CPP_PAYLOAD_DIR="$VLLM_CPP_MODEL_DIR/payload"`,
 		`hf download`,
 		`--local-dir`,
 		runnerCurlInvocation,
 		`\.gguf$`,
 		`backend: vllm-cpp`,
 		`name: '${MODEL_NAME}'`,
-		`model: '${LOCAL_MODEL_PATH}'`,
+		`model: '${CONFIG_MODEL_PATH}'`,
 		`use_tokenizer_template: true`,
 		`model.safetensors.index.json`,
 		`MODEL_CACHE_KEY`,
@@ -692,7 +697,7 @@ func TestRunnerBackendsUseSeparateModelMarkers(t *testing.T) {
 	if !strings.Contains(vllmCppScript, runnerVLLMCppModelMarker) || strings.Contains(vllmCppScript, runnerLlamaCppModelMarker) {
 		t.Fatal("vllm-cpp download script does not use only its backend-scoped marker")
 	}
-	if !strings.Contains(llamaScript, `find "$LLAMA_CPP_MODEL_DIR"`) || strings.Contains(llamaScript, "| head") {
+	if !strings.Contains(llamaScript, `find "$LLAMA_CPP_PAYLOAD_DIR"`) || strings.Contains(llamaScript, "| head") {
 		t.Fatal("llama-cpp lookup must recursively search only its owned cache and avoid pipelines")
 	}
 }
@@ -716,6 +721,7 @@ done
 mkdir -p "$local_dir"
 printf '{}\n' > "$local_dir/config.json"
 printf 'weights\n' > "$local_dir/model.safetensors"
+printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 `)
 
 	model := "huggingface://org/repo"
@@ -725,20 +731,31 @@ printf 'weights\n' > "$local_dir/model.safetensors"
 	}
 
 	localModelDir := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"))
+	localPayloadDir := filepath.Join(localModelDir, "payload")
 	wantConfig := "name: 'repo'\n" +
 		"backend: vllm-cpp\n" +
 		"parameters:\n" +
-		"  model: '" + localModelDir + "'\n" +
+		"  model: 'payload'\n" +
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
-	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(localModelDir, runnerConfigFilename), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(localPayloadDir, "repository.yaml"), "name: repository-owned\n")
 	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), runnerModelCacheKey("org/repo")+"\n")
+	modelRootEntries, err := os.ReadDir(localModelDir)
+	if err != nil {
+		t.Fatalf("read vllm-cpp model root: %v", err)
+	}
+	for _, entry := range modelRootEntries {
+		if !entry.IsDir() && (strings.HasSuffix(entry.Name(), ".yaml") || strings.HasSuffix(entry.Name(), ".yml")) && entry.Name() != runnerConfigFilename {
+			t.Fatalf("repository YAML escaped the unscanned payload directory: %s", entry.Name())
+		}
+	}
 
 	hfArgs, err := os.ReadFile(hfArgsLog)
 	if err != nil {
 		t.Fatalf("read hf arguments: %v", err)
 	}
-	for _, expected := range []string{"download\n", "org/repo\n", "--local-dir\n", localModelDir + "\n", "--exclude\n", "*.gguf\n", "--token\n", "test-token\n"} {
+	for _, expected := range []string{"download\n", "org/repo\n", "--local-dir\n", localPayloadDir + "\n", "--exclude\n", "*.gguf\n", "--token\n", "test-token\n"} {
 		if !strings.Contains(string(hfArgs), expected) {
 			t.Errorf("hf arguments do not contain %q: %s", expected, hfArgs)
 		}
@@ -783,14 +800,15 @@ printf 'GGUF' > "$output"
 		t.Fatalf("run vllm-cpp GGUF flow: %v: %s", err, output)
 	}
 
-	localModelPath := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"), "null.gguf")
+	localModelDir := filepath.Join(modelsDir, strings.TrimPrefix(runnerVLLMCppModelDir, "/models/"))
+	localModelPath := filepath.Join(localModelDir, "payload", "null.gguf")
 	wantConfig := "name: 'null'\n" +
 		"backend: vllm-cpp\n" +
 		"parameters:\n" +
-		"  model: '" + localModelPath + "'\n" +
+		"  model: 'payload/null.gguf'\n" +
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
-	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(localModelDir, runnerConfigFilename), wantConfig)
 	assertRunnerFileContent(t, localModelPath, "GGUF")
 }
 
@@ -857,7 +875,7 @@ printf 'GGUF' > "$output"
 func TestVLLMCppRunnerRepairsIncompleteShardedRepository(t *testing.T) {
 	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
 	model := "huggingface://org/sharded"
-	modelDir := runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir)
+	modelDir := runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir+"/payload")
 	if err := os.MkdirAll(modelDir, 0o755); err != nil {
 		t.Fatalf("create sharded model directory: %v", err)
 	}
@@ -917,8 +935,9 @@ func TestVLLMCppRunnerIsolatesConfigFromStaleLlamaArtifacts(t *testing.T) {
 
 	staleModel := filepath.Join(modelsDir, "stale.gguf")
 	staleConfig := filepath.Join(modelsDir, "stale.yaml")
-	activeConfig := runnerPathInTestModels(modelsDir, runnerConfigPath)
-	if err := os.MkdirAll(filepath.Dir(activeConfig), 0o755); err != nil {
+	staleActiveConfig := runnerPathInTestModels(modelsDir, runnerConfigPath)
+	activeConfig := runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir+"/"+runnerConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(staleActiveConfig), 0o755); err != nil {
 		t.Fatalf("create active config directory: %v", err)
 	}
 	if err := os.WriteFile(staleModel, []byte("stale"), 0o600); err != nil {
@@ -927,7 +946,7 @@ func TestVLLMCppRunnerIsolatesConfigFromStaleLlamaArtifacts(t *testing.T) {
 	if err := os.WriteFile(staleConfig, []byte("name: stale\nbackend: llama-cpp\nparameters:\n  model: stale.gguf\n"), 0o600); err != nil {
 		t.Fatalf("write stale llama config: %v", err)
 	}
-	if err := os.WriteFile(activeConfig, []byte("name: stale\nbackend: llama-cpp\n"), 0o600); err != nil {
+	if err := os.WriteFile(staleActiveConfig, []byte("name: stale\nbackend: llama-cpp\n"), 0o600); err != nil {
 		t.Fatalf("write previous active config: %v", err)
 	}
 
@@ -951,7 +970,7 @@ printf 'GGUF' > "$output"
 		t.Fatalf("run vllm-cpp with stale llama artifacts: %v: %s", err, output)
 	}
 
-	for _, preserved := range []string{staleModel, staleConfig} {
+	for _, preserved := range []string{staleModel, staleConfig, staleActiveConfig} {
 		if _, err := os.Stat(preserved); err != nil {
 			t.Fatalf("vllm-cpp should preserve unrelated llama artifact %q: %v", preserved, err)
 		}
@@ -962,7 +981,7 @@ printf 'GGUF' > "$output"
 	wantConfig := "name: 'fresh'\n" +
 		"backend: vllm-cpp\n" +
 		"parameters:\n" +
-		"  model: '" + runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir+"/fresh.gguf") + "'\n" +
+		"  model: 'payload/fresh.gguf'\n" +
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
 	assertRunnerFileContent(t, activeConfig, wantConfig)

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -2,6 +2,8 @@ package inference
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -417,7 +419,7 @@ func TestGenerateLlamaCppDownload(t *testing.T) {
 	}
 
 	// Should handle HTTP URLs
-	if !strings.Contains(script, `"$MODEL" == http://*`) {
+	if !strings.Contains(script, `"$MODEL_SCHEME" == "http"`) {
 		t.Error("should handle HTTP URLs")
 	}
 
@@ -505,7 +507,7 @@ printf 'fresh' > "$output"
 	}
 	freshModel := runnerPathInTestModels(modelsDir, runnerLlamaCppModelDir+"/fresh.gguf")
 	assertRunnerFileContent(t, freshModel, "fresh")
-	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), model+"\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), runnerModelCacheKey(model)+"\n")
 	configPath := runnerPathInTestModels(modelsDir, runnerConfigPath)
 	wantConfig := "name: \"fresh\"\n" +
 		"backend: llama-cpp\n" +
@@ -537,7 +539,7 @@ func TestLlamaCppRunnerReplacesOnlyOwnedCacheAndConfig(t *testing.T) {
 		userModel:     "user",
 		userConfig:    "name: user-owned\n",
 		activeConfig:  "name: old\nbackend: llama-cpp\nparameters:\n  model: old.gguf\n",
-		filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)): "https://example.com/old.gguf\n",
+		filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)): runnerModelCacheKey("https://example.com/old.gguf") + "\n",
 	}
 	for path, content := range seedFiles {
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -626,7 +628,7 @@ printf 'GGUF' > "$local_dir/quantized/q3/nested.gguf"
 		"parameters:\n" +
 		"  model: \"" + nestedModel + "\"\n"
 	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
-	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), "org/nested-repo\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerLlamaCppModelMarker)), runnerModelCacheKey("org/nested-repo")+"\n")
 
 	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 91\n")
 	output, err = executeRunnerScript(t, script, binDir, "huggingface://org/nested-repo")
@@ -652,6 +654,8 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 		`name: '${MODEL_NAME}'`,
 		`model: '${LOCAL_MODEL_PATH}'`,
 		`use_tokenizer_template: true`,
+		`model.safetensors.index.json`,
+		`MODEL_CACHE_KEY`,
 	} {
 		if !strings.Contains(script, expected) {
 			t.Errorf("vllm-cpp download script does not contain %q", expected)
@@ -728,7 +732,7 @@ printf 'weights\n' > "$local_dir/model.safetensors"
 		"template:\n" +
 		"  use_tokenizer_template: true\n"
 	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
-	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), "org/repo\n")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)), runnerModelCacheKey("org/repo")+"\n")
 
 	hfArgs, err := os.ReadFile(hfArgsLog)
 	if err != nil {
@@ -788,6 +792,123 @@ printf 'GGUF' > "$output"
 		"  use_tokenizer_template: true\n"
 	assertRunnerFileContent(t, runnerPathInTestModels(modelsDir, runnerConfigPath), wantConfig)
 	assertRunnerFileContent(t, localModelPath, "GGUF")
+}
+
+func TestVLLMCppRunnerDoesNotPersistOrLogAuthenticatedURL(t *testing.T) {
+	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'GGUF' > "$output"
+`)
+
+	//nolint:gosec // Deliberately includes fake URL credentials to verify redaction.
+	model := "https://alice:s3cr3t@example.com/model.gguf?X-Amz-Credential=top-secret#fragment"
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("run vllm-cpp authenticated GGUF flow: %v: %s", err, output)
+	}
+
+	for _, secret := range []string{"alice", "s3cr3t", "X-Amz-Credential", "top-secret"} {
+		if strings.Contains(string(output), secret) {
+			t.Errorf("runner output leaked %q: %s", secret, output)
+		}
+	}
+	if !strings.Contains(string(output), "https://[redacted]@example.com/model.gguf") {
+		t.Errorf("runner output does not contain the sanitized URL: %s", output)
+	}
+
+	marker := filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker))
+	assertRunnerFileContent(t, marker, runnerModelCacheKey(model)+"\n")
+	markerContent, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read vllm-cpp marker: %v", err)
+	}
+	if strings.Contains(string(markerContent), "example.com") || strings.Contains(string(markerContent), "top-secret") {
+		t.Fatalf("vllm-cpp marker persisted URL data: %q", markerContent)
+	}
+
+	//nolint:gosec // Deliberately includes fake URL credentials to verify mixed-case scheme redaction.
+	mixedCaseModel := "HTTPS://bob:another-secret@example.com/mixed.gguf?token=still-secret"
+	output, err = executeRunnerScript(t, script, binDir, mixedCaseModel)
+	if err != nil {
+		t.Fatalf("run vllm-cpp mixed-case authenticated GGUF flow: %v: %s", err, output)
+	}
+	for _, secret := range []string{"bob", "another-secret", "token=", "still-secret"} {
+		if strings.Contains(string(output), secret) {
+			t.Errorf("mixed-case runner output leaked %q: %s", secret, output)
+		}
+	}
+	if !strings.Contains(string(output), "https://[redacted]@example.com/mixed.gguf") {
+		t.Errorf("mixed-case runner output does not contain the sanitized URL: %s", output)
+	}
+	assertRunnerFileContent(t, marker, runnerModelCacheKey(mixedCaseModel)+"\n")
+}
+
+func TestVLLMCppRunnerRepairsIncompleteShardedRepository(t *testing.T) {
+	script, modelsDir, binDir := prepareVLLMCppRunnerScript(t)
+	model := "huggingface://org/sharded"
+	modelDir := runnerPathInTestModels(modelsDir, runnerVLLMCppModelDir)
+	if err := os.MkdirAll(modelDir, 0o755); err != nil {
+		t.Fatalf("create sharded model directory: %v", err)
+	}
+	seedFiles := map[string]string{
+		filepath.Join(modelDir, "config.json"):                            "{}\n",
+		filepath.Join(modelDir, "model.safetensors.index.json"):           `{"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}`,
+		filepath.Join(modelDir, "model-00001-of-00002.safetensors"):       "first shard\n",
+		filepath.Join(modelsDir, filepath.Base(runnerVLLMCppModelMarker)): runnerModelCacheKey(model) + "\n",
+	}
+	for path, content := range seedFiles {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("seed sharded repository file %q: %v", path, err)
+		}
+	}
+
+	hfLog := filepath.Join(t.TempDir(), "hf-called")
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+printf 'called\n' > "$HF_LOG"
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir"
+printf '{}\n' > "$local_dir/config.json"
+printf '%s\n' '{"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}' > "$local_dir/model.safetensors.index.json"
+printf 'first shard\n' > "$local_dir/model-00001-of-00002.safetensors"
+printf 'second shard\n' > "$local_dir/model-00002-of-00002.safetensors"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, model, "HF_LOG="+hfLog)
+	if err != nil {
+		t.Fatalf("repair incomplete sharded repository: %v: %s", err, output)
+	}
+	assertRunnerFileContent(t, hfLog, "called\n")
+	assertRunnerFileContent(t, filepath.Join(modelDir, "model-00002-of-00002.safetensors"), "second shard\n")
+
+	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 91\n")
+	output, err = executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("reuse complete sharded repository: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "Found cached vllm-cpp model matching org/sharded") {
+		t.Errorf("complete sharded repository was not treated as a cache hit: %s", output)
+	}
 }
 
 func TestVLLMCppRunnerIsolatesConfigFromStaleLlamaArtifacts(t *testing.T) {
@@ -872,6 +993,34 @@ printf 'GGUF' > "$local_dir/model.gguf"
 	}
 	if !strings.Contains(string(output), "must contain config.json and safetensors weights") {
 		t.Fatalf("unexpected GGUF-only repository error: %s", output)
+	}
+}
+
+func TestVLLMCppRunnerRejectsNestedSafetensorsRepository(t *testing.T) {
+	script, _, binDir := prepareVLLMCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir/weights"
+printf '{}\n' > "$local_dir/config.json"
+printf 'weights\n' > "$local_dir/weights/model.safetensors"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, "huggingface://org/nested-safetensors")
+	if err == nil {
+		t.Fatalf("nested safetensors repository unexpectedly succeeded: %s", output)
+	}
+	if !strings.Contains(string(output), "must contain config.json and safetensors weights") {
+		t.Fatalf("unexpected nested safetensors repository error: %s", output)
 	}
 }
 
@@ -1036,6 +1185,12 @@ func prepareVLLMCppRunnerScript(t *testing.T) (string, string, string) {
 
 func runnerPathInTestModels(modelsDir, runnerPath string) string {
 	return filepath.Join(modelsDir, strings.TrimPrefix(runnerPath, "/models/"))
+}
+
+func runnerModelCacheKey(model string) string {
+	normalizedModel := strings.TrimPrefix(model, "huggingface://")
+	digest := sha256.Sum256([]byte(normalizedModel))
+	return hex.EncodeToString(digest[:])
 }
 
 func executeRunnerScript(t *testing.T, script, binDir, model string, extraEnv ...string) ([]byte, error) {

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -653,6 +653,13 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 		`VLLM_CPP_PAYLOAD_DIR="$VLLM_CPP_MODEL_DIR/payload"`,
 		`hf download`,
 		`--local-dir`,
+		`"--include" "*.json"`,
+		`"--include" "*.safetensors"`,
+		`"--include" "*.model"`,
+		`"--include" "*.txt"`,
+		`"--include" "*.tiktoken"`,
+		`"--include" "*.jinja"`,
+		`"--exclude" "*.gguf"`,
 		runnerCurlInvocation,
 		`\.gguf$`,
 		`backend: vllm-cpp`,
@@ -670,7 +677,6 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 	for _, unexpected := range []string{
 		`model: ${MODEL}`,
 		runnerLegacyHFCLICommand,
-		`--include`,
 	} {
 		if strings.Contains(script, unexpected) {
 			t.Errorf("vllm-cpp download script should not contain %q", unexpected)
@@ -762,6 +768,12 @@ printf 'name: repository-owned\n' > "$local_dir/repository.yaml"
 		"org/repo\n",
 		"--local-dir\n",
 		localPayloadDir + "\n",
+		"--include\n*.json\n",
+		"--include\n*.safetensors\n",
+		"--include\n*.model\n",
+		"--include\n*.txt\n",
+		"--include\n*.tiktoken\n",
+		"--include\n*.jinja\n",
 		"--exclude\n",
 		"*.gguf\n",
 		"--revision\n",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -851,7 +851,7 @@ func validateInferenceConfig(c *config.InferenceConfig) error {
 		}
 	}
 
-	backends := []string{utils.BackendLlamaCpp, utils.BackendDiffusers, utils.BackendVLLM}
+	backends := []string{utils.BackendLlamaCpp, utils.BackendDiffusers, utils.BackendVLLM, utils.BackendVLLMCpp}
 	for _, b := range c.Backends {
 		if !slices.Contains(backends, b) {
 			return errors.Errorf("backend %s is not supported", b)
@@ -868,6 +868,31 @@ func validateInferenceConfig(c *config.InferenceConfig) error {
 
 // validateBackendPlatformCompatibility validates that backends are compatible with target platforms.
 func validateBackendPlatformCompatibility(c *config.InferenceConfig, targetPlatforms []*specs.Platform) error {
+	if slices.Contains(c.Backends, utils.BackendVLLMCpp) {
+		for _, tp := range targetPlatforms {
+			if tp != nil && tp.OS != utils.PlatformLinux {
+				return errors.Errorf("vllm-cpp backend is not supported on %s. only linux is supported", tp.OS)
+			}
+		}
+
+		switch c.Runtime {
+		case "":
+			for _, tp := range targetPlatforms {
+				if tp != nil && tp.Architecture != utils.PlatformAMD64 && tp.Architecture != utils.PlatformARM64 {
+					return errors.Errorf("vllm-cpp backend with CPU runtime is not supported on %s architecture", tp.Architecture)
+				}
+			}
+		case utils.RuntimeNVIDIA:
+			for _, tp := range targetPlatforms {
+				if tp != nil && tp.Architecture != utils.PlatformAMD64 {
+					return errors.Errorf("vllm-cpp backend with cuda runtime is not supported on %s architecture. only amd64 is supported", tp.Architecture)
+				}
+			}
+		default:
+			return errors.Errorf("vllm-cpp backend does not support %s runtime", c.Runtime)
+		}
+	}
+
 	// Check if any target platform is ARM64
 	hasARM64Platform := false
 	for _, tp := range targetPlatforms {
@@ -882,12 +907,16 @@ func validateBackendPlatformCompatibility(c *config.InferenceConfig, targetPlatf
 		return errors.New("rocm runtime is only supported on linux/amd64 platform")
 	}
 
-	// If we have ARM64 platforms, validate backend compatibility
+	// If we have ARM64 platforms, validate backend compatibility.
 	if hasARM64Platform {
 		for _, backend := range c.Backends {
-			if backend != utils.BackendLlamaCpp {
-				return errors.Errorf("backend %s is not supported on arm64 platform. only llama-cpp backend supports arm64", backend)
+			if backend == utils.BackendLlamaCpp {
+				continue
 			}
+			if backend == utils.BackendVLLMCpp && c.Runtime == "" {
+				continue
+			}
+			return errors.Errorf("backend %s with runtime %q is not supported on arm64 platform. only llama-cpp and CPU vllm-cpp support arm64", backend, c.Runtime)
 		}
 	}
 

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -123,6 +123,53 @@ func Test_validateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid vllm-cpp backend with CPU runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Backends:   []string{utils.BackendVLLMCpp},
+				Models: []config.Model{
+					{
+						Name:   "test",
+						Source: "foo",
+					},
+				},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid vllm-cpp backend with cuda runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendVLLMCpp},
+				Models: []config.Model{
+					{
+						Name:   "test",
+						Source: "foo",
+					},
+				},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "vllm-cpp backend rejects rocm runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeROCm,
+				Backends:   []string{utils.BackendVLLMCpp},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "vllm-cpp backend rejects apple silicon runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeAppleSilicon,
+				Backends:   []string{utils.BackendVLLMCpp},
+			}},
+			wantErr: true,
+		},
+		{
 			name: "invalid backend name",
 			args: args{c: &config.InferenceConfig{
 				APIVersion: "v1alpha1",
@@ -300,6 +347,86 @@ func Test_validateBackendPlatformCompatibility(t *testing.T) {
 			},
 			targetPlatforms: []*specs.Platform{
 				{Architecture: "arm64", OS: "linux"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "vllm-cpp CPU backend with amd64 platform - should pass",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "vllm-cpp CPU backend with arm64 platform - should pass",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "vllm-cpp CUDA backend with amd64 platform - should pass",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "vllm-cpp CUDA backend with arm64 platform - should fail",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: utils.PlatformLinux},
+			},
+			wantErr: true,
+		},
+		{
+			name: "vllm-cpp CPU backend with unsupported architecture - should fail",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: "ppc64le", OS: utils.PlatformLinux},
+			},
+			wantErr: true,
+		},
+		{
+			name: "vllm-cpp CPU backend with darwin platform - should fail",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: "darwin"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "vllm-cpp CUDA backend with windows platform - should fail",
+			config: &config.InferenceConfig{
+				APIVersion: "v1alpha1",
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendVLLMCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: "windows"},
 			},
 			wantErr: true,
 		},

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -8,6 +8,7 @@ const (
 	BackendDiffusers = "diffusers"
 	BackendLlamaCpp  = "llama-cpp"
 	BackendVLLM      = "vllm"
+	BackendVLLMCpp   = "vllm-cpp"
 
 	BackendOCIRegistry = "quay.io/go-skynet/local-ai-backends"
 

--- a/runners/vllm-cpp-cpu.yaml
+++ b/runners/vllm-cpp-cpu.yaml
@@ -1,0 +1,4 @@
+#syntax=ghcr.io/kaito-project/aikit/aikit:latest
+apiVersion: v1alpha1
+backends:
+  - vllm-cpp

--- a/runners/vllm-cpp-cuda.yaml
+++ b/runners/vllm-cpp-cuda.yaml
@@ -1,0 +1,5 @@
+#syntax=ghcr.io/kaito-project/aikit/aikit:latest
+apiVersion: v1alpha1
+runtime: cuda
+backends:
+  - vllm-cpp

--- a/test/aikitfile-vllm-cpp-cpu.yaml
+++ b/test/aikitfile-vllm-cpp-cpu.yaml
@@ -1,0 +1,19 @@
+#syntax=aikit:test
+apiVersion: v1alpha1
+debug: true
+backends:
+  - vllm-cpp
+models:
+  - name: qwen35-vllmcpp-smoke
+    source: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q3_K_S.gguf
+    sha256: "4649ee78ff7cbad4e9fe4c0bab3b73a7c70096b51e36ef299469b08989a93c39"
+config: |
+  - name: qwen35-vllmcpp-smoke
+    backend: vllm-cpp
+    context_size: 1024
+    parameters:
+      model: Qwen3.5-0.8B-Q3_K_S.gguf
+    template:
+      use_tokenizer_template: true
+    options:
+      - max_num_seqs:1

--- a/test/aikitfile-vllm-cpp-cuda.yaml
+++ b/test/aikitfile-vllm-cpp-cuda.yaml
@@ -1,0 +1,20 @@
+#syntax=aikit:test
+apiVersion: v1alpha1
+debug: true
+runtime: cuda
+backends:
+  - vllm-cpp
+models:
+  - name: qwen35-vllmcpp-smoke
+    source: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q3_K_S.gguf
+    sha256: "4649ee78ff7cbad4e9fe4c0bab3b73a7c70096b51e36ef299469b08989a93c39"
+config: |
+  - name: qwen35-vllmcpp-smoke
+    backend: vllm-cpp
+    context_size: 1024
+    parameters:
+      model: Qwen3.5-0.8B-Q3_K_S.gguf
+    template:
+      use_tokenizer_template: true
+    options:
+      - max_num_seqs:1

--- a/website/docs/runners.md
+++ b/website/docs/runners.md
@@ -37,10 +37,14 @@ docker run -p 8080:8080 ghcr.io/kaito-project/aikit/runners/llama-cpp-cpu:latest
 # With GPU support
 docker run --gpus all -p 8080:8080 ghcr.io/kaito-project/aikit/runners/llama-cpp-cuda:latest \
   https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf
+
+# Native vllm.cpp with a safetensors repository pinned to an immutable revision
+docker run -p 8080:8080 ghcr.io/kaito-project/aikit/runners/vllm-cpp-cpu:latest \
+  Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
 ```
 
 :::tip
-For HuggingFace repos with many quantization variants, use a **direct URL** to a specific file to avoid downloading all variants.
+For GGUF repositories with many quantization variants, use a **direct URL** to a specific `.gguf` file to avoid downloading all variants. The vllm.cpp runner accepts safetensors only as a repository reference; use `owner/repository@commit` with the full 40-character lowercase commit SHA for reproducible downloads.
 :::
 
 Then query the model:
@@ -52,7 +56,7 @@ curl http://localhost:8080/v1/chat/completions \
 ```
 
 :::note
-The model name in the API request is the GGUF filename without the `.gguf` extension.
+The model name in the API request is the GGUF filename without the `.gguf` extension. For a vllm.cpp safetensors repository, it is the repository name without the owner or pinned revision (for example, `Qwen3-0.6B`).
 :::
 
 ## GPU Support

--- a/website/docs/runners.md
+++ b/website/docs/runners.md
@@ -157,4 +157,4 @@ For AMD GPUs, run the resulting image with the ROCm device flags described in [G
 | `llama-cpp` | GGUF models via llama.cpp (CPU, NVIDIA CUDA, or ROCm) |
 | `diffusers` | HuggingFace diffusers models (requires NVIDIA CUDA) |
 | `vllm` | HuggingFace safetensors models via vLLM (requires NVIDIA CUDA) |
-| `vllm-cpp` | Local GGUF files or materialized Hugging Face repositories via the experimental native engine (CPU, or CUDA 13 on amd64 Blackwell GPUs) |
+| `vllm-cpp` | Direct HTTP(S) GGUF URLs or Hugging Face safetensors repositories via the experimental native engine (CPU, or CUDA 13 on amd64 Blackwell GPUs) |

--- a/website/docs/runners.md
+++ b/website/docs/runners.md
@@ -83,7 +83,7 @@ docker run -e HF_TOKEN=hf_xxx -p 8080:8080 \
 
 ## Volume Caching
 
-Mount a volume to `/models` to cache downloaded models across container restarts. The llama.cpp runner stores GGUF files directly in `/models`; Diffusers and vLLM store their Hugging Face cache under `/models/.cache/huggingface`:
+Mount a volume to `/models` to cache downloaded models across container restarts. The llama.cpp and vllm.cpp runners keep their payloads in `/models/llama-cpp-model` and `/models/vllm-cpp-model`, respectively. Diffusers and Python vLLM store their Hugging Face cache under `/models/.cache/huggingface`:
 
 ```bash
 docker run -v models:/models -p 8080:8080 \
@@ -91,7 +91,7 @@ docker run -v models:/models -p 8080:8080 \
   https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf
 ```
 
-The llama.cpp runner detects when a different model is requested and re-downloads automatically. Diffusers and vLLM update their generated model configuration while retaining the shared Hugging Face cache for reuse.
+Native runners detect when a different model is requested and replace only their backend-owned cache. All runner images place their single active generated config under `/models/aikit-runner`; LocalAI scans that directory instead of unrelated YAML elsewhere in the mounted volume. Diffusers and Python vLLM update this config while retaining the shared Hugging Face cache for reuse.
 
 ## Kubernetes / kubeairunway
 

--- a/website/docs/runners.md
+++ b/website/docs/runners.md
@@ -14,6 +14,8 @@ Pre-built runner images are available at `ghcr.io/kaito-project/aikit/runners/`:
 | `ghcr.io/kaito-project/aikit/runners/llama-cpp-cuda:latest` | NVIDIA CUDA + CPU fallback llama.cpp runner (amd64) |
 | `ghcr.io/kaito-project/aikit/runners/diffusers-cuda:latest` | NVIDIA CUDA diffusers runner (amd64) |
 | `ghcr.io/kaito-project/aikit/runners/vllm-cuda:latest` | NVIDIA CUDA vLLM runner (amd64) |
+| `ghcr.io/kaito-project/aikit/runners/vllm-cpp-cpu:latest` | Experimental native vllm.cpp CPU runner (amd64, arm64) |
+| `ghcr.io/kaito-project/aikit/runners/vllm-cpp-cuda:latest` | Experimental native vllm.cpp CUDA 13 runner for Blackwell GPUs (amd64) |
 
 :::note
 Pre-built runner images are currently published for CPU and NVIDIA CUDA only. For AMD GPUs, build a custom `llama-cpp` runner with `runtime: rocm`.
@@ -155,3 +157,4 @@ For AMD GPUs, run the resulting image with the ROCm device flags described in [G
 | `llama-cpp` | GGUF models via llama.cpp (CPU, NVIDIA CUDA, or ROCm) |
 | `diffusers` | HuggingFace diffusers models (requires NVIDIA CUDA) |
 | `vllm` | HuggingFace safetensors models via vLLM (requires NVIDIA CUDA) |
+| `vllm-cpp` | Local GGUF files or materialized Hugging Face repositories via the experimental native engine (CPU, or CUDA 13 on amd64 Blackwell GPUs) |

--- a/website/docs/runners.md
+++ b/website/docs/runners.md
@@ -91,7 +91,7 @@ docker run -v models:/models -p 8080:8080 \
   https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf
 ```
 
-Native runners detect when a different model is requested and replace only their backend-owned cache. All runner images place their single active generated config under `/models/aikit-runner`; LocalAI scans that directory instead of unrelated YAML elsewhere in the mounted volume. Diffusers and Python vLLM update this config while retaining the shared Hugging Face cache for reuse.
+Native runners detect when a different model is requested and replace only their backend-owned cache. Their generated configs live at `/models/llama-cpp-model/model.yaml` and `/models/vllm-cpp-model/model.yaml`; downloaded payloads stay under each directory's unscanned `payload/` subtree. Diffusers and Python vLLM use `/models/aikit-runner/model.yaml` while retaining the shared Hugging Face cache for reuse. LocalAI scans only the active runner's config directory, not unrelated YAML elsewhere in the mounted volume.
 
 ## Kubernetes / kubeairunway
 

--- a/website/docs/specs-inference.md
+++ b/website/docs/specs-inference.md
@@ -8,7 +8,7 @@ title: Inference API Specifications
 apiVersion: # required. only v1alpha1 is supported at the moment
 debug: # optional. if set to true, debug logs will be printed
 runtime: # optional. omit for the default CPU runtime. can be "cuda", "rocm", or "applesilicon"
-backends: # optional. list of additional backends. can be "llama-cpp" (default), "diffusers", "vllm"
+backends: # optional. list of additional backends. can be "llama-cpp" (default), "diffusers", "vllm", "vllm-cpp"
 loadToMemory: # optional. list of LocalAI model config names to load when the container starts
   - model-name
 models: # optional. list of models to build. omit for runner mode (see runners.md)
@@ -22,7 +22,7 @@ config: # optional. list of config files
 ```
 
 :::note
-If omitted, `runtime` uses the default CPU runtime. `rocm` currently supports only the `llama-cpp` backend on `linux/amd64`.
+If omitted, `runtime` uses the default CPU runtime. `rocm` currently supports only the `llama-cpp` backend on `linux/amd64`. The experimental `vllm-cpp` backend supports CPU on `linux/amd64` and `linux/arm64`, or CUDA 13 on Blackwell-class `linux/amd64` GPUs.
 :::
 
 :::tip
@@ -40,7 +40,7 @@ loadToMemory:
 
 Each item is an exact, case-sensitive LocalAI model-config name. For a baked `config`, use its `config[].name`; configs discovered or generated at runtime use the name declared in that config. Do not use a filename from the top-level `models` list. Names must be non-empty and unique, and cannot contain commas or backslashes. A model composed of several files, such as weight shards or a model plus an `mmproj` file, still has one logical name and needs one entry. Multiple names are loaded in the listed order.
 
-Runner images generate their LocalAI config after resolving the runtime model argument. The `llama-cpp` runner derives the name from the selected GGUF filename without the `.gguf` extension; Diffusers and vLLM runners use the normalized final component of the model source. Avoid a baked `loadToMemory` setting when a runner source can resolve to several GGUF files because the selected name is ambiguous.
+Runner images generate their LocalAI config after resolving the runtime model argument. The `llama-cpp` runner derives the name from the selected GGUF filename without the `.gguf` extension; Diffusers and vLLM runners use the normalized final component of the model source. The `vllm-cpp` runner downloads a Hugging Face repository containing `config.json` and safetensors weights to a local model directory, or accepts a direct HTTP(S) URL ending in `.gguf`, because the native backend cannot download bare repository IDs itself. Use a direct file URL for GGUF weights. Avoid a baked `loadToMemory` setting when a runner source can resolve to several GGUF files because the selected name is ambiguous.
 
 Loading blocks server startup and can fail if the model does not exist or there is insufficient memory, so health probes must allow enough startup time. It warms the model but does not prevent LocalAI from unloading it later, and LocalAI skips startup loading when `LOCALAI_SINGLE_ACTIVE_BACKEND=true`. The setting is disabled when omitted. At runtime, `LOCALAI_LOAD_TO_MEMORY` can replace the image default; set it to an empty value to disable startup loading.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- updates LocalAI from v4.7.1 to v4.8.2
- adds experimental `vllm-cpp` backend selection for Linux CPU amd64/arm64 and CUDA 13 amd64
- adds CPU and CUDA runner definitions plus release publishing entries
- materializes Hugging Face safetensors repositories and direct GGUF URLs for runner mode with model-aware caching and legacy llama cache migration
- adds platform/runtime validation, CUDA 13 image requirements, documentation, and CPU CI smoke coverage
- adds pinned Qwen3.5-0.8B GGUF fixtures for CPU and CUDA validation

**Validation**:

- `make test`
- `golangci-lint run ./... --new-from-rev=origin/main --timeout 5m`
- `git diff origin/main...HEAD --check`
- live CPU completion and chat inference with Qwen3.5-0.8B Q3_K_S
- live CUDA image/backend/ABI loading and completion/chat through CPU fallback
- LocalAI v4.8.2 mirror: https://github.com/kaito-project/aikit/actions/runs/31267353544

**Special notes for your reviewer**:

The published CUDA backend requires Linux amd64, CUDA 13, and Blackwell-class GPUs. This host has no NVIDIA device, so CUDA kernel execution was not validated; the CUDA-tagged image, packaged libraries, backend process, and fallback inference were validated.