### PR TITLE
feat(inference): add parakeet.cpp backend

### DIFF
--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -46,6 +46,14 @@ jobs:
             file: runners/vllm-cpp-cuda.yaml
             platforms: linux/amd64
             max-compressed-mib: 1800
+          - runner: parakeet-cpp-cpu
+            file: runners/parakeet-cpp-cpu.yaml
+            platforms: linux/amd64,linux/arm64
+            max-compressed-mib: 250
+          - runner: parakeet-cpp-cuda
+            file: runners/parakeet-cpp-cuda.yaml
+            platforms: linux/amd64
+            max-compressed-mib: 1800
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/test-docker-runner-gpu.yaml
+++ b/.github/workflows/test-docker-runner-gpu.yaml
@@ -12,6 +12,7 @@ on:
           - all
           - llama-cpp-cuda
           - diffusers-cuda
+          - parakeet-cpp-cuda
           - vllm-cuda
 
 permissions: read-all
@@ -24,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        backend: ${{ inputs.backend == 'all' && fromJson('["llama-cpp-cuda", "diffusers-cuda", "vllm-cuda"]') || fromJson(format('["{0}"]', inputs.backend)) }}
+        backend: ${{ inputs.backend == 'all' && fromJson('["llama-cpp-cuda", "diffusers-cuda", "parakeet-cpp-cuda", "vllm-cuda"]') || fromJson(format('["{0}"]', inputs.backend)) }}
     steps:
       - name: cleanup workspace
         run: |
@@ -76,6 +77,10 @@ jobs:
         if: matrix.backend == 'diffusers-cuda'
         run: docker run --name runner-test -d --rm -p 8080:8080 --gpus all runner-test:test stable-diffusion-v1-5/stable-diffusion-v1-5
 
+      - name: run runner (parakeet-cpp-cuda)
+        if: matrix.backend == 'parakeet-cpp-cuda'
+        run: docker run --name runner-test -d --rm -p 8080:8080 --gpus all runner-test:test huggingface://mudler/parakeet-cpp-gguf@bf0af9f425fa01809cadec671b3cb672709d13e9/tdt_ctc-110m-q4_k.gguf
+
       - name: run runner (vllm-cuda)
         if: matrix.backend == 'vllm-cuda'
         run: docker run --name runner-test -d --rm -p 8080:8080 --gpus all runner-test:test Qwen/Qwen2.5-0.5B-Instruct
@@ -124,6 +129,28 @@ jobs:
       - name: save generated image
         if: matrix.backend == 'diffusers-cuda'
         run: docker cp runner-test:/tmp/generated/content/images /tmp || true
+
+      - name: run test (parakeet-cpp-cuda)
+        if: matrix.backend == 'parakeet-cpp-cuda'
+        run: |
+          curl --fail --location --retry 3 \
+            --output /tmp/parakeet-speech.wav \
+            https://raw.githubusercontent.com/mudler/parakeet.cpp/1bfbebfaaf493866f49597cd3b7901959d395c60/tests/fixtures/speech.wav
+          echo "5fceacff0315d49cb59fcc505bcecf1ed5f2f35c2897b1e65a59f30e5d922150  /tmp/parakeet-speech.wav" | sha256sum --check
+          docker run --rm \
+            --volume /tmp:/fixtures \
+            --entrypoint ffmpeg \
+            runner-test:test \
+            -y -i /fixtures/parakeet-speech.wav -ar 44100 -ac 2 -c:a pcm_s16le /fixtures/parakeet-speech-input.wav
+          result=$(curl --fail --retry 10 --retry-all-errors --retry-max-time 600 \
+            http://127.0.0.1:8080/v1/audio/transcriptions \
+            -F "file=@/tmp/parakeet-speech-input.wav;type=audio/wav" \
+            -F "model=tdt_ctc-110m-q4_k" \
+            -F "response_format=json")
+          echo "$result"
+          echo "$result" | jq -e \
+            --arg expected "Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait." \
+            '.error == null and .text == $expected'
 
       - name: run test (vllm-cuda)
         if: matrix.backend == 'vllm-cuda'

--- a/.github/workflows/test-docker-runner.yaml
+++ b/.github/workflows/test-docker-runner.yaml
@@ -27,24 +27,36 @@ jobs:
       matrix:
         include:
           - runner: llama-cpp-cpu
+            test_type: chat
             model_ref: https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/f0b45be0aac41bd6a100a4b5734cad5f67255bfb/gemma-3-1b-it-Q2_K.gguf
             model_name: gemma-3-1b-it-Q2_K
             prompt: explain kubernetes in a sentence
             max_tokens: 64
             expected_content: ""
           - runner: vllm-cpp-cpu
+            test_type: chat
             model_ref: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
             model_name: Qwen3-0.6B
             prompt: What is the capital of France? Reply with only the city name. /no_think
             max_tokens: 256
             expected_content: Paris
+          - runner: parakeet-cpp-cpu
+            test_type: transcription
+            model_ref: huggingface://mudler/parakeet-cpp-gguf@bf0af9f425fa01809cadec671b3cb672709d13e9/tdt_ctc-110m-q4_k.gguf
+            model_name: tdt_ctc-110m-q4_k
+            audio_ref: https://raw.githubusercontent.com/mudler/parakeet.cpp/1bfbebfaaf493866f49597cd3b7901959d395c60/tests/fixtures/speech.wav
+            audio_sha256: 5fceacff0315d49cb59fcc505bcecf1ed5f2f35c2897b1e65a59f30e5d922150
+            expected_content: "Well, I don't wish to see it any more, observed Phoebe, turning away her eyes. It is certainly very like the old portrait."
     env:
+      AUDIO_REF: ${{ matrix.audio_ref }}
+      AUDIO_SHA256: ${{ matrix.audio_sha256 }}
       EXPECTED_CONTENT: ${{ matrix.expected_content }}
       MAX_TOKENS: ${{ matrix.max_tokens }}
       MODEL_NAME: ${{ matrix.model_name }}
       MODEL_PROMPT: ${{ matrix.prompt }}
       MODEL_REF: ${{ matrix.model_ref }}
       RUNNER: ${{ matrix.runner }}
