### PR TITLE
feat(models): add Muse Glimmer 30B

### DIFF
--- a/.github/workflows/update-models.yaml
+++ b/.github/workflows/update-models.yaml
@@ -11,7 +11,7 @@ on:
       models:
         description: "models to update"
         required: true
-        default: '["llama-3.2-1b-instruct", "llama-3.2-3b-instruct", "llama-3.1-8b-instruct", "phi-4-14b-instruct", "gemma-2-2b-instruct", "flux-1-dev", "llama-3.3-70b-instruct", "mixtral-8x7b-instruct", "codestral-22b", "qwq-32b", "gpt-oss-20b", "gpt-oss-120b"]'
+        default: '["llama-3.2-1b-instruct", "llama-3.2-3b-instruct", "llama-3.1-8b-instruct", "phi-4-14b-instruct", "gemma-2-2b-instruct", "flux-1-dev", "llama-3.3-70b-instruct", "mixtral-8x7b-instruct", "codestral-22b", "qwq-32b", "gpt-oss-20b", "gpt-oss-120b", "muse-glimmer-30b"]'
         type: string
       runtime:
         description: "runtime to build"
@@ -35,6 +35,8 @@ jobs:
         runtime: ${{ fromJSON(github.event.inputs.runtime) }}
         exclude:
         - model: flux-1-dev # requires cuda runtime
+          runtime: applesilicon
+        - model: muse-glimmer-30b # legacy Apple Silicon backend lacks Muse support
           runtime: applesilicon
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 360

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If it doesn't include a specific model, you can always [create your own images](
 | ⌨️ Codestral 0.1 | Code         | 22B        | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/codestral:22b` | `codestral-22b`          | [MNLP](https://mistral.ai/licenses/MNPL-0.1.md)                                    |
 | 🤖 GPT-OSS       |              | 20B        | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/gpt-oss:20b`   | `gpt-oss-20b`            | [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)                      |
 | 🤖 GPT-OSS       |              | 120B       | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/gpt-oss:120b`  | `gpt-oss-120b`           | [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)                      |
+| ✨ Muse Glimmer   | Vision + DFlash | 30B     | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/muse-glimmer:30b` | `muse-glimmer-30b`    | [Apache 2.0](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/blob/main/LICENSE) |
 
 
 ### NVIDIA CUDA

--- a/models/muse-glimmer-30b.yaml
+++ b/models/muse-glimmer-30b.yaml
@@ -1,6 +1,7 @@
 #syntax=ghcr.io/kaito-project/aikit/aikit:latest
 apiVersion: v1alpha1
 debug: true
+runtime: cuda
 models:
   - name: muse-glimmer-30b
     source: https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/resolve/a0532f7263ee67f1e0a5f5c5fdcd50dd62fc9aa4/muse-glimmer-30B-kquant-17gb.gguf

--- a/models/muse-glimmer-30b.yaml
+++ b/models/muse-glimmer-30b.yaml
@@ -1,0 +1,37 @@
+#syntax=ghcr.io/kaito-project/aikit/aikit:latest
+apiVersion: v1alpha1
+debug: true
+models:
+  - name: muse-glimmer-30b
+    source: https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/resolve/a0532f7263ee67f1e0a5f5c5fdcd50dd62fc9aa4/muse-glimmer-30B-kquant-17gb.gguf
+    sha256: "7e9b74b7c8875e9e265695df9613bf6290f2392e479ce740495a129019c488d8"
+  - name: muse-glimmer-30b-mmproj
+    source: https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/resolve/a0532f7263ee67f1e0a5f5c5fdcd50dd62fc9aa4/mmproj-kquant.gguf
+    sha256: "f48b452316f9b213758e8659444029b961a24a07f99a1abb2a9f88b06f7c00c6"
+  - name: muse-glimmer-30b-dflash
+    source: https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/resolve/a0532f7263ee67f1e0a5f5c5fdcd50dd62fc9aa4/dflash-kquant.gguf
+    sha256: "27d9a805fa29b943cfb6ad4843367cd4eaaaf06bd452d8cc3e00a2cd18a677bc"
+config: |
+  - name: muse-glimmer-30b
+    backend: llama-cpp
+    flash_attention: "on"
+    draft_model: dflash-kquant.gguf
+    function:
+      automatic_tool_parsing_fallback: true
+      grammar:
+        disable: true
+    known_usecases:
+      - chat
+      - vision
+    mmproj: mmproj-kquant.gguf
+    options:
+      - use_jinja:true
+      - spec_type:draft-dflash
+      - spec_n_max:15
+    parameters:
+      model: muse-glimmer-30B-kquant-17gb.gguf
+      temperature: 1.0
+      top_k: 64
+      top_p: 0.95
+    template:
+      use_tokenizer_template: true

--- a/website/docs/premade-models.md
+++ b/website/docs/premade-models.md
@@ -26,6 +26,7 @@ Depending on your CPU capabilities, AIKit will automatically select the most opt
 | QwQ             |              | 32B        | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/qwq:32b`       | `qwq-32b`                | [Apache 2.0](https://huggingface.co/Qwen/QwQ-32B/blob/main/LICENSE) |  |
 | 🤖 GPT-OSS       |              | 20B        | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/gpt-oss:20b`   | `gpt-oss-20b`            | [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)       |
 | 🤖 GPT-OSS       |              | 120B       | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/gpt-oss:120b`  | `gpt-oss-120b`           | [Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)       |
+| ✨ Muse Glimmer   | Vision + DFlash | 30B     | `docker run -d --rm -p 8080:8080 ghcr.io/kaito-project/aikit/muse-glimmer:30b` | `muse-glimmer-30b`    | [Apache 2.0](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/blob/main/LICENSE) |
 
 ## NVIDIA CUDA
 


### PR DESCRIPTION
## Summary

- Add a predefined `muse-glimmer-30b` model using the pinned 17 GB K-quant model, vision projector, and DFlash draft model.
- Enable Jinja templates, flash attention, and `draft-dflash` speculative decoding.
- Register the model in the update workflow and document the intended image.
- Exclude the legacy Apple Silicon backend, which does not recognize Muse Glimmer.

## Compatibility status

Muse Glimmer requires llama.cpp **b10353 or newer**. Support landed in [ggml-org/llama.cpp#26841](https://github.com/ggml-org/llama.cpp/pull/26841) at commit [`62bf73d`](https://github.com/ggml-org/llama.cpp/commit/62bf73d25c53b8161f8a22894d4f90c4aebbd7d0).

AIKit's current signed backend catalog pins LocalAI v4.8.2 for both CPU and CUDA llama.cpp backends. That release embeds llama.cpp **b10235** (`221f0f6`), which rejects the model with:

```text
unknown model architecture: 'muse-glimmer'
```

This PR intentionally does not introduce a CPU-only backend upgrade or asymmetric CPU/CUDA version pins. It should not be merged until Muse-capable CPU and CUDA backend artifacts can be promoted together in the backend catalog.

## Validation

- `make test` passes after rebasing onto `main`.
- The model configuration produced a successful completion on the CPU VM when paired diagnostically with the Muse-capable `sha-7cfccdc-cpu-llama-cpp` backend.
- The current v4.8.2 CUDA backend reproduced the expected architecture error on an NVIDIA A100 80 GB before model loading or GPU offload.
- The matching `sha-7cfccdc-gpu-nvidia-cuda-12-llama-cpp` artifact is not currently published.