+      TEST_TYPE: ${{ matrix.test_type }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -117,9 +129,28 @@ jobs:
             test ! -d /root/.cache/pip
             test ! -e /usr/local/cuda
           '
+          if [[ "$TEST_TYPE" == "transcription" ]]; then
+            docker run --rm --entrypoint ffmpeg runner-test:test -version
+          fi
+
+      - name: download transcription fixture
+        if: matrix.test_type == 'transcription'
+        run: |
+          curl --fail --location --retry 3 --output /tmp/parakeet-speech.wav "$AUDIO_REF"
+          echo "$AUDIO_SHA256  /tmp/parakeet-speech.wav" | sha256sum --check
+          docker run --rm \
+            --volume /tmp:/fixtures \
+            --entrypoint ffmpeg \
+            runner-test:test \
+            -y -i /fixtures/parakeet-speech.wav -ar 44100 -ac 2 -c:a pcm_s16le /fixtures/parakeet-speech-input.wav
 
       - name: run runner with model
-        run: docker run --name runner-test -d -p 8080:8080 runner-test:test "$MODEL_REF" --context-size 1024
+        run: |
+          extra_args=()
+          if [[ "$TEST_TYPE" == "chat" ]]; then
+            extra_args+=(--context-size 1024)
+          fi
+          docker run --name runner-test -d -p 8080:8080 runner-test:test "$MODEL_REF" "${extra_args[@]}"
 
       - name: wait for model download
         run: |
@@ -149,6 +180,7 @@ jobs:
           fi
 
       - name: run chat completion test
+        if: matrix.test_type == 'chat'
         run: |
           payload=$(jq -n \
             --arg model "$MODEL_NAME" \
@@ -180,6 +212,27 @@ jobs:
               '(((.choices[0].message.content // "") | type == "string" and length > 0) or
                ((.choices[0].message.reasoning_content // .choices[0].message.reasoning // "") | type == "string" and length > 0))'
           fi
+
+      - name: run transcription test
+        if: matrix.test_type == 'transcription'
+        run: |
+          response=""
+          for i in $(seq 1 10); do
+            response=$(curl --fail --silent --show-error --max-time 300 \
+              http://127.0.0.1:8080/v1/audio/transcriptions \
+              -F "file=@/tmp/parakeet-speech-input.wav;type=audio/wav" \
+              -F "model=$MODEL_NAME" \
+              -F "response_format=json") && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          if [[ -z "$response" ]]; then
+            echo "Transcription did not return a response" >&2
+            exit 1
+          fi
+          echo "$response"
+          echo "$response" | jq -e --arg expected "$EXPECTED_CONTENT" \
+            '.error == null and .text == $expected'
 
       - name: save logs
         if: always()

--- a/pkg/aikit2llb/inference/backend.go
+++ b/pkg/aikit2llb/inference/backend.go
@@ -10,17 +10,19 @@ import (
 )
 
 const (
-	defaultBackendName    = "llama-cpp"
-	cpuLlamaCppBackend    = "cpu-llama-cpp"
-	cpuVLLMCppBackend     = "cpu-vllm-cpp"
-	cuda12LlamaCppBackend = "cuda12-llama-cpp"
-	cuda13VLLMCppBackend  = "cuda13-vllm-cpp"
-	vulkanLlamaCppBackend = "gpu-vulkan-llama-cpp"
+	defaultBackendName       = "llama-cpp"
+	cpuLlamaCppBackend       = "cpu-llama-cpp"
+	cpuParakeetCppBackend    = "cpu-parakeet-cpp"
+	cpuVLLMCppBackend        = "cpu-vllm-cpp"
+	cuda12LlamaCppBackend    = "cuda12-llama-cpp"
+	cuda12ParakeetCppBackend = "cuda12-parakeet-cpp"
+	cuda13VLLMCppBackend     = "cuda13-vllm-cpp"
+	vulkanLlamaCppBackend    = "gpu-vulkan-llama-cpp"
 )
 
 func normalizeBackend(backend string) string {
 	switch backend {
-	case utils.BackendDiffusers, utils.BackendLlamaCpp, utils.BackendVLLM, utils.BackendVLLMCpp:
+	case utils.BackendDiffusers, utils.BackendLlamaCpp, utils.BackendParakeetCpp, utils.BackendVLLM, utils.BackendVLLMCpp:
 		return backend
 	default:
 		return defaultBackendName
@@ -39,7 +41,7 @@ func getEffectiveBackend(backend, runtime string, platform specs.Platform) strin
 	if runtime == utils.RuntimeNVIDIA && platform.Architecture == utils.PlatformAMD64 {
 		return normalizedBackend
 	}
-	if runtime == "" && normalizedBackend == utils.BackendVLLMCpp &&
+	if runtime == "" && (normalizedBackend == utils.BackendParakeetCpp || normalizedBackend == utils.BackendVLLMCpp) &&
 		(platform.Architecture == utils.PlatformAMD64 || platform.Architecture == utils.PlatformARM64) {
 		return normalizedBackend
 	}
@@ -58,7 +60,7 @@ func getBackendVersion(backend, runtime string, platform specs.Platform) string 
 	switch getEffectiveBackend(backend, runtime, platform) {
 	case utils.BackendDiffusers:
 		return localAILegacyBackendVersion
-	case utils.BackendVLLM, utils.BackendVLLMCpp:
+	case utils.BackendParakeetCpp, utils.BackendVLLM, utils.BackendVLLMCpp:
 		return localAIBinaryVersion
 	default:
 		return localAILlamaCppBackendVersion
@@ -100,6 +102,8 @@ func getBackendTag(backend, runtime string, platform specs.Platform) string {
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-12-diffusers", baseTag)
 		case "vllm":
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-12-vllm", baseTag)
+		case utils.BackendParakeetCpp:
+			return fmt.Sprintf("%s-gpu-nvidia-%s", baseTag, cuda12ParakeetCppBackend)
 		case utils.BackendVLLMCpp:
 			return fmt.Sprintf("%s-gpu-nvidia-cuda-13-vllm-cpp", baseTag)
 		case defaultBackendName:
@@ -116,6 +120,9 @@ func getBackendTag(backend, runtime string, platform specs.Platform) string {
 	}
 
 	// Handle CPU runtime (default).
+	if backendName == utils.BackendParakeetCpp {
+		return fmt.Sprintf("%s-%s", baseTag, cpuParakeetCppBackend)
+	}
 	if backendName == utils.BackendVLLMCpp {
 		return fmt.Sprintf("%s-cpu-vllm-cpp", baseTag)
 	}
@@ -141,6 +148,8 @@ func getBackendName(backend, runtime string, platform specs.Platform) string {
 			return "cuda12-diffusers"
 		case utils.BackendVLLM:
 			return "cuda12-vllm"
+		case utils.BackendParakeetCpp:
+			return cuda12ParakeetCppBackend
 		case utils.BackendVLLMCpp:
 			return cuda13VLLMCppBackend
 		case defaultBackendName:
@@ -158,6 +167,9 @@ func getBackendName(backend, runtime string, platform specs.Platform) string {
 	}
 
 	// Handle CPU runtime (default)
+	if getEffectiveBackend(backend, runtime, platform) == utils.BackendParakeetCpp {
+		return cpuParakeetCppBackend
+	}
 	if getEffectiveBackend(backend, runtime, platform) == utils.BackendVLLMCpp {
 		return cpuVLLMCppBackend
 	}
@@ -168,7 +180,10 @@ func getBackendName(backend, runtime string, platform specs.Platform) string {
 func installBackend(backend string, c *config.InferenceConfig, platform specs.Platform, s llb.State, merge llb.State) llb.State {
 	tag := getBackendTag(backend, c.Runtime, platform)
 
-	// Install dependencies for Python-based backends
+	// Install backend-specific runtime dependencies.
+	if backend == utils.BackendParakeetCpp {
+		merge = installParakeetCppDependencies(s, merge)
+	}
 	if backend == utils.BackendDiffusers {
 		merge = installDiffusersDependencies(s, merge)
 	}

--- a/pkg/aikit2llb/inference/backend_test.go
+++ b/pkg/aikit2llb/inference/backend_test.go
@@ -68,6 +68,24 @@ func TestGetBackendTag(t *testing.T) {
 			want: fmt.Sprintf("%s-cpu-vllm-cpp", localAIBinaryVersion),
 		},
 		{
+			name:    "CPU parakeet-cpp amd64",
+			backend: utils.BackendParakeetCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: fmt.Sprintf("%s-%s", localAIBinaryVersion, cpuParakeetCppBackend),
+		},
+		{
+			name:    "CPU parakeet-cpp arm64",
+			backend: utils.BackendParakeetCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: fmt.Sprintf("%s-%s", localAIBinaryVersion, cpuParakeetCppBackend),
+		},
+		{
 			name:    "CUDA llama-cpp",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeNVIDIA,
@@ -102,6 +120,15 @@ func TestGetBackendTag(t *testing.T) {
 				Architecture: utils.PlatformAMD64,
 			},
 			want: fmt.Sprintf("%s-gpu-nvidia-cuda-13-vllm-cpp", localAIBinaryVersion),
+		},
+		{
+			name:    "CUDA parakeet-cpp",
+			backend: utils.BackendParakeetCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: fmt.Sprintf("%s-gpu-nvidia-%s", localAIBinaryVersion, cuda12ParakeetCppBackend),
 		},
 		{
 			name:    "Apple Silicon llama-cpp",
@@ -241,6 +268,24 @@ func TestGetBackendVersion(t *testing.T) {
 			want: localAIBinaryVersion,
 		},
 		{
+			name:    "CPU parakeet-cpp uses current backend tags",
+			backend: utils.BackendParakeetCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name:    "CUDA parakeet-cpp uses current backend tags",
+			backend: utils.BackendParakeetCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
 			name:    "apple silicon stays on legacy backend tags",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeAppleSilicon,
@@ -304,6 +349,27 @@ func TestGetLocalAIArtifactVersion(t *testing.T) {
 			config: &config.InferenceConfig{
 				Runtime:  utils.RuntimeNVIDIA,
 				Backends: []string{utils.BackendVLLMCpp},
+			},
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name: "CPU parakeet-cpp uses current LocalAI binary",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: localAIBinaryVersion,
+		},
+		{
+			name: "CUDA parakeet-cpp uses current LocalAI binary",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendParakeetCpp},
 			},
 			platform: specs.Platform{
 				Architecture: utils.PlatformAMD64,
@@ -547,6 +613,93 @@ func TestInstallBackendVLLMCppIsSelfContained(t *testing.T) {
 	}
 }
 
+func TestInstallBackendParakeetCppUsesExpectedArtifact(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *config.InferenceConfig
+		platform    specs.Platform
+		wantImage   string
+		wantBackend string
+	}{
+		{
+			name: "CPU arm64",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			platform: specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformARM64},
+			wantImage: fmt.Sprintf(
+				"%s:%s-%s",
+				utils.BackendOCIRegistry,
+				localAIBinaryVersion,
+				cpuParakeetCppBackend,
+			),
+			wantBackend: cpuParakeetCppBackend,
+		},
+		{
+			name: "CUDA amd64",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			platform: specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformAMD64},
+			wantImage: fmt.Sprintf(
+				"%s:%s-gpu-nvidia-%s",
+				utils.BackendOCIRegistry,
+				localAIBinaryVersion,
+				cuda12ParakeetCppBackend,
+			),
+			wantBackend: cuda12ParakeetCppBackend,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := llb.Image(utils.UbuntuBase, llb.Platform(tt.platform))
+			state := installBackend(utils.BackendParakeetCpp, tt.config, tt.platform, base, base)
+			definition, err := state.Marshal(context.Background())
+			if err != nil {
+				t.Fatalf("marshal parakeet-cpp backend definition: %v", err)
+			}
+
+			var foundImage, foundMetadata bool
+			for _, data := range definition.Def {
+				op := new(pb.Op)
+				if err := op.Unmarshal(data); err != nil {
+					t.Fatalf("unmarshal LLB op: %v", err)
+				}
+
+				if source := op.GetSource(); source != nil && strings.Contains(source.Identifier, tt.wantImage) {
+					foundImage = true
+				}
+				fileOp := op.GetFile()
+				if fileOp == nil {
+					continue
+				}
+				metadataPath := "/backends/" + tt.wantBackend + "/metadata.json"
+				for _, action := range fileOp.Actions {
+					mkfile := action.GetMkfile()
+					if mkfile == nil || mkfile.Path != metadataPath {
+						continue
+					}
+					metadata := string(mkfile.Data)
+					if !strings.Contains(metadata, `"alias": "parakeet-cpp"`) ||
+						!strings.Contains(metadata, `"name": "`+tt.wantBackend+`"`) {
+						t.Fatalf("parakeet-cpp metadata = %q", metadata)
+					}
+					foundMetadata = true
+				}
+			}
+
+			if !foundImage {
+				t.Errorf("backend image %q is missing", tt.wantImage)
+			}
+			if !foundMetadata {
+				t.Errorf("backend metadata for %q is missing", tt.wantBackend)
+			}
+		})
+	}
+}
+
 func TestGetDefaultBackends(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -613,6 +766,11 @@ func TestGetBackendAlias(t *testing.T) {
 			want:    "vllm-cpp",
 		},
 		{
+			name:    "parakeet-cpp backend",
+			backend: utils.BackendParakeetCpp,
+			want:    utils.BackendParakeetCpp,
+		},
+		{
 			name:    "unknown backend defaults to llama-cpp",
 			backend: "unknown",
 			want:    "llama-cpp",
@@ -670,6 +828,24 @@ func TestGetBackendName(t *testing.T) {
 			want: "cpu-vllm-cpp",
 		},
 		{
+			name:    "CPU parakeet-cpp amd64",
+			backend: utils.BackendParakeetCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: cpuParakeetCppBackend,
+		},
+		{
+			name:    "CPU parakeet-cpp arm64",
+			backend: utils.BackendParakeetCpp,
+			runtime: "",
+			platform: specs.Platform{
+				Architecture: utils.PlatformARM64,
+			},
+			want: cpuParakeetCppBackend,
+		},
+		{
 			name:    "CUDA llama-cpp",
 			backend: utils.BackendLlamaCpp,
 			runtime: utils.RuntimeNVIDIA,
@@ -704,6 +880,15 @@ func TestGetBackendName(t *testing.T) {
 				Architecture: utils.PlatformAMD64,
 			},
 			want: "cuda13-vllm-cpp",
+		},
+		{
+			name:    "CUDA parakeet-cpp",
+			backend: utils.BackendParakeetCpp,
+			runtime: utils.RuntimeNVIDIA,
+			platform: specs.Platform{
+				Architecture: utils.PlatformAMD64,
+			},
+			want: cuda12ParakeetCppBackend,
 		},
 		{
 			name:    "Apple Silicon llama-cpp",

--- a/pkg/aikit2llb/inference/convert.go
+++ b/pkg/aikit2llb/inference/convert.go
@@ -92,11 +92,11 @@ func getBaseImage(c *config.InferenceConfig, platform *specs.Platform) llb.State
 		return llb.Image(utils.UbuntuBase, llb.Platform(*platform))
 	}
 
-	// LocalAI, llama-cpp, and vllm-cpp are self-contained. Keep the full Ubuntu
-	// base only for Python backends whose portable environments still rely on
-	// additional system runtime libraries.
+	// LocalAI and the native C++ backend bundles can use the minimal base. Any
+	// supplemental runtime tools are layered explicitly by the backend installer;
+	// Python backends retain Ubuntu for their additional system libraries.
 	selfContainedBackend := len(c.Backends) == 0 ||
-		(len(c.Backends) == 1 && slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendVLLMCpp}, c.Backends[0]))
+		(len(c.Backends) == 1 && slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendParakeetCpp, utils.BackendVLLMCpp}, c.Backends[0]))
 	if !selfContainedBackend {
 		return llb.Image(utils.UbuntuBase, llb.Platform(*platform))
 	}

--- a/pkg/aikit2llb/inference/convert_test.go
+++ b/pkg/aikit2llb/inference/convert_test.go
@@ -199,6 +199,14 @@ func TestGetBaseImageUsesMinimalCompatibleRuntime(t *testing.T) {
 			want: distrolessBase,
 		},
 		{
+			name: "standard parakeet-cpp",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+				Models:   []config.Model{{Name: testInferenceModelName, Source: "parakeet-model.gguf"}},
+			},
+			want: distrolessBase,
+		},
+		{
 			name:   "Apple Silicon",
 			config: &config.InferenceConfig{Runtime: utils.RuntimeAppleSilicon},
 			want:   utils.AppleSiliconBase,

--- a/pkg/aikit2llb/inference/parakeet.go
+++ b/pkg/aikit2llb/inference/parakeet.go
@@ -1,0 +1,20 @@
+package inference
+
+import (
+	"github.com/kaito-project/aikit/pkg/utils"
+	"github.com/moby/buildkit/client/llb"
+)
+
+// installParakeetCppDependencies installs FFmpeg for normalizing uploaded audio
+// to the 16 kHz mono WAV format consumed by parakeet.cpp.
+func installParakeetCppDependencies(s llb.State, merge llb.State) llb.State {
+	savedState := s
+	s = s.Run(
+		utils.Sh("apt-get update && apt-get install --no-install-recommends -y ffmpeg && apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*"),
+		llb.WithCustomName("Installing FFmpeg for parakeet.cpp audio conversion"),
+		llb.IgnoreCache,
+	).Root()
+
+	diff := llb.Diff(savedState, s)
+	return llb.Merge([]llb.State{merge, diff})
+}

--- a/pkg/aikit2llb/inference/parakeet_test.go
+++ b/pkg/aikit2llb/inference/parakeet_test.go
@@ -1,0 +1,48 @@
+package inference
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+)
+
+const (
+	parakeetAptCleanupFragment = "rm -rf /var/lib/apt/lists/*"
+	parakeetPythonFragment     = "python3"
+)
+
+func TestInstallParakeetCppDependenciesAddsOnlyAudioConverter(t *testing.T) {
+	baseState := llb.Image("ubuntu:22.04")
+	result := installParakeetCppDependencies(baseState, baseState)
+
+	definition, err := result.Marshal(context.Background())
+	if err != nil {
+		t.Fatalf("marshal parakeet.cpp dependencies: %v", err)
+	}
+
+	ffmpegInstall := findInferenceExecOp(t, definition, "ffmpeg")
+	command := strings.Join(ffmpegInstall.op.GetExec().Meta.Args, "\x00")
+	for _, fragment := range []string{
+		"apt-get install --no-install-recommends -y ffmpeg",
+		parakeetAptCleanupFragment,
+		"/var/cache/apt/archives/*",
+	} {
+		if !strings.Contains(command, fragment) {
+			t.Fatalf("parakeet.cpp dependency command = %q, want %q", command, fragment)
+		}
+	}
+	for _, fragment := range []string{
+		parakeetPythonFragment,
+		"python3-pip",
+		"gcc",
+		"libc6-dev",
+		"cuda",
+		"rocm",
+	} {
+		if strings.Contains(command, fragment) {
+			t.Fatalf("parakeet.cpp dependency command = %q, unexpectedly contains %q", command, fragment)
+		}
+	}
+}

--- a/pkg/aikit2llb/inference/runner.go
+++ b/pkg/aikit2llb/inference/runner.go
@@ -12,16 +12,18 @@ import (
 )
 
 const (
-	runnerHuggingFaceHubVersion = "1.26.0"
-	runnerConfigDir             = "/models/aikit-runner"
-	runnerConfigFilename        = "model.yaml"
-	runnerConfigPath            = runnerConfigDir + "/" + runnerConfigFilename
-	runnerLegacyModelMarker     = "/models/.aikit-model-ref"
-	runnerLlamaCppModelDir      = "/models/llama-cpp-model"
-	runnerLlamaCppModelMarker   = "/models/.aikit-llama-cpp-model-ref"
-	runnerVLLMCppModelDir       = "/models/vllm-cpp-model"
-	runnerVLLMCppModelMarker    = "/models/.aikit-vllm-cpp-model-ref"
-	runnerDependenciesCommand   = "sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; " +
+	runnerHuggingFaceHubVersion  = "1.26.0"
+	runnerConfigDir              = "/models/aikit-runner"
+	runnerConfigFilename         = "model.yaml"
+	runnerConfigPath             = runnerConfigDir + "/" + runnerConfigFilename
+	runnerLegacyModelMarker      = "/models/.aikit-model-ref"
+	runnerLlamaCppModelDir       = "/models/llama-cpp-model"
+	runnerLlamaCppModelMarker    = "/models/.aikit-llama-cpp-model-ref"
+	runnerParakeetCppModelDir    = "/models/parakeet-cpp-model"
+	runnerParakeetCppModelMarker = "/models/.aikit-parakeet-cpp-model-ref"
+	runnerVLLMCppModelDir        = "/models/vllm-cpp-model"
+	runnerVLLMCppModelMarker     = "/models/.aikit-vllm-cpp-model-ref"
+	runnerDependenciesCommand    = "sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; " +
 		"s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && " +
 		"apt-get -o Acquire::Retries=5 -o APT::Update::Error-Mode=any update && " +
 		"apt-get install --no-install-recommends -y curl ca-certificates python3 python3-pip && " +
@@ -38,7 +40,7 @@ func isRunnerMode(c *config.InferenceConfig) bool {
 
 // installRunnerDependencies installs packages needed for runtime model downloading.
 func installRunnerDependencies(c *config.InferenceConfig, s llb.State, merge llb.State, platform specs.Platform) (llb.State, llb.State) {
-	if !slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendVLLMCpp}, runnerBackend(c)) {
+	if !slices.Contains([]string{utils.BackendLlamaCpp, utils.BackendParakeetCpp, utils.BackendVLLMCpp}, runnerBackend(c)) {
 		return s, merge
 	}
 
@@ -143,6 +145,10 @@ if [[ -z "$MODEL" ]]; then
     echo "  docker run -p 8080:8080 <image> org/safetensors-model@0123456789abcdef0123456789abcdef01234567"
     echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
     echo "  docker run -p 8080:8080 <image> --model org/safetensors-model"
+  elif [[ "$BACKEND" == "parakeet-cpp" ]]; then
+    echo "  docker run -p 8080:8080 <image> huggingface://org/repo/model-q4_k.gguf"
+    echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
+    echo "  docker run -p 8080:8080 <image> --model org/single-gguf-repo"
   else
     echo "  docker run -p 8080:8080 <image> org/model"
     echo "  docker run -p 8080:8080 <image> https://example.com/model.gguf"
@@ -161,6 +167,9 @@ RUNNER_CONFIG_DIR="` + runnerConfigDir + `"
 case "$BACKEND" in
   llama-cpp)
     RUNNER_CONFIG_DIR="` + runnerLlamaCppModelDir + `"
+    ;;
+  parakeet-cpp)
+    RUNNER_CONFIG_DIR="` + runnerParakeetCppModelDir + `"
     ;;
   vllm-cpp)
     RUNNER_CONFIG_DIR="` + runnerVLLMCppModelDir + `"
@@ -200,6 +209,8 @@ echo "AIKit Runner: backend=$BACKEND model=$MODEL_LOG_REF"
 	switch backend {
 	case utils.BackendLlamaCpp:
 		sb.WriteString(generateLlamaCppDownload())
+	case utils.BackendParakeetCpp:
+		sb.WriteString(generateParakeetCppDownload())
 	case utils.BackendVLLMCpp:
 		sb.WriteString(generateVLLMCppDownload())
 	case utils.BackendDiffusers, utils.BackendVLLM:
@@ -318,6 +329,219 @@ parameters:
   model: ${YAML_MODEL_PATH}
 CFGEOF
 mv "$CONFIG_TMP" "$RUNNER_CONFIG"
+`
+}
+
+// generateParakeetCppDownload generates download and configuration logic for
+// the parakeet.cpp backend, which accepts exactly one local GGUF model file.
+func generateParakeetCppDownload() string {
+	return `# parakeet.cpp requires one GGUF model to be materialized locally.
+MODEL_MARKER="` + runnerParakeetCppModelMarker + `"
+PARAKEET_CPP_MODEL_DIR="` + runnerParakeetCppModelDir + `"
+PARAKEET_CPP_PAYLOAD_DIR="$PARAKEET_CPP_MODEL_DIR/payload"
+SAFE_GGUF_FILENAME_REGEX='^[A-Za-z0-9][A-Za-z0-9._-]*\.gguf$'
+SAFE_GGUF_PATH_REGEX='^([A-Za-z0-9][A-Za-z0-9._-]*/)*[A-Za-z0-9][A-Za-z0-9._-]*\.gguf$'
+EXPECTED_GGUF_RELATIVE_PATH=""
+HF_REPOSITORY=""
+HF_REVISION=""
+HF_FILENAME=""
+
+# Locate the sole safe GGUF in the backend-owned payload. The null-delimited
+# traversal remains correct even if a mounted cache contains hostile filenames.
+locate_parakeet_cpp_model() {
+  PARAKEET_GGUF_COUNT=0
+  PARAKEET_GGUF_RELATIVE_PATH=""
+  PARAKEET_GGUF_PATHS_VALID="true"
+
+  local candidate relative_path
+  while IFS= read -r -d '' candidate; do
+    PARAKEET_GGUF_COUNT=$((PARAKEET_GGUF_COUNT + 1))
+    relative_path="${candidate#"$PARAKEET_CPP_PAYLOAD_DIR"/}"
+    if [[ "$relative_path" == "$candidate" ]] || [[ ! "$relative_path" =~ $SAFE_GGUF_PATH_REGEX ]]; then
+      PARAKEET_GGUF_PATHS_VALID="false"
+      continue
+    fi
+    PARAKEET_GGUF_RELATIVE_PATH="$relative_path"
+  done < <(find "$PARAKEET_CPP_PAYLOAD_DIR" -type f -name "*.gguf" -print0 2>/dev/null)
+
+  [[ "$PARAKEET_GGUF_COUNT" -eq 1 ]] && [[ "$PARAKEET_GGUF_PATHS_VALID" == "true" ]]
+}
+
+case "$MODEL_SCHEME" in
+  http|https)
+    # Strip query and fragment components before validating the local filename.
+    MODEL_URL_PATH="${MODEL%%\#*}"
+    MODEL_URL_PATH="${MODEL_URL_PATH%%\?*}"
+    GGUF_FILENAME="${MODEL_URL_PATH##*/}"
+    if [[ ! "$GGUF_FILENAME" =~ $SAFE_GGUF_FILENAME_REGEX ]]; then
+      echo "Error: parakeet-cpp direct URLs must point to a .gguf file with a safe filename" >&2
+      exit 1
+    fi
+    EXPECTED_GGUF_RELATIVE_PATH="$GGUF_FILENAME"
+    ;;
+  ?*)
+    echo "Error: parakeet-cpp supports only huggingface:// repository references or HTTP(S) .gguf URLs" >&2
+    exit 1
+    ;;
+  "")
+    # Parse org/repo[@commit][/path/to/model.gguf]. An explicit path downloads
+    # exactly that file; a bare repository is listed before selecting its only
+    # GGUF so repositories containing multiple quantizations are not downloaded.
+    if [[ "$MODEL" != */* ]]; then
+      echo "Error: invalid Hugging Face repository reference for parakeet-cpp: $MODEL" >&2
+      exit 1
+    fi
+    HF_OWNER="${MODEL%%/*}"
+    HF_REMAINDER="${MODEL#*/}"
+    HF_REPOSITORY_COMPONENT="${HF_REMAINDER%%/*}"
+    HF_REPOSITORY_NAME="${HF_REPOSITORY_COMPONENT%%@*}"
+    if [[ "$HF_REPOSITORY_COMPONENT" == *@* ]]; then
+      HF_REVISION="${HF_REPOSITORY_COMPONENT#*@}"
+      if [[ ! "$HF_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "Error: Hugging Face revisions for parakeet-cpp must be 40-character lowercase commit SHAs" >&2
+        exit 1
+      fi
+    fi
+    if [[ ! "$HF_OWNER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+      [[ ! "$HF_REPOSITORY_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+      echo "Error: invalid Hugging Face repository reference for parakeet-cpp: $MODEL" >&2
+      exit 1
+    fi
+    HF_REPOSITORY="$HF_OWNER/$HF_REPOSITORY_NAME"
+    if [[ "$HF_REMAINDER" == */* ]]; then
+      HF_FILENAME="${HF_REMAINDER#*/}"
+      if [[ ! "$HF_FILENAME" =~ $SAFE_GGUF_PATH_REGEX ]]; then
+        echo "Error: parakeet-cpp Hugging Face file references must point to a safe .gguf path" >&2
+        exit 1
+      fi
+      EXPECTED_GGUF_RELATIVE_PATH="$HF_FILENAME"
+    fi
+    ;;
+esac
+
+# Reuse the payload only when its source marker matches and it still contains
+# exactly the expected model. This makes mounted /models volumes model-aware.
+CACHE_HIT="false"
+if [[ -f "$MODEL_MARKER" ]] && [[ "$(cat "$MODEL_MARKER")" == "$MODEL_CACHE_KEY" ]] &&
+  locate_parakeet_cpp_model; then
+  if [[ -z "$EXPECTED_GGUF_RELATIVE_PATH" ]] ||
+    [[ "$PARAKEET_GGUF_RELATIVE_PATH" == "$EXPECTED_GGUF_RELATIVE_PATH" ]]; then
+    CACHE_HIT="true"
+  fi
+fi
+
+if [[ "$CACHE_HIT" == "true" ]]; then
+  echo "Found cached parakeet-cpp model matching $MODEL_LOG_REF in $PARAKEET_CPP_MODEL_DIR, skipping download"
+else
+  if [[ -f "$MODEL_MARKER" ]]; then
+    echo "Cached model does not match requested parakeet-cpp model ($MODEL_LOG_REF), re-downloading"
+  fi
+
+  # Replace only the fixed backend-owned directory. Never derive a deletion
+  # target from the user-controlled model reference.
+  rm -rf ` + runnerParakeetCppModelDir + `
+  rm -f "$MODEL_MARKER" "$RUNNER_CONFIG"
+  mkdir -p "$PARAKEET_CPP_PAYLOAD_DIR"
+
+  if [[ "$MODEL_SCHEME" == "http" ]] || [[ "$MODEL_SCHEME" == "https" ]]; then
+    echo "Downloading parakeet-cpp GGUF model from URL: $MODEL_LOG_REF"
+    LOCAL_MODEL_PATH="$PARAKEET_CPP_PAYLOAD_DIR/$EXPECTED_GGUF_RELATIVE_PATH"
+    PARTIAL_PATH="${LOCAL_MODEL_PATH}.part"
+    curl -fL --progress-bar --output "$PARTIAL_PATH" "$MODEL"
+    mv "$PARTIAL_PATH" "$LOCAL_MODEL_PATH"
+  else
+    if [[ -z "$HF_FILENAME" ]]; then
+      echo "Inspecting Hugging Face repository for parakeet-cpp: $MODEL_LOG_REF"
+      if ! HF_GGUF_LIST="$(python3 - "$HF_REPOSITORY" "$HF_REVISION" <<'PYEOF'
+import os
+import sys
+
+from huggingface_hub import HfApi
+
+repository, revision = sys.argv[1:]
+for filename in sorted(
+    HfApi(token=os.environ.get("HF_TOKEN") or None).list_repo_files(
+        repo_id=repository,
+        revision=revision or None,
+    )
+):
+    if filename.endswith(".gguf"):
+        print(filename)
+PYEOF
+)"; then
+        echo "Error: unable to list Hugging Face repository for parakeet-cpp: $MODEL_LOG_REF" >&2
+        exit 1
+      fi
+
+      HF_GGUF_COUNT=0
+      while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        if [[ ! "$candidate" =~ $SAFE_GGUF_PATH_REGEX ]]; then
+          echo "Error: Hugging Face repository contains an unsafe GGUF path: $candidate" >&2
+          exit 1
+        fi
+        HF_GGUF_COUNT=$((HF_GGUF_COUNT + 1))
+        HF_FILENAME="$candidate"
+      done <<< "$HF_GGUF_LIST"
+
+      if [[ "$HF_GGUF_COUNT" -eq 0 ]]; then
+        echo "Error: Hugging Face repository contains no GGUF files for parakeet-cpp: $MODEL_LOG_REF" >&2
+        exit 1
+      fi
+      if [[ "$HF_GGUF_COUNT" -ne 1 ]]; then
+        echo "Error: Hugging Face repository contains multiple GGUF files; select one with huggingface://org/repo/path/to/model.gguf" >&2
+        exit 1
+      fi
+      EXPECTED_GGUF_RELATIVE_PATH="$HF_FILENAME"
+    fi
+
+    echo "Downloading parakeet-cpp GGUF from Hugging Face: $MODEL_LOG_REF ($HF_FILENAME)"
+    HF_ARGS=("$HF_REPOSITORY" "$HF_FILENAME" "--local-dir" "$PARAKEET_CPP_PAYLOAD_DIR")
+    if [[ -n "$HF_REVISION" ]]; then
+      HF_ARGS+=("--revision" "$HF_REVISION")
+    fi
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+      HF_ARGS+=("--token" "$HF_TOKEN")
+    fi
+    hf download "${HF_ARGS[@]}"
+  fi
+
+  if ! locate_parakeet_cpp_model; then
+    if [[ "$PARAKEET_GGUF_PATHS_VALID" != "true" ]]; then
+      echo "Error: downloaded parakeet-cpp payload contains an unsafe GGUF path" >&2
+    elif [[ "$PARAKEET_GGUF_COUNT" -eq 0 ]]; then
+      echo "Error: no valid GGUF file was downloaded for parakeet-cpp model $MODEL_LOG_REF" >&2
+    else
+      echo "Error: parakeet-cpp requires exactly one GGUF file, but the download produced $PARAKEET_GGUF_COUNT" >&2
+    fi
+    exit 1
+  fi
+  if [[ "$PARAKEET_GGUF_RELATIVE_PATH" != "$EXPECTED_GGUF_RELATIVE_PATH" ]]; then
+    echo "Error: downloaded parakeet-cpp GGUF does not match requested file $EXPECTED_GGUF_RELATIVE_PATH" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$MODEL_CACHE_KEY" > "$MODEL_MARKER"
+  echo "Download complete"
+fi
+
+# Generate the LocalAI v4.8.2 model configuration with a path relative to the
+# backend-owned --models-path directory.
+GGUF_BASENAME="${PARAKEET_GGUF_RELATIVE_PATH##*/}"
+MODEL_NAME="${GGUF_BASENAME%.gguf}"
+CONFIG_MODEL_PATH="payload/$PARAKEET_GGUF_RELATIVE_PATH"
+mkdir -p "$RUNNER_CONFIG_DIR"
+CONFIG_TMP=$(mktemp "$RUNNER_CONFIG_DIR/.model.yaml.XXXXXX")
+cat > "$CONFIG_TMP" <<MODELEOF
+name: '${MODEL_NAME}'
+backend: parakeet-cpp
+known_usecases:
+  - transcript
+parameters:
+  model: '${CONFIG_MODEL_PATH}'
+MODELEOF
+mv "$CONFIG_TMP" "$RUNNER_CONFIG"
+echo "Config generated at $RUNNER_CONFIG"
 `
 }
 

--- a/pkg/aikit2llb/inference/runner_test.go
+++ b/pkg/aikit2llb/inference/runner_test.go
@@ -27,6 +27,10 @@ const (
 	runnerPredownloadMessage  = "Pre-downloading model"
 	runnerTestInferenceModel  = "test"
 	runnerTestInferenceSource = "http://example.com/model.gguf"
+	runnerTestFreshGGUFURL    = "https://example.com/fresh.gguf"
+	runnerDirectGGUFError     = "direct URLs must point to a .gguf file"
+	runnerVLLMCppBackendYAML  = "backend: vllm-cpp"
+	runnerUnresolvedModelYAML = `model: ${MODEL}`
 )
 
 func TestIsRunnerMode(t *testing.T) {
@@ -87,6 +91,13 @@ func TestIsRunnerMode(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "runner mode - parakeet-cpp backend with no models",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -122,6 +133,11 @@ func TestInstallRunnerDependencies(t *testing.T) {
 		{
 			name:             "vllm-cpp installs downloader dependencies",
 			backend:          utils.BackendVLLMCpp,
+			wantDependencies: true,
+		},
+		{
+			name:             "parakeet-cpp installs downloader dependencies",
+			backend:          utils.BackendParakeetCpp,
 			wantDependencies: true,
 		},
 	}
@@ -251,13 +267,35 @@ func TestGenerateRunnerScript(t *testing.T) {
 				runnerVLLMCppModelMarker,
 				runnerHFCLIInvocation,
 				runnerCurlInvocation,
-				"backend: vllm-cpp",
+				runnerVLLMCppBackendYAML,
 				"use_tokenizer_template: true",
 				runnerLocalAIExec,
 			},
 			expectMissing: []string{
 				runnerLegacyHFCLICommand,
-				`model: ${MODEL}`,
+				runnerUnresolvedModelYAML,
+			},
+		},
+		{
+			name: "parakeet-cpp backend script",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			expectContains: []string{
+				`BACKEND="parakeet-cpp"`,
+				runnerParakeetCppModelDir,
+				runnerParakeetCppModelMarker,
+				runnerHFCLIInvocation,
+				runnerCurlInvocation,
+				"backend: parakeet-cpp",
+				"known_usecases:",
+				"  - transcript",
+				runnerLocalAIExec,
+			},
+			expectMissing: []string{
+				runnerLegacyHFCLICommand,
+				runnerUnresolvedModelYAML,
+				runnerVLLMCppBackendYAML,
 			},
 		},
 		{
@@ -375,6 +413,12 @@ func TestGenerateRunnerScriptUsageMessage(t *testing.T) {
 			wantExample:   "--model org/safetensors-model",
 			rejectExample: "--model org/model\n",
 		},
+		{
+			name:          "parakeet-cpp",
+			backend:       utils.BackendParakeetCpp,
+			wantExample:   "huggingface://org/repo/model-q4_k.gguf",
+			rejectExample: "--model org/model\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -490,7 +534,7 @@ printf 'fresh' > "$output"
 	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendLlamaCpp}})
 	script = strings.ReplaceAll(script, "/models", modelsDir)
 	script = strings.Replace(script, "exec /usr/bin/local-ai", "printf 'LOCAL_AI_ARG=%s\\n'", 1)
-	model := "https://example.com/fresh.gguf"
+	model := runnerTestFreshGGUFURL
 	output, err := executeRunnerScript(t, script, binDir, model)
 	if err != nil {
 		t.Fatalf("run llama-cpp legacy cache migration: %v: %s", err, output)
@@ -568,7 +612,7 @@ printf 'fresh' > "$output"
 	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendLlamaCpp}})
 	script = strings.ReplaceAll(script, "/models", modelsDir)
 	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
-	model := "https://example.com/fresh.gguf"
+	model := runnerTestFreshGGUFURL
 	output, err := executeRunnerScript(t, script, binDir, model)
 	if err != nil {
 		t.Fatalf("replace llama-cpp cache: %v: %s", err, output)
@@ -644,6 +688,49 @@ printf 'GGUF' > "$local_dir/quantized/q3/nested.gguf"
 	}
 }
 
+func TestGenerateParakeetCppDownload(t *testing.T) {
+	script := generateParakeetCppDownload()
+
+	for _, expected := range []string{
+		runnerParakeetCppModelMarker,
+		`PARAKEET_CPP_MODEL_DIR="` + runnerParakeetCppModelDir + `"`,
+		`PARAKEET_CPP_PAYLOAD_DIR="$PARAKEET_CPP_MODEL_DIR/payload"`,
+		`hf download`,
+		`HfApi(token=os.environ.get("HF_TOKEN") or None).list_repo_files`,
+		`HF_ARGS=("$HF_REPOSITORY" "$HF_FILENAME"`,
+		runnerCurlInvocation,
+		`--output "$PARTIAL_PATH"`,
+		`-print0`,
+		`backend: parakeet-cpp`,
+		`known_usecases:`,
+		`  - transcript`,
+		`name: '${MODEL_NAME}'`,
+		`model: '${CONFIG_MODEL_PATH}'`,
+		`MODEL_CACHE_KEY`,
+		`requires exactly one GGUF file`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Errorf("parakeet-cpp download script does not contain %q", expected)
+		}
+	}
+
+	for _, unexpected := range []string{
+		`"--include" "*.gguf"`,
+		runnerUnresolvedModelYAML,
+		runnerLegacyHFCLICommand,
+	} {
+		if strings.Contains(script, unexpected) {
+			t.Errorf("parakeet-cpp download script should not contain %q", unexpected)
+		}
+	}
+
+	cmd := exec.Command("bash", "-n")
+	cmd.Stdin = strings.NewReader(generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendParakeetCpp}}))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("parakeet-cpp runner script has invalid shell syntax: %v: %s", err, output)
+	}
+}
+
 func TestGenerateVLLMCppDownload(t *testing.T) {
 	script := generateVLLMCppDownload()
 
@@ -662,7 +749,7 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 		`"--exclude" "*.gguf"`,
 		runnerCurlInvocation,
 		`\.gguf$`,
-		`backend: vllm-cpp`,
+		runnerVLLMCppBackendYAML,
 		`name: '${MODEL_NAME}'`,
 		`model: '${CONFIG_MODEL_PATH}'`,
 		`use_tokenizer_template: true`,
@@ -675,7 +762,7 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 	}
 
 	for _, unexpected := range []string{
-		`model: ${MODEL}`,
+		runnerUnresolvedModelYAML,
 		runnerLegacyHFCLICommand,
 	} {
 		if strings.Contains(script, unexpected) {
@@ -691,11 +778,17 @@ func TestGenerateVLLMCppDownload(t *testing.T) {
 }
 
 func TestRunnerBackendsUseSeparateModelMarkers(t *testing.T) {
-	if runnerLlamaCppModelMarker == runnerVLLMCppModelMarker {
-		t.Fatal("llama-cpp and vllm-cpp must not share a model cache marker")
+	markers := []string{runnerLlamaCppModelMarker, runnerParakeetCppModelMarker, runnerVLLMCppModelMarker}
+	for markerIndex, marker := range markers {
+		for otherIndex := markerIndex + 1; otherIndex < len(markers); otherIndex++ {
+			if marker == markers[otherIndex] {
+				t.Fatalf("native runner backends must not share model cache marker %q", marker)
+			}
+		}
 	}
 
 	llamaScript := generateLlamaCppDownload()
+	parakeetScript := generateParakeetCppDownload()
 	vllmCppScript := generateVLLMCppDownload()
 	if !strings.Contains(llamaScript, runnerLlamaCppModelMarker) || strings.Contains(llamaScript, runnerVLLMCppModelMarker) {
 		t.Fatal("llama-cpp download script does not use only its backend-scoped marker")
@@ -703,8 +796,455 @@ func TestRunnerBackendsUseSeparateModelMarkers(t *testing.T) {
 	if !strings.Contains(vllmCppScript, runnerVLLMCppModelMarker) || strings.Contains(vllmCppScript, runnerLlamaCppModelMarker) {
 		t.Fatal("vllm-cpp download script does not use only its backend-scoped marker")
 	}
+	if !strings.Contains(parakeetScript, runnerParakeetCppModelMarker) ||
+		strings.Contains(parakeetScript, runnerLlamaCppModelMarker) ||
+		strings.Contains(parakeetScript, runnerVLLMCppModelMarker) {
+		t.Fatal("parakeet-cpp download script does not use only its backend-scoped marker")
+	}
 	if !strings.Contains(llamaScript, `find "$LLAMA_CPP_PAYLOAD_DIR"`) || strings.Contains(llamaScript, "| head") {
 		t.Fatal("llama-cpp lookup must recursively search only its owned cache and avoid pipelines")
+	}
+}
+
+func TestParakeetCppRunnerDownloadsDirectGGUFLocally(t *testing.T) {
+	script, modelsDir, binDir := prepareParakeetCppRunnerScript(t)
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'PARAKEET' > "$output"
+`)
+
+	model := "https://example.com/tdt_ctc-110m-q4_k.gguf?download=1#weights"
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("run parakeet-cpp direct GGUF flow: %v: %s", err, output)
+	}
+
+	modelDir := runnerPathInTestModels(modelsDir, runnerParakeetCppModelDir)
+	modelPath := filepath.Join(modelDir, "payload", "tdt_ctc-110m-q4_k.gguf")
+	wantConfig := "name: 'tdt_ctc-110m-q4_k'\n" +
+		"backend: parakeet-cpp\n" +
+		"known_usecases:\n" +
+		"  - transcript\n" +
+		"parameters:\n" +
+		"  model: 'payload/tdt_ctc-110m-q4_k.gguf'\n"
+	assertRunnerFileContent(t, filepath.Join(modelDir, runnerConfigFilename), wantConfig)
+	assertRunnerFileContent(t, modelPath, "PARAKEET")
+	assertRunnerFileContent(t, filepath.Join(modelsDir, filepath.Base(runnerParakeetCppModelMarker)), runnerModelCacheKey(model)+"\n")
+
+	writeRunnerStub(t, binDir, "curl", "#!/bin/bash\nexit 91\n")
+	output, err = executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("reuse cached parakeet-cpp GGUF: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "Found cached parakeet-cpp model matching") {
+		t.Fatalf("parakeet-cpp cache hit was not detected: %s", output)
+	}
+}
+
+func TestParakeetCppRunnerDownloadsPinnedHuggingFaceFile(t *testing.T) {
+	script, modelsDir, binDir := prepareParakeetCppRunnerScript(t)
+	hfArgsLog := filepath.Join(t.TempDir(), "hf-args")
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" > "$HF_ARGS_LOG"
+repository="$2"
+filename="$3"
+shift 3
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ "$repository" == "org/parakeet" ]]
+[[ -n "$filename" ]]
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir/$(dirname "$filename")"
+printf 'PARAKEET' > "$local_dir/$filename"
+`)
+
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+	model := "huggingface://org/parakeet@" + revision + "/weights/tdt_ctc-110m-f16.gguf"
+	output, err := executeRunnerScript(t, script, binDir, model, "HF_ARGS_LOG="+hfArgsLog, "HF_TOKEN=test-token")
+	if err != nil {
+		t.Fatalf("run pinned parakeet-cpp Hugging Face file flow: %v: %s", err, output)
+	}
+
+	modelDir := runnerPathInTestModels(modelsDir, runnerParakeetCppModelDir)
+	wantConfig := "name: 'tdt_ctc-110m-f16'\n" +
+		"backend: parakeet-cpp\n" +
+		"known_usecases:\n" +
+		"  - transcript\n" +
+		"parameters:\n" +
+		"  model: 'payload/weights/tdt_ctc-110m-f16.gguf'\n"
+	assertRunnerFileContent(t, filepath.Join(modelDir, runnerConfigFilename), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(modelDir, "payload", "weights", "tdt_ctc-110m-f16.gguf"), "PARAKEET")
+
+	hfArgs, err := os.ReadFile(hfArgsLog)
+	if err != nil {
+		t.Fatalf("read hf arguments: %v", err)
+	}
+	for _, argument := range []string{
+		"org/parakeet\n",
+		"weights/tdt_ctc-110m-f16.gguf\n",
+		"--revision\n" + revision + "\n",
+		"--token\ntest-token\n",
+	} {
+		if !strings.Contains(string(hfArgs), argument) {
+			t.Errorf("hf arguments do not contain %q: %s", argument, hfArgs)
+		}
+	}
+	if strings.Contains(string(hfArgs), "--include") {
+		t.Errorf("exact Hugging Face file download should not use a broad include: %s", hfArgs)
+	}
+}
+
+func TestParakeetCppRunnerSelectsOnlyGGUFInRepository(t *testing.T) {
+	script, modelsDir, binDir := prepareParakeetCppRunnerScript(t)
+	hfArgsLog := filepath.Join(t.TempDir(), "hf-args")
+	pythonArgsLog := filepath.Join(t.TempDir(), "python-args")
+	writeRunnerStub(t, binDir, "python3", `#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" > "$PYTHON_ARGS_LOG"
+printf 'nested/only-q4_k.gguf\n'
+`)
+	writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$@" > "$HF_ARGS_LOG"
+filename="$3"
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+mkdir -p "$local_dir/$(dirname "$filename")"
+printf 'PARAKEET' > "$local_dir/$filename"
+`)
+
+	model := "huggingface://org/single-gguf"
+	output, err := executeRunnerScript(
+		t,
+		script,
+		binDir,
+		model,
+		"HF_ARGS_LOG="+hfArgsLog,
+		"PYTHON_ARGS_LOG="+pythonArgsLog,
+		"HF_TOKEN=test-token",
+	)
+	if err != nil {
+		t.Fatalf("run unique parakeet-cpp Hugging Face repository flow: %v: %s", err, output)
+	}
+
+	hfArgs, err := os.ReadFile(hfArgsLog)
+	if err != nil {
+		t.Fatalf("read hf arguments: %v", err)
+	}
+	if !strings.HasPrefix(string(hfArgs), "download\norg/single-gguf\nnested/only-q4_k.gguf\n") {
+		t.Errorf("hf downloader did not receive the selected file as a positional argument: %s", hfArgs)
+	}
+	for _, broadDownload := range []string{"--include", "*.gguf"} {
+		if strings.Contains(string(hfArgs), broadDownload) {
+			t.Errorf("single-GGUF repository download unexpectedly contains %q: %s", broadDownload, hfArgs)
+		}
+	}
+	pythonArgs, err := os.ReadFile(pythonArgsLog)
+	if err != nil {
+		t.Fatalf("read Python listing arguments: %v", err)
+	}
+	if !strings.Contains(string(pythonArgs), "-\norg/single-gguf\n") {
+		t.Errorf("repository preflight did not receive the expected repository: %s", pythonArgs)
+	}
+
+	modelDir := runnerPathInTestModels(modelsDir, runnerParakeetCppModelDir)
+	wantConfig := "name: 'only-q4_k'\n" +
+		"backend: parakeet-cpp\n" +
+		"known_usecases:\n" +
+		"  - transcript\n" +
+		"parameters:\n" +
+		"  model: 'payload/nested/only-q4_k.gguf'\n"
+	assertRunnerFileContent(t, filepath.Join(modelDir, runnerConfigFilename), wantConfig)
+	assertRunnerFileContent(t, filepath.Join(modelDir, "payload", "nested", "only-q4_k.gguf"), "PARAKEET")
+
+	writeRunnerStub(t, binDir, "python3", "#!/bin/bash\nexit 91\n")
+	writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nexit 92\n")
+	output, err = executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("reuse cached bare-repository parakeet-cpp GGUF: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "Found cached parakeet-cpp model matching org/single-gguf") {
+		t.Fatalf("bare-repository parakeet-cpp cache hit was not detected: %s", output)
+	}
+}
+
+func TestParakeetCppRunnerRejectsAmbiguousOrInvalidRepositoriesBeforeDownload(t *testing.T) {
+	tests := []struct {
+		name          string
+		listing       string
+		wantError     string
+		pythonFailure bool
+	}{
+		{
+			name:      "missing GGUF",
+			wantError: "contains no GGUF files",
+		},
+		{
+			name:      "multiple quantizations",
+			listing:   "model-f16.gguf\nmodel-q4_k.gguf\n",
+			wantError: "contains multiple GGUF files",
+		},
+		{
+			name:      "unsafe path",
+			listing:   "../escape.gguf\n",
+			wantError: "contains an unsafe GGUF path",
+		},
+		{
+			name:          "listing failure",
+			wantError:     "unable to list Hugging Face repository",
+			pythonFailure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, _, binDir := prepareParakeetCppRunnerScript(t)
+			hfCalled := filepath.Join(t.TempDir(), "hf-called")
+			pythonScript := "#!/bin/bash\nset -euo pipefail\nprintf '%s' '" + tt.listing + "'\n"
+			if tt.pythonFailure {
+				pythonScript = "#!/bin/bash\nexit 92\n"
+			}
+			writeRunnerStub(t, binDir, "python3", pythonScript)
+			writeRunnerStub(t, binDir, "hf", "#!/bin/bash\nprintf 'called\\n' > \"$HF_CALLED\"\n")
+
+			output, err := executeRunnerScript(t, script, binDir, "huggingface://org/repo", "HF_CALLED="+hfCalled)
+			if err == nil {
+				t.Fatalf("invalid Hugging Face repository unexpectedly succeeded: %s", output)
+			}
+			if !strings.Contains(string(output), tt.wantError) {
+				t.Errorf("error output does not contain %q: %s", tt.wantError, output)
+			}
+			if _, err := os.Stat(hfCalled); !os.IsNotExist(err) {
+				t.Errorf("hf downloader ran before repository validation; stat error = %v", err)
+			}
+		})
+	}
+}
+
+func TestParakeetCppRunnerValidatesDownloadedPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		wantError string
+	}{
+		{
+			name:      "missing requested file",
+			mode:      "missing",
+			wantError: "no valid GGUF file was downloaded",
+		},
+		{
+			name:      "multiple GGUF files",
+			mode:      "multiple",
+			wantError: "requires exactly one GGUF file",
+		},
+		{
+			name:      "wrong GGUF file",
+			mode:      "wrong",
+			wantError: "does not match requested file",
+		},
+		{
+			name:      "unsafe GGUF filename",
+			mode:      "unsafe",
+			wantError: "payload contains an unsafe GGUF path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, _, binDir := prepareParakeetCppRunnerScript(t)
+			writeRunnerStub(t, binDir, "hf", `#!/bin/bash
+set -euo pipefail
+requested="$3"
+local_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--local-dir" ]]; then
+    local_dir="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$local_dir" ]]
+case "$HF_STUB_MODE" in
+  missing)
+    ;;
+  multiple)
+    printf 'one' > "$local_dir/one.gguf"
+    printf 'two' > "$local_dir/two.gguf"
+    ;;
+  wrong)
+    printf 'wrong' > "$local_dir/wrong.gguf"
+    ;;
+  unsafe)
+    printf 'unsafe' > "$local_dir/bad name.gguf"
+    ;;
+esac
+`)
+
+			output, err := executeRunnerScript(
+				t,
+				script,
+				binDir,
+				"huggingface://org/repo/requested.gguf",
+				"HF_STUB_MODE="+tt.mode,
+			)
+			if err == nil {
+				t.Fatalf("invalid parakeet-cpp payload unexpectedly succeeded: %s", output)
+			}
+			if !strings.Contains(string(output), tt.wantError) {
+				t.Errorf("error output does not contain %q: %s", tt.wantError, output)
+			}
+		})
+	}
+}
+
+func TestParakeetCppRunnerRepairsOnlyOwnedCache(t *testing.T) {
+	script, modelsDir, binDir := prepareParakeetCppRunnerScript(t)
+	model := runnerTestFreshGGUFURL
+	modelDir := runnerPathInTestModels(modelsDir, runnerParakeetCppModelDir)
+	payloadDir := filepath.Join(modelDir, "payload")
+	if err := os.MkdirAll(payloadDir, 0o755); err != nil {
+		t.Fatalf("create parakeet-cpp payload directory: %v", err)
+	}
+
+	seedFiles := map[string]string{
+		filepath.Join(payloadDir, "stale-one.gguf"):                           "stale one",
+		filepath.Join(payloadDir, "stale-two.gguf"):                           "stale two",
+		filepath.Join(modelsDir, "user.gguf"):                                 "user model",
+		filepath.Join(modelsDir, "user.yaml"):                                 "name: user-owned\n",
+		filepath.Join(modelsDir, filepath.Base(runnerParakeetCppModelMarker)): runnerModelCacheKey(model) + "\n",
+	}
+	for path, content := range seedFiles {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("seed runner file %q: %v", path, err)
+		}
+	}
+
+	writeRunnerStub(t, binDir, "curl", `#!/bin/bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output" ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[[ -n "$output" ]]
+printf 'fresh' > "$output"
+`)
+
+	output, err := executeRunnerScript(t, script, binDir, model)
+	if err != nil {
+		t.Fatalf("repair ambiguous parakeet-cpp cache: %v: %s", err, output)
+	}
+	if !strings.Contains(string(output), "does not match requested parakeet-cpp model") {
+		t.Errorf("cache repair output missing mismatch message: %s", output)
+	}
+	for _, stale := range []string{filepath.Join(payloadDir, "stale-one.gguf"), filepath.Join(payloadDir, "stale-two.gguf")} {
+		if _, err := os.Stat(stale); !os.IsNotExist(err) {
+			t.Errorf("stale runner-owned GGUF remains after repair; stat error = %v", err)
+		}
+	}
+	for _, preserved := range []string{filepath.Join(modelsDir, "user.gguf"), filepath.Join(modelsDir, "user.yaml")} {
+		if _, err := os.Stat(preserved); err != nil {
+			t.Errorf("runner should preserve unrelated file %q: %v", preserved, err)
+		}
+	}
+	assertRunnerFileContent(t, filepath.Join(payloadDir, "fresh.gguf"), "fresh")
+}
+
+func TestParakeetCppRunnerRejectsUnsupportedModelReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantError string
+	}{
+		{
+			name:      "non-GGUF direct URL",
+			model:     "https://example.com/model.bin",
+			wantError: runnerDirectGGUFError,
+		},
+		{
+			name:      "unsafe direct URL filename",
+			model:     "https://example.com/model name.gguf",
+			wantError: runnerDirectGGUFError,
+		},
+		{
+			name:      "unsupported scheme",
+			model:     "s3://bucket/model.gguf",
+			wantError: "supports only huggingface:// repository references or HTTP(S) .gguf URLs",
+		},
+		{
+			name:      "missing repository owner",
+			model:     "repository",
+			wantError: "invalid Hugging Face repository reference",
+		},
+		{
+			name:      "unsafe repository owner",
+			model:     "../repository/model.gguf",
+			wantError: "invalid Hugging Face repository reference",
+		},
+		{
+			name:      "mutable named revision",
+			model:     "org/repo@main/model.gguf",
+			wantError: "revisions for parakeet-cpp must be 40-character lowercase commit SHAs",
+		},
+		{
+			name:      "uppercase commit revision",
+			model:     "org/repo@0123456789ABCDEF0123456789abcdef01234567/model.gguf",
+			wantError: "revisions for parakeet-cpp must be 40-character lowercase commit SHAs",
+		},
+		{
+			name:      "non-GGUF repository path",
+			model:     "org/repo/model.bin",
+			wantError: "file references must point to a safe .gguf path",
+		},
+		{
+			name:      "traversing repository path",
+			model:     "org/repo/../model.gguf",
+			wantError: "file references must point to a safe .gguf path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, _, binDir := prepareParakeetCppRunnerScript(t)
+			output, err := executeRunnerScript(t, script, binDir, tt.model)
+			if err == nil {
+				t.Fatalf("model reference %q unexpectedly succeeded: %s", tt.model, output)
+			}
+			if !strings.Contains(string(output), tt.wantError) {
+				t.Errorf("error output does not contain %q: %s", tt.wantError, output)
+			}
+		})
 	}
 }
 
@@ -1033,7 +1573,7 @@ done
 printf 'GGUF' > "$output"
 `)
 
-	output, err := executeRunnerScript(t, script, binDir, "https://example.com/fresh.gguf")
+	output, err := executeRunnerScript(t, script, binDir, runnerTestFreshGGUFURL)
 	if err != nil {
 		t.Fatalf("run vllm-cpp with stale llama artifacts: %v: %s", err, output)
 	}
@@ -1150,12 +1690,12 @@ func TestVLLMCppRunnerRejectsUnsupportedModelReferences(t *testing.T) {
 		{
 			name:      "non-GGUF direct URL",
 			model:     "https://example.com/model.safetensors",
-			wantError: "direct URLs must point to a .gguf file",
+			wantError: runnerDirectGGUFError,
 		},
 		{
 			name:      "unsafe GGUF filename",
 			model:     "https://example.com/model name.gguf",
-			wantError: "direct URLs must point to a .gguf file",
+			wantError: runnerDirectGGUFError,
 		},
 		{
 			name:      "unsupported URL scheme",
@@ -1289,6 +1829,25 @@ func TestRunnerModelNameScript(t *testing.T) {
 			}
 		})
 	}
+}
+
+func prepareParakeetCppRunnerScript(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	testRoot := t.TempDir()
+	modelsDir := filepath.Join(testRoot, "models")
+	binDir := filepath.Join(testRoot, "bin")
+	for _, dir := range []string{modelsDir, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create runner test directory %q: %v", dir, err)
+		}
+	}
+
+	script := generateRunnerScript(&config.InferenceConfig{Backends: []string{utils.BackendParakeetCpp}})
+	script = strings.ReplaceAll(script, "/models", modelsDir)
+	script = strings.Replace(script, "exec /usr/bin/local-ai", "exec true", 1)
+
+	return script, modelsDir, binDir
 }
 
 func prepareVLLMCppRunnerScript(t *testing.T) (string, string, string) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -851,7 +851,7 @@ func validateInferenceConfig(c *config.InferenceConfig) error {
 		}
 	}
 
-	backends := []string{utils.BackendLlamaCpp, utils.BackendDiffusers, utils.BackendVLLM, utils.BackendVLLMCpp}
+	backends := []string{utils.BackendLlamaCpp, utils.BackendDiffusers, utils.BackendParakeetCpp, utils.BackendVLLM, utils.BackendVLLMCpp}
 	for _, b := range c.Backends {
 		if !slices.Contains(backends, b) {
 			return errors.Errorf("backend %s is not supported", b)
@@ -868,10 +868,15 @@ func validateInferenceConfig(c *config.InferenceConfig) error {
 
 // validateBackendPlatformCompatibility validates that backends are compatible with target platforms.
 func validateBackendPlatformCompatibility(c *config.InferenceConfig, targetPlatforms []*specs.Platform) error {
-	if slices.Contains(c.Backends, utils.BackendVLLMCpp) {
+	nativePortableBackends := []string{utils.BackendParakeetCpp, utils.BackendVLLMCpp}
+	for _, backend := range nativePortableBackends {
+		if !slices.Contains(c.Backends, backend) {
+			continue
+		}
+
 		for _, tp := range targetPlatforms {
 			if tp != nil && tp.OS != utils.PlatformLinux {
-				return errors.Errorf("vllm-cpp backend is not supported on %s. only linux is supported", tp.OS)
+				return errors.Errorf("%s backend is not supported on %s. only linux is supported", backend, tp.OS)
 			}
 		}
 
@@ -879,17 +884,17 @@ func validateBackendPlatformCompatibility(c *config.InferenceConfig, targetPlatf
 		case "":
 			for _, tp := range targetPlatforms {
 				if tp != nil && tp.Architecture != utils.PlatformAMD64 && tp.Architecture != utils.PlatformARM64 {
-					return errors.Errorf("vllm-cpp backend with CPU runtime is not supported on %s architecture", tp.Architecture)
+					return errors.Errorf("%s backend with CPU runtime is not supported on %s architecture", backend, tp.Architecture)
 				}
 			}
 		case utils.RuntimeNVIDIA:
 			for _, tp := range targetPlatforms {
 				if tp != nil && tp.Architecture != utils.PlatformAMD64 {
-					return errors.Errorf("vllm-cpp backend with cuda runtime is not supported on %s architecture. only amd64 is supported", tp.Architecture)
+					return errors.Errorf("%s backend with cuda runtime is not supported on %s architecture. only amd64 is supported", backend, tp.Architecture)
 				}
 			}
 		default:
-			return errors.Errorf("vllm-cpp backend does not support %s runtime", c.Runtime)
+			return errors.Errorf("%s backend does not support %s runtime", backend, c.Runtime)
 		}
 	}
 
@@ -913,10 +918,10 @@ func validateBackendPlatformCompatibility(c *config.InferenceConfig, targetPlatf
 			if backend == utils.BackendLlamaCpp {
 				continue
 			}
-			if backend == utils.BackendVLLMCpp && c.Runtime == "" {
+			if (backend == utils.BackendParakeetCpp || backend == utils.BackendVLLMCpp) && c.Runtime == "" {
 				continue
 			}
-			return errors.Errorf("backend %s with runtime %q is not supported on arm64 platform. only llama-cpp and CPU vllm-cpp support arm64", backend, c.Runtime)
+			return errors.Errorf("backend %s with runtime %q is not supported on arm64 platform. only llama-cpp, CPU parakeet-cpp, and CPU vllm-cpp support arm64", backend, c.Runtime)
 		}
 	}
 

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -170,6 +170,53 @@ func Test_validateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid parakeet-cpp backend with CPU runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Backends:   []string{utils.BackendParakeetCpp},
+				Models: []config.Model{
+					{
+						Name:   "parakeet",
+						Source: "parakeet-cpu.gguf",
+					},
+				},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid parakeet-cpp backend with cuda runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendParakeetCpp},
+				Models: []config.Model{
+					{
+						Name:   "parakeet",
+						Source: "parakeet-cuda.gguf",
+					},
+				},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "parakeet-cpp backend rejects rocm runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Runtime:    utils.RuntimeROCm,
+				Backends:   []string{utils.BackendParakeetCpp},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "parakeet-cpp backend rejects apple silicon runtime",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Runtime:    utils.RuntimeAppleSilicon,
+				Backends:   []string{utils.BackendParakeetCpp},
+			}},
+			wantErr: true,
+		},
+		{
 			name: "invalid backend name",
 			args: args{c: &config.InferenceConfig{
 				APIVersion: "v1alpha1",
@@ -217,6 +264,23 @@ func Test_validateConfig(t *testing.T) {
 				APIVersion: "v1alpha1",
 				Runtime:    "cuda",
 				Backends:   []string{"vllm"},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid runner mode - parakeet-cpp with CPU",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Backends:   []string{utils.BackendParakeetCpp},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid runner mode - parakeet-cpp with cuda",
+			args: args{c: &config.InferenceConfig{
+				APIVersion: utils.APIv1alpha1,
+				Runtime:    utils.RuntimeNVIDIA,
+				Backends:   []string{utils.BackendParakeetCpp},
 			}},
 			wantErr: false,
 		},
@@ -427,6 +491,79 @@ func Test_validateBackendPlatformCompatibility(t *testing.T) {
 			},
 			targetPlatforms: []*specs.Platform{
 				{Architecture: utils.PlatformAMD64, OS: "windows"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "parakeet-cpp CPU backend with amd64 platform - should pass",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "parakeet-cpp CPU backend with arm64 platform - should pass",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "parakeet-cpp CPU backend with mixed platforms - should pass",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux},
+				{Architecture: utils.PlatformARM64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "parakeet-cpp CUDA backend with amd64 platform - should pass",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformAMD64, OS: utils.PlatformLinux},
+			},
+			wantErr: false,
+		},
+		{
+			name: "parakeet-cpp CUDA backend with arm64 platform - should fail",
+			config: &config.InferenceConfig{
+				Runtime:  utils.RuntimeNVIDIA,
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: utils.PlatformLinux},
+			},
+			wantErr: true,
+		},
+		{
+			name: "parakeet-cpp CPU backend with unsupported architecture - should fail",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: "ppc64le", OS: utils.PlatformLinux},
+			},
+			wantErr: true,
+		},
+		{
+			name: "parakeet-cpp CPU backend with non-linux platform - should fail",
+			config: &config.InferenceConfig{
+				Backends: []string{utils.BackendParakeetCpp},
+			},
+			targetPlatforms: []*specs.Platform{
+				{Architecture: utils.PlatformARM64, OS: "freebsd"},
 			},
 			wantErr: true,
 		},

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -5,10 +5,11 @@ const (
 	RuntimeROCm         = "rocm"
 	RuntimeAppleSilicon = "applesilicon" // experimental apple silicon runtime with vulkan arm64 support
 
-	BackendDiffusers = "diffusers"
-	BackendLlamaCpp  = "llama-cpp"
-	BackendVLLM      = "vllm"
-	BackendVLLMCpp   = "vllm-cpp"
+	BackendDiffusers   = "diffusers"
+	BackendLlamaCpp    = "llama-cpp"
+	BackendParakeetCpp = "parakeet-cpp"
+	BackendVLLM        = "vllm"
+	BackendVLLMCpp     = "vllm-cpp"
 
 	BackendOCIRegistry = "quay.io/go-skynet/local-ai-backends"
 

--- a/runners/parakeet-cpp-cpu.yaml
+++ b/runners/parakeet-cpp-cpu.yaml
@@ -1,0 +1,4 @@
+#syntax=ghcr.io/kaito-project/aikit/aikit:latest
+apiVersion: v1alpha1
+backends:
+  - parakeet-cpp

--- a/runners/parakeet-cpp-cuda.yaml
+++ b/runners/parakeet-cpp-cuda.yaml
@@ -1,0 +1,5 @@
+#syntax=ghcr.io/kaito-project/aikit/aikit:latest
+apiVersion: v1alpha1
+runtime: cuda
+backends:
+  - parakeet-cpp


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds LocalAI v4.8.2 parakeet.cpp speech-to-text support for CPU and NVIDIA CUDA deployments.

- Supports Linux CPU on amd64 and arm64, plus CUDA 12 on amd64.
- Adds secure GGUF downloading, model-aware caching, and LocalAI configuration generation for runner images.
- Installs FFmpeg so Parakeet can normalize noncanonical audio inputs.
- Adds CPU and CUDA runner definitions, release matrices, and pinned transcription CI coverage.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Validation completed:

- go test -race -count=1 ./...
- golangci-lint run -v ./... --timeout 5m --new-from-rev=HEAD: zero issues
- actionlint and YAML parsing passed; the existing custom gpu runner label was allowed
- Built and ran the Linux arm64 CPU runner with LocalAI v4.8.2
- A stereo 44.1 kHz fixture produced the exact expected transcript
- Runtime hygiene checks passed and the compressed arm64 image is about 235 MiB, below its 250 MiB budget

CUDA execution requires the existing self-hosted GPU workflow. ROCm support is intentionally out of scope.