### PR TITLE
chore: bump LocalAI to v4.9.0

### DIFF
--- a/.github/workflows/mirror-localai.yml
+++ b/.github/workflows/mirror-localai.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "LocalAI version tag (e.g. v4.8.2)"
+        description: "LocalAI version tag (e.g. v4.9.0)"
         required: true
-        default: v4.8.2
+        default: v4.9.0
 
 permissions:
   contents: read

--- a/cmd/backendcatalog/main.go
+++ b/cmd/backendcatalog/main.go
@@ -24,7 +24,7 @@ type commandConfig struct {
 
 func main() {
 	config := commandConfig{
-		Source:  backendcatalogimport.LocalAIV482Source,
+		Source:  backendcatalogimport.LocalAIV490Source,
 		Version: backendcatalogimport.LocalAIVersion,
 		Stdout:  os.Stdout,
 	}

--- a/cmd/backendcatalog/main.go
+++ b/cmd/backendcatalog/main.go
@@ -24,7 +24,7 @@ type commandConfig struct {
 
 func main() {
 	config := commandConfig{
-		Source:  backendcatalogimport.LocalAIV490Source,
+		Source:  backendcatalogimport.LocalAISource,
 		Version: backendcatalogimport.LocalAIVersion,
 		Stdout:  os.Stdout,
 	}

--- a/cmd/backendcatalog/main_test.go
+++ b/cmd/backendcatalog/main_test.go
@@ -36,7 +36,7 @@ func TestRunWritesAndChecksCatalog(t *testing.T) {
 	arguments := []string{
 		"--source", sourcePath,
 		"--snapshot", snapshotPath,
-		"--core-ref", "registry.example/core:v4.8.2-{architecture}",
+		"--core-ref", "registry.example/core:v4.9.0-{architecture}",
 		"--output", outputPath,
 	}
 

--- a/cmd/backendcatalog/main_test.go
+++ b/cmd/backendcatalog/main_test.go
@@ -36,7 +36,7 @@ func TestRunWritesAndChecksCatalog(t *testing.T) {
 	arguments := []string{
 		"--source", sourcePath,
 		"--snapshot", snapshotPath,
-		"--core-ref", "registry.example/core:v4.9.0-{architecture}",
+		"--core-ref", "registry.example/core:" + backendcatalogimport.LocalAIVersion + "-{architecture}",
 		"--output", outputPath,
 	}
 

--- a/internal/backendcatalogimport/availability.go
+++ b/internal/backendcatalogimport/availability.go
@@ -14,26 +14,10 @@ type unavailableSourcePolicy struct {
 var reviewedUnavailableSources = []unavailableSourcePolicy{
 	{
 		Version:    LocalAIVersion,
-		Family:     "kokoros",
-		Selector:   selectorDefault,
-		Target:     "cpu-kokoros",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-kokoros",
-		ErrorClass: resolutionErrorNotFound,
-	},
-	{
-		Version:    LocalAIVersion,
 		Family:     "turboquant",
 		Selector:   selectorAMD,
 		Target:     "rocm-turboquant",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-turboquant",
-		ErrorClass: resolutionErrorNotFound,
-	},
-	{
-		Version:    LocalAIVersion,
-		Family:     familyVLLM,
-		Selector:   "intel",
-		Target:     "intel-vllm",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-vllm",
+		SourceRef:  "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-turboquant",
 		ErrorClass: resolutionErrorNotFound,
 	},
 }

--- a/internal/backendcatalogimport/availability.go
+++ b/internal/backendcatalogimport/availability.go
@@ -17,7 +17,7 @@ var reviewedUnavailableSources = []unavailableSourcePolicy{
 		Family:     "turboquant",
 		Selector:   selectorAMD,
 		Target:     "rocm-turboquant",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-turboquant",
+		SourceRef:  "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-turboquant",
 		ErrorClass: resolutionErrorNotFound,
 	},
 }

--- a/internal/backendcatalogimport/availability.go
+++ b/internal/backendcatalogimport/availability.go
@@ -13,11 +13,11 @@ type unavailableSourcePolicy struct {
 
 var reviewedUnavailableSources = []unavailableSourcePolicy{
 	{
-		Version:    LocalAIVersion,
+		Version:    reviewedLocalAIVersion,
 		Family:     "turboquant",
 		Selector:   selectorAMD,
 		Target:     "rocm-turboquant",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-turboquant",
+		SourceRef:  "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-rocm-hipblas-turboquant",
 		ErrorClass: resolutionErrorNotFound,
 	},
 }

--- a/internal/backendcatalogimport/generate.go
+++ b/internal/backendcatalogimport/generate.go
@@ -37,8 +37,8 @@ func Generate(ctx context.Context, source []byte, options GenerateOptions) (Cata
 
 func localAIReviewedPolicyRequirements() reviewedPolicyRequirements {
 	return reviewedPolicyRequirements{
-		Source:   LocalAIV490Source,
-		Version:  reviewedLocalAIVersion,
+		Source:   LocalAISource,
+		Version:  LocalAIVersion,
 		Overlays: reviewedPolicyOverlays,
 	}
 }

--- a/internal/backendcatalogimport/generate.go
+++ b/internal/backendcatalogimport/generate.go
@@ -38,7 +38,7 @@ func Generate(ctx context.Context, source []byte, options GenerateOptions) (Cata
 func localAIReviewedPolicyRequirements() reviewedPolicyRequirements {
 	return reviewedPolicyRequirements{
 		Source:   LocalAISource,
-		Version:  LocalAIVersion,
+		Version:  reviewedLocalAIVersion,
 		Overlays: reviewedPolicyOverlays,
 	}
 }

--- a/internal/backendcatalogimport/generate.go
+++ b/internal/backendcatalogimport/generate.go
@@ -37,7 +37,7 @@ func Generate(ctx context.Context, source []byte, options GenerateOptions) (Cata
 
 func localAIReviewedPolicyRequirements() reviewedPolicyRequirements {
 	return reviewedPolicyRequirements{
-		Source:   LocalAIV482Source,
+		Source:   LocalAIV490Source,
 		Version:  reviewedLocalAIVersion,
 		Overlays: reviewedPolicyOverlays,
 	}

--- a/internal/backendcatalogimport/generate_test.go
+++ b/internal/backendcatalogimport/generate_test.go
@@ -130,7 +130,7 @@ func TestGenerateDeterministicCatalog(t *testing.T) {
 		t.Fatalf("NVIDIA fallbacks = %#v, want %#v", nvidia.Fallbacks, amd64CPU.Backend)
 	}
 	vulkan := findGeneratedEntry(t, first, runnerLlamaCpp, targetVulkan, Platform{OS: platformLinux, Architecture: architectureARM64})
-	if vulkan.Version != legacyLocalAIVersion || vulkan.SourceRef != reviewedSourceVulkanLLM ||
+	if vulkan.Version != LegacyLocalAIVersion || vulkan.SourceRef != reviewedSourceVulkanLLM ||
 		vulkan.Backend.InstallName != backendInstallVulkanLLM || vulkan.Status != statusExperimental || vulkan.RunnerProfile != runnerUnsupported {
 		t.Fatalf("Vulkan legacy compatibility entry = %#v", vulkan)
 	}
@@ -141,8 +141,8 @@ func TestGenerateDeterministicCatalog(t *testing.T) {
 
 func TestGenerateAppliesReviewedOverlayToLegacyDiffusersArtifact(t *testing.T) {
 	const (
-		diffusersRef = "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-nvidia-cuda-12-diffusers"
-		legacyCore   = "registry.example/core:v3.12.1-amd64"
+		diffusersRef = "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-nvidia-cuda-12-diffusers"
+		legacyCore   = "registry.example/core:" + LegacyLocalAIVersion + "-amd64"
 	)
 	source := sourceWithDefaultFixture(t, `- name: diffusers
   capabilities:
@@ -168,7 +168,7 @@ func TestGenerateAppliesReviewedOverlayToLegacyDiffusersArtifact(t *testing.T) {
 	}
 
 	diffusers := findGeneratedEntry(t, catalog, familyDiffusers, selectorNVIDIA, linuxPlatform(architectureAMD64))
-	if diffusers.Version != legacyLocalAIVersion || diffusers.SourceRef != diffusersRef || diffusers.Status != statusSupported ||
+	if diffusers.Version != LegacyLocalAIVersion || diffusers.SourceRef != diffusersRef || diffusers.Status != statusSupported ||
 		diffusers.RunnerProfile != runnerHFConfig || diffusers.RuntimeBase.Ref != "docker.io/library/ubuntu@"+fixtureUbuntu22AMD64 {
 		t.Fatalf("Diffusers legacy compatibility entry = %#v", diffusers)
 	}
@@ -200,7 +200,7 @@ func TestGenerateRejectsReviewedPolicyMappingDrift(t *testing.T) {
 - name: cpu-llama-cpp
   uri: quay.io/go-skynet/local-ai-backends:latest-cpu-repacked-llama-cpp
 `,
-			sourceRef: "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-repacked-llama-cpp",
+			sourceRef: "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-repacked-llama-cpp",
 			wantErr:   "reviewed policy source reference drift",
 		},
 	}
@@ -229,7 +229,7 @@ func TestGenerateRejectsReviewedPolicyMappingDrift(t *testing.T) {
 func TestReviewedPolicyRequirementsApplyOnlyToExactPinnedSource(t *testing.T) {
 	requirements := localAIReviewedPolicyRequirements()
 	exact := GenerateOptions{
-		Source:  LocalAIV490Source,
+		Source:  LocalAISource,
 		Version: LocalAIVersion,
 	}
 	if !requirements.applies(exact) {
@@ -272,7 +272,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
   uri: quay.io/go-skynet/local-ai-backends:latest-gpu-nvidia-cuda-12-vllm
 `
 	vllmKey := reviewedPolicyKey{
-		Version:  reviewedLocalAIVersion,
+		Version:  LocalAIVersion,
 		Family:   familyVLLM,
 		Selector: selectorNVIDIA,
 		Platform: linuxPlatform(architectureAMD64),
@@ -314,7 +314,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				Digest:   fixtureDigestA,
 				Platform: linuxPlatform(architectureAMD64),
 			}},
-			wantErr: "reviewed policy overlay v4.9.0/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
+			wantErr: "reviewed policy overlay " + LocalAIVersion + "/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
 		},
 		{
 			name:   "missing non-default vLLM platform",
@@ -323,7 +323,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				Digest:   fixtureDigestA,
 				Platform: linuxPlatform(architectureARM64),
 			}},
-			wantErr: "reviewed policy overlay v4.9.0/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
+			wantErr: "reviewed policy overlay " + LocalAIVersion + "/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
 		},
 	}
 
@@ -342,7 +342,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				},
 			}, reviewedPolicyRequirements{
 				Source:   pin,
-				Version:  reviewedLocalAIVersion,
+				Version:  LocalAIVersion,
 				Overlays: []reviewedPolicyOverlay{vllmOverlay},
 			})
 			if test.wantErr == "" {
@@ -697,17 +697,17 @@ func TestPolicyInferencePreservesAcceleratorSemantics(t *testing.T) {
 }
 
 func TestStableVersionReference(t *testing.T) {
-	got, err := stableVersionReference("quay.io/example/backend:latest-gpu-demo", "v4.9.0")
+	got, err := stableVersionReference("quay.io/example/backend:latest-gpu-demo", LocalAIVersion)
 	if err != nil {
 		t.Fatalf("stableVersionReference() error = %v", err)
 	}
-	if want := "quay.io/example/backend:v4.9.0-gpu-demo"; got != want {
+	if want := "quay.io/example/backend:" + LocalAIVersion + "-gpu-demo"; got != want {
 		t.Fatalf("stableVersionReference() = %q, want %q", got, want)
 	}
-	if _, err := stableVersionReference("quay.io/example/backend:master-gpu-demo", "v4.9.0"); err == nil {
+	if _, err := stableVersionReference("quay.io/example/backend:master-gpu-demo", LocalAIVersion); err == nil {
 		t.Fatal("stableVersionReference() accepted a development tag")
 	}
-	if _, err := stableVersionReference("quay.io/example/backend", "v4.9.0"); err == nil {
+	if _, err := stableVersionReference("quay.io/example/backend", LocalAIVersion); err == nil {
 		t.Fatal("stableVersionReference() accepted a reference without a tag")
 	}
 }
@@ -756,11 +756,11 @@ func TestGenerateAcceptsMissingWorkloadsAndPlatformlessSpecializedCore(t *testin
 	resolver := scriptedResolver{
 		base: readSnapshot(t, "testdata/resolutions.json"),
 		manifests: staticResolver{
-			"registry.example/repo:v4.9.0-cpu-demo": {{
+			"registry.example/repo:" + LocalAIVersion + "-cpu-demo": {{
 				Digest:   fixtureDigestA,
 				Platform: Platform{OS: platformLinux, Architecture: architectureAMD64},
 			}},
-			"registry.example/core:v4.9.0-amd64": {{Digest: fixtureDigestB}},
+			"registry.example/core:" + LocalAIVersion + "-amd64": {{Digest: fixtureDigestB}},
 		},
 	}
 	catalog, err := Generate(context.Background(), source, GenerateOptions{
@@ -787,9 +787,9 @@ func TestGenerateAcceptsMissingWorkloadsAndPlatformlessSpecializedCore(t *testin
 
 func TestGenerateAppliesReviewedUnavailableSourcePolicyStrictly(t *testing.T) {
 	const (
-		availableRef = "registry.example/repo:v4.9.0-cpu-demo"
-		missingRef   = "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-turboquant"
-		coreRef      = "registry.example/core:v4.9.0-amd64"
+		availableRef = "registry.example/repo:" + LocalAIVersion + "-cpu-demo"
+		missingRef   = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-turboquant"
+		coreRef      = "registry.example/core:" + LocalAIVersion + "-amd64"
 	)
 	source := sourceWithDefaultFixture(t, `- name: demo
   capabilities:
@@ -907,11 +907,11 @@ func TestGenerateExcludesNonLinuxManifests(t *testing.T) {
 	resolver := scriptedResolver{
 		base: readSnapshot(t, "testdata/resolutions.json"),
 		manifests: staticResolver{
-			"registry.example/repo:v4.9.0-cpu-demo": {{
+			"registry.example/repo:" + LocalAIVersion + "-cpu-demo": {{
 				Digest:   fixtureDigestA,
 				Platform: Platform{OS: platformLinux, Architecture: architectureAMD64},
 			}},
-			"registry.example/repo:v4.9.0-metal-darwin-arm64-demo": {{
+			"registry.example/repo:" + LocalAIVersion + "-metal-darwin-arm64-demo": {{
 				Digest:   fixtureDigestB,
 				Platform: Platform{OS: "darwin", Architecture: architectureARM64},
 			}},
@@ -1021,7 +1021,7 @@ func (resolver versionAliasResolver) Resolve(ctx context.Context, reference stri
 		return manifests, nil
 	}
 
-	return resolver.Base.Resolve(ctx, strings.Replace(reference, resolver.From, legacyLocalAIVersion, 1))
+	return resolver.Base.Resolve(ctx, strings.Replace(reference, resolver.From, LegacyLocalAIVersion, 1))
 }
 
 func readFixture(t *testing.T, path string) []byte {

--- a/internal/backendcatalogimport/generate_test.go
+++ b/internal/backendcatalogimport/generate_test.go
@@ -272,7 +272,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
   uri: quay.io/go-skynet/local-ai-backends:latest-gpu-nvidia-cuda-12-vllm
 `
 	vllmKey := reviewedPolicyKey{
-		Version:  LocalAIVersion,
+		Version:  reviewedLocalAIVersion,
 		Family:   familyVLLM,
 		Selector: selectorNVIDIA,
 		Platform: linuxPlatform(architectureAMD64),
@@ -342,7 +342,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				},
 			}, reviewedPolicyRequirements{
 				Source:   pin,
-				Version:  LocalAIVersion,
+				Version:  reviewedLocalAIVersion,
 				Overlays: []reviewedPolicyOverlay{vllmOverlay},
 			})
 			if test.wantErr == "" {

--- a/internal/backendcatalogimport/generate_test.go
+++ b/internal/backendcatalogimport/generate_test.go
@@ -200,7 +200,7 @@ func TestGenerateRejectsReviewedPolicyMappingDrift(t *testing.T) {
 - name: cpu-llama-cpp
   uri: quay.io/go-skynet/local-ai-backends:latest-cpu-repacked-llama-cpp
 `,
-			sourceRef: "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-repacked-llama-cpp",
+			sourceRef: "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-repacked-llama-cpp",
 			wantErr:   "reviewed policy source reference drift",
 		},
 	}
@@ -229,7 +229,7 @@ func TestGenerateRejectsReviewedPolicyMappingDrift(t *testing.T) {
 func TestReviewedPolicyRequirementsApplyOnlyToExactPinnedSource(t *testing.T) {
 	requirements := localAIReviewedPolicyRequirements()
 	exact := GenerateOptions{
-		Source:  LocalAIV482Source,
+		Source:  LocalAIV490Source,
 		Version: LocalAIVersion,
 	}
 	if !requirements.applies(exact) {
@@ -314,7 +314,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				Digest:   fixtureDigestA,
 				Platform: linuxPlatform(architectureAMD64),
 			}},
-			wantErr: "reviewed policy overlay v4.8.2/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
+			wantErr: "reviewed policy overlay v4.9.0/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
 		},
 		{
 			name:   "missing non-default vLLM platform",
@@ -323,7 +323,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				Digest:   fixtureDigestA,
 				Platform: linuxPlatform(architectureARM64),
 			}},
-			wantErr: "reviewed policy overlay v4.8.2/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
+			wantErr: "reviewed policy overlay v4.9.0/vllm/nvidia on linux/amd64/ did not produce its expected catalog entry",
 		},
 	}
 
@@ -697,17 +697,17 @@ func TestPolicyInferencePreservesAcceleratorSemantics(t *testing.T) {
 }
 
 func TestStableVersionReference(t *testing.T) {
-	got, err := stableVersionReference("quay.io/example/backend:latest-gpu-demo", "v4.8.2")
+	got, err := stableVersionReference("quay.io/example/backend:latest-gpu-demo", "v4.9.0")
 	if err != nil {
 		t.Fatalf("stableVersionReference() error = %v", err)
 	}
-	if want := "quay.io/example/backend:v4.8.2-gpu-demo"; got != want {
+	if want := "quay.io/example/backend:v4.9.0-gpu-demo"; got != want {
 		t.Fatalf("stableVersionReference() = %q, want %q", got, want)
 	}
-	if _, err := stableVersionReference("quay.io/example/backend:master-gpu-demo", "v4.8.2"); err == nil {
+	if _, err := stableVersionReference("quay.io/example/backend:master-gpu-demo", "v4.9.0"); err == nil {
 		t.Fatal("stableVersionReference() accepted a development tag")
 	}
-	if _, err := stableVersionReference("quay.io/example/backend", "v4.8.2"); err == nil {
+	if _, err := stableVersionReference("quay.io/example/backend", "v4.9.0"); err == nil {
 		t.Fatal("stableVersionReference() accepted a reference without a tag")
 	}
 }
@@ -756,11 +756,11 @@ func TestGenerateAcceptsMissingWorkloadsAndPlatformlessSpecializedCore(t *testin
 	resolver := scriptedResolver{
 		base: readSnapshot(t, "testdata/resolutions.json"),
 		manifests: staticResolver{
-			"registry.example/repo:v4.8.2-cpu-demo": {{
+			"registry.example/repo:v4.9.0-cpu-demo": {{
 				Digest:   fixtureDigestA,
 				Platform: Platform{OS: platformLinux, Architecture: architectureAMD64},
 			}},
-			"registry.example/core:v4.8.2-amd64": {{Digest: fixtureDigestB}},
+			"registry.example/core:v4.9.0-amd64": {{Digest: fixtureDigestB}},
 		},
 	}
 	catalog, err := Generate(context.Background(), source, GenerateOptions{
@@ -787,20 +787,20 @@ func TestGenerateAcceptsMissingWorkloadsAndPlatformlessSpecializedCore(t *testin
 
 func TestGenerateAppliesReviewedUnavailableSourcePolicyStrictly(t *testing.T) {
 	const (
-		availableRef = "registry.example/repo:v4.8.2-cpu-demo"
-		missingRef   = "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-kokoros"
-		coreRef      = "registry.example/core:v4.8.2-amd64"
+		availableRef = "registry.example/repo:v4.9.0-cpu-demo"
+		missingRef   = "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-turboquant"
+		coreRef      = "registry.example/core:v4.9.0-amd64"
 	)
 	source := sourceWithDefaultFixture(t, `- name: demo
   capabilities:
     default: cpu-demo
 - name: cpu-demo
   uri: registry.example/repo:latest-cpu-demo
-- name: kokoros
+- name: turboquant
   capabilities:
-    default: cpu-kokoros
-- name: cpu-kokoros
-  uri: quay.io/go-skynet/local-ai-backends:latest-cpu-kokoros
+    amd: rocm-turboquant
+- name: rocm-turboquant
+  uri: quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-turboquant
 `)
 	manifest := ResolvedManifest{
 		Digest:   fixtureDigestA,
@@ -884,7 +884,7 @@ func TestUnavailableSourcePolicyMatchingIsExact(t *testing.T) {
 	if _, found := reviewedUnavailableSource(policy.Version, policy.Family, policy.Selector, policy.Target, policy.SourceRef); !found {
 		t.Fatal("reviewedUnavailableSource() did not find exact policy")
 	}
-	if _, found := reviewedUnavailableSource(policy.Version, policy.Family, policy.Selector, "cpu-renamed-kokoros", policy.SourceRef); found {
+	if _, found := reviewedUnavailableSource(policy.Version, policy.Family, policy.Selector, "rocm-renamed-turboquant", policy.SourceRef); found {
 		t.Fatal("reviewedUnavailableSource() matched a different target")
 	}
 	if _, found := reviewedUnavailableSource(policy.Version, policy.Family, policy.Selector, policy.Target, policy.SourceRef+"-moved"); found {
@@ -907,11 +907,11 @@ func TestGenerateExcludesNonLinuxManifests(t *testing.T) {
 	resolver := scriptedResolver{
 		base: readSnapshot(t, "testdata/resolutions.json"),
 		manifests: staticResolver{
-			"registry.example/repo:v4.8.2-cpu-demo": {{
+			"registry.example/repo:v4.9.0-cpu-demo": {{
 				Digest:   fixtureDigestA,
 				Platform: Platform{OS: platformLinux, Architecture: architectureAMD64},
 			}},
-			"registry.example/repo:v4.8.2-metal-darwin-arm64-demo": {{
+			"registry.example/repo:v4.9.0-metal-darwin-arm64-demo": {{
 				Digest:   fixtureDigestB,
 				Platform: Platform{OS: "darwin", Architecture: architectureARM64},
 			}},

--- a/internal/backendcatalogimport/policy.go
+++ b/internal/backendcatalogimport/policy.go
@@ -80,7 +80,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
 		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDALLM,
-		SourceRef:            "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-llama-cpp",
+		SourceRef:            "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
 		TargetProfile:        targetCUDA12,
 		Status:               statusSupported,
 		RuntimeBaseRef:       chiseledRuntimeBase,
@@ -91,7 +91,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
 		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "rocm-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
 		TargetProfile:  targetROCm,
 		Status:         statusExperimental,
 		RuntimeBaseRef: rocmRuntimeBase,
@@ -122,7 +122,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
 		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
 		Target:         "cuda13-nvidia-l4t-arm64-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-llama-cpp",
 		TargetProfile:  targetL4TCUDA13,
 		Status:         statusExperimental,
 		RuntimeBaseRef: ubuntuRuntimeBase,
@@ -151,7 +151,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
 		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         backendTargetCUDAVLLM,
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
 		TargetProfile:  targetCUDA12,
 		Status:         statusSupported,
 		RuntimeBaseRef: ubuntu22RuntimeBase,
@@ -311,8 +311,8 @@ func policyFor(input policyInput) (entryPolicy, error) {
 		policy.Status = statusQuarantined
 	}
 
-	// LocalAI v4.8.2's CUDA 12 SGLang bundle mixes PyTorch CUDA 13.0 with
-	// TorchAudio CUDA 12.8 and exits before its gRPC service becomes ready.
+	// The CUDA 12 SGLang bundle was quarantined in v4.8.2 for mixing PyTorch
+	// CUDA 13.0 with TorchAudio CUDA 12.8. Keep it unavailable until verified.
 	if input.Family == familySGLang && policy.TargetProfile == targetCUDA12 && input.Platform.OS == platformLinux && input.Platform.Architecture == architectureAMD64 {
 		policy.Status = statusQuarantined
 	}

--- a/internal/backendcatalogimport/policy.go
+++ b/internal/backendcatalogimport/policy.go
@@ -58,7 +58,7 @@ type reviewedPolicyOverlay struct {
 
 var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -68,7 +68,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -78,9 +78,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDALLM,
-		SourceRef:            "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
+		SourceRef:            "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
 		TargetProfile:        targetCUDA12,
 		Status:               statusSupported,
 		RuntimeBaseRef:       chiseledRuntimeBase,
@@ -89,9 +89,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:            []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "rocm-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
 		TargetProfile:  targetROCm,
 		Status:         statusExperimental,
 		RuntimeBaseRef: rocmRuntimeBase,
@@ -100,7 +100,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -110,7 +110,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -120,9 +120,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
 		Target:         "cuda13-nvidia-l4t-arm64-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-cuda-13-arm64-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-nvidia-l4t-cuda-13-arm64-llama-cpp",
 		TargetProfile:  targetL4TCUDA13,
 		Status:         statusExperimental,
 		RuntimeBaseRef: ubuntuRuntimeBase,
@@ -130,7 +130,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetVulkanLLM,
 		SourceRef:      reviewedSourceVulkanLLM,
 		TargetProfile:  targetVulkan,
@@ -140,7 +140,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:  runnerUnsupported,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "cuda12-diffusers",
 		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-nvidia-cuda-12-diffusers",
 		TargetProfile:  targetCUDA12,
@@ -149,16 +149,16 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         backendTargetCUDAVLLM,
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
 		TargetProfile:  targetCUDA12,
 		Status:         statusSupported,
 		RuntimeBaseRef: ubuntu22RuntimeBase,
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -168,7 +168,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -178,7 +178,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -188,7 +188,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -223,7 +223,7 @@ func hasReviewedOverlayMapping(version, family, selector, target, sourceRef stri
 }
 
 func artifactVersionFor(requestedVersion, family, selector string) string {
-	if requestedVersion != LocalAIVersion {
+	if requestedVersion != reviewedLocalAIVersion {
 		return requestedVersion
 	}
 

--- a/internal/backendcatalogimport/policy.go
+++ b/internal/backendcatalogimport/policy.go
@@ -58,7 +58,7 @@ type reviewedPolicyOverlay struct {
 
 var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -68,7 +68,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -78,9 +78,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDALLM,
-		SourceRef:            "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
+		SourceRef:            "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
 		TargetProfile:        targetCUDA12,
 		Status:               statusSupported,
 		RuntimeBaseRef:       chiseledRuntimeBase,
@@ -89,9 +89,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:            []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "rocm-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
 		TargetProfile:  targetROCm,
 		Status:         statusExperimental,
 		RuntimeBaseRef: rocmRuntimeBase,
@@ -100,7 +100,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -110,7 +110,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -120,9 +120,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
 		Target:         "cuda13-nvidia-l4t-arm64-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-cuda-13-arm64-llama-cpp",
 		TargetProfile:  targetL4TCUDA13,
 		Status:         statusExperimental,
 		RuntimeBaseRef: ubuntuRuntimeBase,
@@ -130,7 +130,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetVulkanLLM,
 		SourceRef:      reviewedSourceVulkanLLM,
 		TargetProfile:  targetVulkan,
@@ -140,25 +140,25 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:  runnerUnsupported,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "cuda12-diffusers",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-nvidia-cuda-12-diffusers",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-nvidia-cuda-12-diffusers",
 		TargetProfile:  targetCUDA12,
 		Status:         statusSupported,
 		RuntimeBaseRef: ubuntu22RuntimeBase,
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         backendTargetCUDAVLLM,
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
 		TargetProfile:  targetCUDA12,
 		Status:         statusSupported,
 		RuntimeBaseRef: ubuntu22RuntimeBase,
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -168,7 +168,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -178,7 +178,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -188,7 +188,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -223,13 +223,13 @@ func hasReviewedOverlayMapping(version, family, selector, target, sourceRef stri
 }
 
 func artifactVersionFor(requestedVersion, family, selector string) string {
-	if requestedVersion != reviewedLocalAIVersion {
+	if requestedVersion != LocalAIVersion {
 		return requestedVersion
 	}
 
 	switch family + "/" + selector {
 	case familyDiffusers + "/" + selectorNVIDIA, runnerLlamaCpp + "/" + targetVulkan:
-		return legacyLocalAIVersion
+		return LegacyLocalAIVersion
 	default:
 		return requestedVersion
 	}

--- a/internal/backendcatalogimport/policy_test.go
+++ b/internal/backendcatalogimport/policy_test.go
@@ -14,9 +14,9 @@ func TestCompatibilityArtifactVersions(t *testing.T) {
 		selector string
 		want     string
 	}{
-		{name: "Diffusers default CUDA", version: LocalAIVersion, family: familyDiffusers, selector: selectorNVIDIA, want: legacyLocalAIVersion},
+		{name: "Diffusers default CUDA", version: LocalAIVersion, family: familyDiffusers, selector: selectorNVIDIA, want: LegacyLocalAIVersion},
 		{name: "Diffusers explicit CUDA 12", version: LocalAIVersion, family: familyDiffusers, selector: selectorNVIDIACUDA12, want: LocalAIVersion},
-		{name: "Apple Silicon Vulkan", version: LocalAIVersion, family: runnerLlamaCpp, selector: targetVulkan, want: legacyLocalAIVersion},
+		{name: "Apple Silicon Vulkan", version: LocalAIVersion, family: runnerLlamaCpp, selector: targetVulkan, want: LegacyLocalAIVersion},
 		{name: "vLLM default CUDA", version: LocalAIVersion, family: familyVLLM, selector: selectorNVIDIA, want: LocalAIVersion},
 		{name: "different imported release", version: fixtureFutureVersion, family: familyDiffusers, selector: selectorNVIDIA, want: fixtureFutureVersion},
 	}
@@ -30,14 +30,14 @@ func TestCompatibilityArtifactVersions(t *testing.T) {
 	}
 
 	const template = "registry.example/localai:" + LocalAIVersion + "-{architecture}"
-	got, err := coreReferenceTemplateForVersion(template, LocalAIVersion, legacyLocalAIVersion)
+	got, err := coreReferenceTemplateForVersion(template, LocalAIVersion, LegacyLocalAIVersion)
 	if err != nil {
 		t.Fatalf("coreReferenceTemplateForVersion() error = %v", err)
 	}
-	if want := "registry.example/localai:" + legacyLocalAIVersion + "-{architecture}"; got != want {
+	if want := "registry.example/localai:" + LegacyLocalAIVersion + "-{architecture}"; got != want {
 		t.Errorf("coreReferenceTemplateForVersion() = %q, want %q", got, want)
 	}
-	if _, err := coreReferenceTemplateForVersion("registry.example/localai:stable-{architecture}", LocalAIVersion, legacyLocalAIVersion); err == nil ||
+	if _, err := coreReferenceTemplateForVersion("registry.example/localai:stable-{architecture}", LocalAIVersion, LegacyLocalAIVersion); err == nil ||
 		!strings.Contains(err.Error(), "must contain imported version") {
 		t.Fatalf("coreReferenceTemplateForVersion() error = %v, want missing imported version", err)
 	}
@@ -115,7 +115,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			environment:       cuda12Environment,
 			runner:            runnerLlamaCpp,
 			fallbacks:         1,
-			sourceRef:         "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
+			sourceRef:         "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
 		},
 		{
 			name:            "llama ROCm",
@@ -131,7 +131,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			runner:          runnerLlamaCpp,
 			installName:     "hipblas-llama-cpp",
 			fallbacks:       1,
-			sourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
+			sourceRef:       "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
 		},
 		{
 			name:         "llama Vulkan",
@@ -214,7 +214,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			runtimeBase:  ubuntu22RuntimeBase,
 			environment:  cuda12Environment,
 			runner:       runnerHFConfig,
-			sourceRef:    "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-nvidia-cuda-12-diffusers",
+			sourceRef:    "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-nvidia-cuda-12-diffusers",
 		},
 		{
 			name:           "vllm CUDA",
@@ -227,7 +227,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			systemPackages: []string{systemPackageGCC, systemPackageLibcDev},
 			environment:    append(cuda12Environment, vllmNativeSampler),
 			runner:         runnerHFConfig,
-			sourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
+			sourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
 		},
 		{
 			name:           "vllm explicit CUDA 12 keeps native sampler",
@@ -459,7 +459,7 @@ func TestReviewedPolicyOverlayDriftFailsClosed(t *testing.T) {
 			Family:          cpuOverlay.Key.Family,
 			Selector:        cpuOverlay.Key.Selector,
 			Target:          cpuOverlay.Target,
-			SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-repacked-llama-cpp",
+			SourceRef:       "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-repacked-llama-cpp",
 			Platform:        cpuOverlay.Key.Platform,
 		})
 		if err == nil || !strings.Contains(err.Error(), "reviewed policy source reference drift") {
@@ -646,7 +646,7 @@ func TestGenericL4TProfileFollowsArtifactCUDA(t *testing.T) {
 		Family:          familyVLLMCpp,
 		Selector:        selectorNVIDIAL4T,
 		Target:          "nvidia-l4t-arm64-vllm-cpp",
-		SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm-cpp",
+		SourceRef:       "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-cuda-13-arm64-vllm-cpp",
 		Platform:        Platform{OS: platformLinux, Architecture: architectureARM64},
 	})
 	if err != nil {

--- a/internal/backendcatalogimport/policy_test.go
+++ b/internal/backendcatalogimport/policy_test.go
@@ -115,7 +115,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			environment:       cuda12Environment,
 			runner:            runnerLlamaCpp,
 			fallbacks:         1,
-			sourceRef:         "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-llama-cpp",
+			sourceRef:         "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
 		},
 		{
 			name:            "llama ROCm",
@@ -131,7 +131,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			runner:          runnerLlamaCpp,
 			installName:     "hipblas-llama-cpp",
 			fallbacks:       1,
-			sourceRef:       "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-llama-cpp",
+			sourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
 		},
 		{
 			name:         "llama Vulkan",
@@ -227,7 +227,7 @@ func TestReviewedPolicyOverlay(t *testing.T) {
 			systemPackages: []string{systemPackageGCC, systemPackageLibcDev},
 			environment:    append(cuda12Environment, vllmNativeSampler),
 			runner:         runnerHFConfig,
-			sourceRef:      "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm",
+			sourceRef:      "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
 		},
 		{
 			name:           "vllm explicit CUDA 12 keeps native sampler",
@@ -459,7 +459,7 @@ func TestReviewedPolicyOverlayDriftFailsClosed(t *testing.T) {
 			Family:          cpuOverlay.Key.Family,
 			Selector:        cpuOverlay.Key.Selector,
 			Target:          cpuOverlay.Target,
-			SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-repacked-llama-cpp",
+			SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-repacked-llama-cpp",
 			Platform:        cpuOverlay.Key.Platform,
 		})
 		if err == nil || !strings.Contains(err.Error(), "reviewed policy source reference drift") {
@@ -646,7 +646,7 @@ func TestGenericL4TProfileFollowsArtifactCUDA(t *testing.T) {
 		Family:          familyVLLMCpp,
 		Selector:        selectorNVIDIAL4T,
 		Target:          "nvidia-l4t-arm64-vllm-cpp",
-		SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vllm-cpp",
+		SourceRef:       "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm-cpp",
 		Platform:        Platform{OS: platformLinux, Architecture: architectureARM64},
 	})
 	if err != nil {

--- a/internal/backendcatalogimport/test_constants_test.go
+++ b/internal/backendcatalogimport/test_constants_test.go
@@ -1,7 +1,7 @@
 package backendcatalogimport
 
 const (
-	fixtureCoreRefTemplate = "registry.example/core:v4.9.0-{architecture}"
+	fixtureCoreRefTemplate = "registry.example/core:" + LocalAIVersion + "-{architecture}"
 	fixtureCPULlamaCpp     = "cpu-llama-cpp"
 	fixtureDigestA         = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	fixtureDigestB         = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/internal/backendcatalogimport/test_constants_test.go
+++ b/internal/backendcatalogimport/test_constants_test.go
@@ -1,7 +1,7 @@
 package backendcatalogimport
 
 const (
-	fixtureCoreRefTemplate = "registry.example/core:v4.8.2-{architecture}"
+	fixtureCoreRefTemplate = "registry.example/core:v4.9.0-{architecture}"
 	fixtureCPULlamaCpp     = "cpu-llama-cpp"
 	fixtureDigestA         = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	fixtureDigestB         = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/internal/backendcatalogimport/testdata/resolutions.json
+++ b/internal/backendcatalogimport/testdata/resolutions.json
@@ -2,7 +2,7 @@
   "schemaVersion": "v1alpha1",
   "references": [
     {
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp",
       "manifests": [
         {
           "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -22,7 +22,7 @@
       ]
     },
     {
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-llama-cpp",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
       "manifests": [
         {
           "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-llama-cpp",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
       "manifests": [
         {
           "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -46,7 +46,7 @@
       ]
     },
     {
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-llama-cpp",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-llama-cpp",
       "manifests": [
         {
           "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
@@ -70,7 +70,7 @@
       ]
     },
     {
-      "sourceRef": "registry.example/core:v4.8.2-amd64",
+      "sourceRef": "registry.example/core:v4.9.0-amd64",
       "manifests": [
         {
           "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "sourceRef": "registry.example/core:v4.8.2-arm64",
+      "sourceRef": "registry.example/core:v4.9.0-arm64",
       "manifests": [
         {
           "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",

--- a/internal/backendcatalogimport/types.go
+++ b/internal/backendcatalogimport/types.go
@@ -5,10 +5,10 @@ const (
 	SchemaVersion = "v2"
 
 	// LocalAIVersion is the LocalAI release imported by this generator.
-	LocalAIVersion = "v4.8.2"
+	LocalAIVersion = "v4.9.0"
 
 	legacyLocalAIVersion   = "v3.12.1"
-	reviewedLocalAIVersion = "v4.8.2"
+	reviewedLocalAIVersion = "v4.9.0"
 
 	architectureAMD64         = "amd64"
 	architectureARM64         = "arm64"
@@ -72,19 +72,19 @@ const (
 	cudaPath                  = "PATH=/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	cudaVisibleDevices        = "NVIDIA_VISIBLE_DEVICES=all"
 	vllmNativeSampler         = "VLLM_USE_FLASHINFER_SAMPLER=0"
-	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp"
-	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vllm-cpp"
-	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vllm-cpp"
-	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-llama-cpp"
+	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp"
+	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vllm-cpp"
+	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm-cpp"
+	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-llama-cpp"
 	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-vulkan-llama-cpp"
 )
 
-// LocalAIV482Source pins the exact upstream input accepted by the command.
-var LocalAIV482Source = SourcePin{
+// LocalAIV490Source pins the exact upstream input accepted by the command.
+var LocalAIV490Source = SourcePin{
 	Repository: "https://github.com/mudler/LocalAI",
 	Path:       "backend/index.yaml",
-	Revision:   "5ff25d9d145e0a03a5b9a3559c620f1e1204ca6d",
-	SHA256:     "sha256:bee962adf3332b9f5adea1c9ab28709d9371bee6de24c828f72b8668a694e3ca",
+	Revision:   "f7ad3f70eb5d8a0ddf80e08557f0d7df28cf032e",
+	SHA256:     "sha256:4a4635559a9e726a384a35eebc779da86235a7796821ea56edc01082ff3f0a28",
 }
 
 // SourcePin identifies and verifies an upstream catalog source.

--- a/internal/backendcatalogimport/types.go
+++ b/internal/backendcatalogimport/types.go
@@ -10,6 +10,9 @@ const (
 	// LegacyLocalAIVersion is the LocalAI release retained for compatibility backends.
 	LegacyLocalAIVersion = "v3.12.1"
 
+	// Keep policy approval pinned independently of LocalAIVersion.
+	reviewedLocalAIVersion = "v4.9.0"
+
 	architectureAMD64         = "amd64"
 	architectureARM64         = "arm64"
 	architectureX8664         = "x86_64"
@@ -72,10 +75,10 @@ const (
 	cudaPath                  = "PATH=/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	cudaVisibleDevices        = "NVIDIA_VISIBLE_DEVICES=all"
 	vllmNativeSampler         = "VLLM_USE_FLASHINFER_SAMPLER=0"
-	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-llama-cpp"
-	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-vllm-cpp"
-	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
-	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
+	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-cpu-llama-cpp"
+	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-cpu-vllm-cpp"
+	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
+	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
 	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-vulkan-llama-cpp"
 )
 

--- a/internal/backendcatalogimport/types.go
+++ b/internal/backendcatalogimport/types.go
@@ -7,8 +7,8 @@ const (
 	// LocalAIVersion is the LocalAI release imported by this generator.
 	LocalAIVersion = "v4.9.0"
 
-	legacyLocalAIVersion   = "v3.12.1"
-	reviewedLocalAIVersion = "v4.9.0"
+	// LegacyLocalAIVersion is the LocalAI release retained for compatibility backends.
+	LegacyLocalAIVersion = "v3.12.1"
 
 	architectureAMD64         = "amd64"
 	architectureARM64         = "arm64"
@@ -72,15 +72,15 @@ const (
 	cudaPath                  = "PATH=/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	cudaVisibleDevices        = "NVIDIA_VISIBLE_DEVICES=all"
 	vllmNativeSampler         = "VLLM_USE_FLASHINFER_SAMPLER=0"
-	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp"
-	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vllm-cpp"
-	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm-cpp"
-	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-llama-cpp"
-	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-vulkan-llama-cpp"
+	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-llama-cpp"
+	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-vllm-cpp"
+	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
+	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
+	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-vulkan-llama-cpp"
 )
 
-// LocalAIV490Source pins the exact upstream input accepted by the command.
-var LocalAIV490Source = SourcePin{
+// LocalAISource pins the exact upstream input accepted by the command.
+var LocalAISource = SourcePin{
 	Repository: "https://github.com/mudler/LocalAI",
 	Path:       "backend/index.yaml",
 	Revision:   "f7ad3f70eb5d8a0ddf80e08557f0d7df28cf032e",

--- a/pkg/aikit2llb/inference/backend_test.go
+++ b/pkg/aikit2llb/inference/backend_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	testCPULlamaCppBackend = "cpu-llama-cpp"
-	testLocalAIVersion     = "v4.8.2"
+	testLocalAIVersion     = "v4.9.0"
 	testLegacyLocalAI      = "v3.12.1"
 	testArbitraryFamily    = "arbitrary-family"
 	testVLLMNativeSampler  = "VLLM_USE_FLASHINFER_SAMPLER=0"

--- a/pkg/aikit2llb/inference/backend_test.go
+++ b/pkg/aikit2llb/inference/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kaito-project/aikit/internal/backendcatalogimport"
 	"github.com/kaito-project/aikit/pkg/aikit/config"
 	"github.com/kaito-project/aikit/pkg/backendcatalog"
 	"github.com/kaito-project/aikit/pkg/utils"
@@ -21,8 +22,8 @@ import (
 
 const (
 	testCPULlamaCppBackend = "cpu-llama-cpp"
-	testLocalAIVersion     = "v4.9.0"
-	testLegacyLocalAI      = "v3.12.1"
+	testLocalAIVersion     = backendcatalogimport.LocalAIVersion
+	testLegacyLocalAI      = backendcatalogimport.LegacyLocalAIVersion
 	testArbitraryFamily    = "arbitrary-family"
 	testVLLMNativeSampler  = "VLLM_USE_FLASHINFER_SAMPLER=0"
 )
@@ -373,7 +374,7 @@ func TestInstallBackendsUsesOnlyCatalogArtifacts(t *testing.T) {
 	}
 }
 
-func TestBackendMetadataMatchesLocalAIV482(t *testing.T) {
+func TestBackendMetadataMatchesLocalAI(t *testing.T) {
 	platform := specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformAMD64}
 	resolved := testArbitraryBackendPlan(platform)
 	tests := []struct {

--- a/pkg/backendcatalog/catalog.lock.json
+++ b/pkg/backendcatalog/catalog.lock.json
@@ -3,8 +3,8 @@
   "source": {
     "repository": "https://github.com/mudler/LocalAI",
     "path": "backend/index.yaml",
-    "revision": "5ff25d9d145e0a03a5b9a3559c620f1e1204ca6d",
-    "sha256": "sha256:bee962adf3332b9f5adea1c9ab28709d9371bee6de24c828f72b8668a694e3ca"
+    "revision": "f7ad3f70eb5d8a0ddf80e08557f0d7df28cf032e",
+    "sha256": "sha256:4a4635559a9e726a384a35eebc779da86235a7796821ea56edc01082ff3f0a28"
   },
   "defaults": {
     "family": "llama-cpp",
@@ -51,14 +51,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b6e88baf44c56f17e78488d3d3901288380b94dd3d29012f47a33839a5b130cf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ab4f07d915747d46c3e03b4c62b5edf6cd7f52c4bbbdc2eaf1cc8b4f1a985545",
         "installName": "rocm-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-ace-step",
       "systemPackages": [
         "pciutils"
       ],
@@ -94,14 +94,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7fadefed11f5a6d73c4f4549bc8dfa0ecccbe9313bdc797f0be0913eb49f6b4b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6b271b1f72b49953f99973bb95988564b7043a60a91d8e16887821358afa6f16",
         "installName": "cpu-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ace-step",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -123,14 +123,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3134dbe425442ef775f5d36a3dd9d023f80b77dea874b3de44f0bb55c5c7de6e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5a524d522451ae66aec287b77024ab5ea0bc76a9c85a7b4a6607b11212d869e2",
         "installName": "intel-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-ace-step",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -152,14 +152,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:19acce5281608e2067891e881932a6f835f5a336bbde9ed56c8296c687669d2a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c6a88de4842b8f1bed8b1417c1b66b9972672bc930da1f785685195483cda964",
         "installName": "cuda12-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-ace-step",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -187,14 +187,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8b485b277d95797c9409a611ec69a4e9dce2179005bda5fac7317b586fe06510",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:af5c4e8b04ebead7a2a7d4f7a2a3ed46a7fa7072ee217340cfd283933cd99b38",
         "installName": "cuda13-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-ace-step",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -222,14 +222,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:19acce5281608e2067891e881932a6f835f5a336bbde9ed56c8296c687669d2a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c6a88de4842b8f1bed8b1417c1b66b9972672bc930da1f785685195483cda964",
         "installName": "cuda12-ace-step"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-ace-step",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-ace-step",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -257,14 +257,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c4fe11f24a48c1a1558329bfc24194a31764e984e31afac501bf2c6f09efe06",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:25bdfca85027b1640eda825a17a5394a2cc782954e5e71cfabbf3bd520f82aa6",
         "installName": "rocm-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-acestep-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -300,14 +300,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:899c24724eb1f6419a761a4b24290e78fcc06369db9e158dd090dae9f7bb9924",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccda27ced7edf8b24939bd6c13d4a78292e5b22a91568cfaf48db838110f525b",
         "installName": "cpu-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-acestep-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -329,14 +329,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:de5ee4610f9d37d73d50dbc580adfc84f4eeb8d2988eef10220928ac32682757",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:77fbb3c7e4d92e1ca845d52524a4f693041ba32f161abad517089e89403b0cfe",
         "installName": "cpu-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-acestep-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -358,14 +358,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c84113dcfcca933376b040110db8b98ea88e351182c29b48c60bf6b07f64e44a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:79291c6e73da2b3017625f71c0da6a5199dc03064eaab4664c3970927e60a7e0",
         "installName": "intel-sycl-f16-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-acestep-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -387,14 +387,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f6b8426eafb4c2f12457e1a2146776abe3929d09f9771f8bc772ec492bc58cfc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5dfed3cb5a86a733723c1771ccbc28364f763901f9bb0c93aab9cd38191c7beb",
         "installName": "cuda12-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -422,14 +422,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c0266290c9718ba43a7505a8a585f2a8532069c89de8093a94c8ae25560d6aa1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ecf9a249bf58e82e8d2e776604fae912ca964bdb1d895703230f792ff1144120",
         "installName": "cuda13-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -457,14 +457,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d8e80c568183f39e9ec6aca035b4f4ce12087ac07b486b103fc50dde54dfe94c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f3ce3b8f60c33b6c2b2833caf2cb92a8c45ccf5610e4dbb9a803bfeeec756994",
         "installName": "nvidia-l4t-arm64-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -495,14 +495,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ec9a1bedec43d87c776dd65f54d7633b5b7d645eb8607bb1061087e65c8cd83a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:574d8c8c10a96d11036ecc5350578880a40955639e3939d2f35ea3c221661ce2",
         "installName": "cuda13-nvidia-l4t-arm64-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -533,14 +533,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d8e80c568183f39e9ec6aca035b4f4ce12087ac07b486b103fc50dde54dfe94c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f3ce3b8f60c33b6c2b2833caf2cb92a8c45ccf5610e4dbb9a803bfeeec756994",
         "installName": "nvidia-l4t-arm64-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -571,14 +571,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f6b8426eafb4c2f12457e1a2146776abe3929d09f9771f8bc772ec492bc58cfc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5dfed3cb5a86a733723c1771ccbc28364f763901f9bb0c93aab9cd38191c7beb",
         "installName": "cuda12-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-acestep-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -606,14 +606,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a70eefa714e9654b8b7bf150238ae2a6bc413d377d58ac7c51fcea2ef76e732",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bb54bbc7ea40e0ce11d6cffbb50c1e483f7294d841cd4b5c21862112b66f5340",
         "installName": "vulkan-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-acestep-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "music-generation",
@@ -635,14 +635,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8cd9ee1f51bc553f2a89981add2006527685a897e3a70e6671272030567f94c3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1682907defa63cf4122b87e34aeaa64e65f369c85095af810f9a9707505b1fb4",
         "installName": "vulkan-acestep-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-acestep-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-acestep-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -667,14 +667,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dea5916f5e04811f168f0480258bdcdb4044ad655de930722708ab46c0da1d76",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fe52415fdd005b9b2bfd40233b768615d2791a44bc4ee860bbca593d1be041b9",
         "installName": "cpu-audio-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-audio-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-audio-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -700,14 +700,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b26f447d96f2f566432900357026ceb865d4fb71f053f23075a5e2779f1f4e6d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:029baf0750da8e0270a1404cf9b982d00bc29c1944ea56416782b47a286cdd45",
         "installName": "cpu-audio-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-audio-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-audio-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -733,14 +733,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bf35fed0161960e8247987a821568c4a46041cfd062fec8dc9d34b6150e1641a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:243a262ba6b1e7e70809ebc7f40dc0b91e3b117e9180eb00d2237495cedeb934",
         "installName": "cuda12-audio-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-audio-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-audio-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -772,14 +772,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7cbf0f7641c4f6d1711b93fe7a9a298ee77c85afea24b96f00bc3ec81d98447b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cfc61639010dee62ba2ade3978694d26e6b4adf45cb95ba6db6447e5a7b5f557",
         "installName": "cuda13-audio-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-audio-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-audio-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -811,14 +811,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bf35fed0161960e8247987a821568c4a46041cfd062fec8dc9d34b6150e1641a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:243a262ba6b1e7e70809ebc7f40dc0b91e3b117e9180eb00d2237495cedeb934",
         "installName": "cuda12-audio-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-audio-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-audio-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -850,14 +850,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:30b847a9ec55c0a2b3b2232fa444fabca2067d6bba43b3822ec15e27fc4471ee",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8038efdd9ecba3e9e77d4714ac68a7e38a59e76234d62d87a785836c4d84c772",
         "installName": "rocm-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-bonsai",
       "systemPackages": [
         "pciutils"
       ],
@@ -900,14 +900,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8226b578b320a0f59f0db748e04505e779dd0f773f31c2f4c1bc5542919ba61d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:699d52b79a9e0cee6d407427aeee10323205dcf7d65137f7ef31ee531f59790b",
         "installName": "cpu-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-bonsai",
       "runnerProfile": "unsupported",
       "workloads": [
         "1-bit",
@@ -936,14 +936,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ff123e3dade7c5224101f56815a8bc203488c8d3ab93ef51c8ae5c068d757d25",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c5459b00d725c3a2a309dba588d755734376a63dc3102c7cdb92f60415dc38e",
         "installName": "cpu-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-bonsai",
       "runnerProfile": "unsupported",
       "workloads": [
         "1-bit",
@@ -972,14 +972,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e0326d367d7a8ef97da868a736f5395e65f3cf905b1e7fee5f3877da37ab793",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3bed8e96e7f133feb6b10fa9c136ccb115cc7841127cdccccad3493b01392c42",
         "installName": "intel-sycl-f16-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-bonsai",
       "runnerProfile": "unsupported",
       "workloads": [
         "1-bit",
@@ -1008,14 +1008,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:44bf9c255c333436dc759e7558e87e756cbd26f6175cacb3219d2e9fcf495f5b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7cd8a86dad0895399d90f0fefb6cba2989d088348a252e76276a049edac40c5d",
         "installName": "cuda12-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1050,14 +1050,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:73bd6a9b6adb3a6fd69e2c3cc9b1835f7239df3ae67993a8097147e30ae8589e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:edf73763d20ad10b35eb2cba13e4db211b79c83ec3ac08d29baf9b65342da2b5",
         "installName": "cuda13-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1092,14 +1092,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cad0baa551ab71d9eb5e3902f8caa708db6b9285fafa2268f218ce989db00bc3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:212b0ec2f358330c3f2a1b28344c18437ff63acd0070dd738a0b8bda3723f63e",
         "installName": "nvidia-l4t-arm64-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1137,14 +1137,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ed35b5cf9fed36d364fe45efb57cdedfb8718028dc07fe8b88a4428bea90d31e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2ccb42473a146842366596d147090648d66966363b68467d5aa551ff4d22729e",
         "installName": "cuda13-nvidia-l4t-arm64-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1182,14 +1182,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cad0baa551ab71d9eb5e3902f8caa708db6b9285fafa2268f218ce989db00bc3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:212b0ec2f358330c3f2a1b28344c18437ff63acd0070dd738a0b8bda3723f63e",
         "installName": "nvidia-l4t-arm64-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1227,14 +1227,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:44bf9c255c333436dc759e7558e87e756cbd26f6175cacb3219d2e9fcf495f5b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7cd8a86dad0895399d90f0fefb6cba2989d088348a252e76276a049edac40c5d",
         "installName": "cuda12-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-bonsai",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1269,14 +1269,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3c85f4a30c9cc98e6f1a4b1cc7df84fdbabc1107f697812eab17c056fb3bdd3f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a926f09a1413153eaca4e5ed2e0213d2cfa7a58ff3fafed7a5e2d69caa023a69",
         "installName": "vulkan-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-bonsai",
       "runnerProfile": "unsupported",
       "workloads": [
         "1-bit",
@@ -1305,14 +1305,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:462c4768498535995e58730dbf17b489da5a2b261e6ca710082acb39b9a950cd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:910a01a532c8410d8ccefa2895fbd9f2c822bd5716117ad99edc220c5a1b7f08",
         "installName": "vulkan-bonsai"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-bonsai",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-bonsai",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -1344,14 +1344,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7b0324cac335f6e860b9f3d6d3c37ccfc19b6645aa90579eceebea51dcf5a455",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a2743a2125e46d0665cbb1937baf14be18f25ccf4225473aeed50d80e425f91e",
         "installName": "rocm-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-ced",
       "systemPackages": [
         "pciutils"
       ],
@@ -1390,14 +1390,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6110f9f1a8c1ae42942860af54c8ae00d4ea7b773c30215b3a2a984b6e00d08d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dade4d4d350399949854e8e19bf3a29d545f5f507a88506ed8d0228914a3baf0",
         "installName": "cpu-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ced",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-classification",
@@ -1422,14 +1422,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6f1d2958a4b34a6d5e3fa770214181315928b46a75a7ef35446daba924913509",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9de04db6da73bd60e349f30479b7afbaad59c2dda6cb2fce492ec47f0a074fc9",
         "installName": "cpu-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ced",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-classification",
@@ -1454,14 +1454,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cba6625f14db13439517e1e39a48a619d0f614cea977c3711c4423f71c6225f8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0d458f8deb7150bf367a039632f69153f13c67c4c3a983bf61d317c4deadd435",
         "installName": "intel-sycl-f16-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-ced",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-classification",
@@ -1486,14 +1486,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:05ebf71023ee4b11fde91c3a3bd867c4c40f39d68a7116f3eeb855d4c6847cf6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:60c56ed3fd0ac1813c6622c06bae77493d9d04db8c88d8316097b44a46a4dee5",
         "installName": "cuda12-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1524,14 +1524,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7de9725df3e96d1f7297f94790ec244999ff5fcd76523c31910ba864b4d526ff",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d9853c27d1bfae822746fe9b1e68d8a85d71f4756a33ef1e55bc383a79f8fb1a",
         "installName": "cuda13-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1562,14 +1562,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d84229af8a0ffb4f0c77089e18c8283e16fdf9a59487f44dd43ee9b631d1b5ab",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:24c7535c64420f4f2f8cf6255d461f3d0a1634fd82f85e5019e41a9f0ec01a84",
         "installName": "nvidia-l4t-arm64-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1603,14 +1603,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:396f6a232f5df1838bb722a439a88a974e8ca912775e95cc12c286c968f6c3a9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fada581f1b649fd4df5a055af9eff2ebb0980b2f83fd47262ee8ad6a90e018b8",
         "installName": "cuda13-nvidia-l4t-arm64-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1644,14 +1644,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d84229af8a0ffb4f0c77089e18c8283e16fdf9a59487f44dd43ee9b631d1b5ab",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:24c7535c64420f4f2f8cf6255d461f3d0a1634fd82f85e5019e41a9f0ec01a84",
         "installName": "nvidia-l4t-arm64-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1685,14 +1685,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:05ebf71023ee4b11fde91c3a3bd867c4c40f39d68a7116f3eeb855d4c6847cf6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:60c56ed3fd0ac1813c6622c06bae77493d9d04db8c88d8316097b44a46a4dee5",
         "installName": "cuda12-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-ced",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1723,14 +1723,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6b734845e55fda1b7f194aba9d7c5c4732d625866be3ca482e7136d46692b278",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:672c586bfc70d23ddf32dca97347a1ffd24a984d81963088bbeb05bbaafdb1c0",
         "installName": "vulkan-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-ced",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-classification",
@@ -1755,14 +1755,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:32894f682c1e35328c8e98ed6cdba476230700c99c883a47c030589560d1b7bb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:663b5decdccd27e232ac9598695a7a7b550764cd1d4fcb2b2150decc6de24aae",
         "installName": "vulkan-ced"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-ced",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-ced",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -1790,14 +1790,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88563e1a6ae9f56e7c47b86e413a631f716377195cafbe63cc5a34ee1df2db5c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:963a4835002506e8c87f252908d53c9e39c44be1840438b0e13abaaffe65cac8",
         "installName": "cpu-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-chatterbox",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -1819,14 +1819,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f277ead5e99a18eb2af2204a678526d33ed83f68bd1fa9fc3654b90fb3aec085",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e2f6dad88abee39f74c897dcd70145415dae368c46b96067843d9109dabd00a",
         "installName": "cuda12-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1854,14 +1854,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6194bb6f7690d076d7945ce951ce5af714d9ccd199211c00e5c15585392c7f01",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:92877bf6be7d9f3e40cc1a563d9c750ae2d7834e54c44dcf7d7fc504c7fde97e",
         "installName": "cuda13-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -1889,14 +1889,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f8524124d90dc16cf6a56ca3310b31e1cf3f15b84fc861fe3a1674fecb54290f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c54433d64121568aecad5f99834a45afbb028ee04f2cc5b1be656952cd158c1f",
         "installName": "nvidia-l4t-arm64-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1927,14 +1927,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:faa45e7980a2f6923afae814d049bac2d354726a47d6d6398fa775e678f7ba3b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c6449e0b1a674d3a69bd0b7325d5e5f94a4490c64f30c26344831066ea19dfcc",
         "installName": "cuda13-nvidia-l4t-arm64-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -1965,14 +1965,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f8524124d90dc16cf6a56ca3310b31e1cf3f15b84fc861fe3a1674fecb54290f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c54433d64121568aecad5f99834a45afbb028ee04f2cc5b1be656952cd158c1f",
         "installName": "nvidia-l4t-arm64-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2003,14 +2003,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f277ead5e99a18eb2af2204a678526d33ed83f68bd1fa9fc3654b90fb3aec085",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e2f6dad88abee39f74c897dcd70145415dae368c46b96067843d9109dabd00a",
         "installName": "cuda12-chatterbox"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-chatterbox",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-chatterbox",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2038,14 +2038,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0430a06dff2ed358b2dffee963fd05a40d5cf9f5667b009b0319c3dd67cddd37",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5f9e05e4ae91ce22b59a349707579c0a61337d6c44168b55755fdf5243b87d2a",
         "installName": "cpu-cloud-proxy"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-cloud-proxy",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-cloud-proxy",
       "runnerProfile": "unsupported",
       "workloads": [
         "cloud",
@@ -2069,14 +2069,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0306ca9ecd0efc37775643735f7bc26f7ffe14eefa01b608757b9149caad3781",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f295f848255f87ba3127f17433523c5a1eb50634e264c1ceb11d9bee37b55e7f",
         "installName": "cpu-cloud-proxy"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-cloud-proxy",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-cloud-proxy",
       "runnerProfile": "unsupported",
       "workloads": [
         "cloud",
@@ -2100,14 +2100,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f36bff05ee685b72695713b130a70f7ebdb76d580b819e684ee14bc92c1da81",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:75d7309a7b10420dc23a3d88ba610c550a675b5d7d02d2051128ee7218c7ffb8",
         "installName": "rocm-coqui"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-coqui",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-coqui",
       "systemPackages": [
         "pciutils"
       ],
@@ -2143,14 +2143,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b04fc194276b4634480215280fd91e877290901efd42c69d8b630dfa441d38a8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e6029bb1aa2fe3c8269bb514d722d4bcb8273eb7f355babb523fb424b5023c5",
         "installName": "intel-coqui"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-coqui",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-coqui",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -2172,14 +2172,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c7385e39c65bdda9a634986b668ca5953d5031e189d7c01836486aaf9ab3ab4c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1d34aed5490060da77e7cecf69c918c20f1a651cd826b96f9050a90cae435566",
         "installName": "cuda12-coqui"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-coqui",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-coqui",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2207,14 +2207,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c7385e39c65bdda9a634986b668ca5953d5031e189d7c01836486aaf9ab3ab4c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1d34aed5490060da77e7cecf69c918c20f1a651cd826b96f9050a90cae435566",
         "installName": "cuda12-coqui"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-coqui",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-coqui",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2242,14 +2242,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:954e9ee6e13c1e83cb73966c24b455d9005ba998ce0cda1d509830afeafafa48",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d843b81143393cce7a347793911772f4750e51c5250f9e6eb52987674a791b08",
         "installName": "rocm-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-crispasr",
       "systemPackages": [
         "pciutils"
       ],
@@ -2288,14 +2288,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:214a94c1b1e2cf84ba930f0b13bc77dc0153494b1840109b54532ca1b1e13222",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f043d6a685d7a778a6e9a35363da34fa0851c42203e8268af4c3b1a32520b01",
         "installName": "cpu-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-crispasr",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -2320,14 +2320,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:19282d97d85fe061bb5e30c937f41be611271c8e38a22b2b244b558e060a503a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5793a2dee43d8dde5208e0542a721522361e42b084a879f89c73b40bdf698407",
         "installName": "cpu-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-crispasr",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -2352,14 +2352,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0b38a0a64e462d834a7b226a8220ac89414e279399643cdae3f18550b3ba9023",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:91998f61925255552f83f494d8c355cf17c0396b8e658e9dba7a25dd91679921",
         "installName": "intel-sycl-f16-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-crispasr",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -2384,14 +2384,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b4345dd1551b9bbbd7ca66ca1887223279bfa079386b50ec2b1580ed0f431a35",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:199d3ece84463411b2df75c214b710ec9cc0c2757f97db3f2781a85c6e0223e6",
         "installName": "cuda12-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2422,14 +2422,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6f25423c7807d9291aeb8077b998b0cd569b4f74373407a3b48d58a9afd2e6cf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fea26d883d5e286e6ecf5af8e14d4abcf3951aea8fbe09347e7ead80a800b102",
         "installName": "cuda13-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2460,14 +2460,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:42db52f8823889c3cafc3ac5f3e87f64ff3ac1b6b8d4f7837f6f3720c3e2687e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8d06f1b9172f0b328543b789e72e47914bf36dbb885860e2b88447f833bf828a",
         "installName": "nvidia-l4t-arm64-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2501,14 +2501,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2b0a3d67b9ca33ba1d265009094a2b86c4e4833ac81aee1fba3cd9e898e3db23",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eae5d927a5488c533210220fa44f5f7110ef6a07d50eaef551777eb5f840fcae",
         "installName": "cuda13-nvidia-l4t-arm64-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2542,14 +2542,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:42db52f8823889c3cafc3ac5f3e87f64ff3ac1b6b8d4f7837f6f3720c3e2687e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8d06f1b9172f0b328543b789e72e47914bf36dbb885860e2b88447f833bf828a",
         "installName": "nvidia-l4t-arm64-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2583,14 +2583,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b4345dd1551b9bbbd7ca66ca1887223279bfa079386b50ec2b1580ed0f431a35",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:199d3ece84463411b2df75c214b710ec9cc0c2757f97db3f2781a85c6e0223e6",
         "installName": "cuda12-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-crispasr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2621,14 +2621,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:11a43ba8149364ceb8b8d8e688e1c2a640a26ed5c1031864b1960dab78e61150",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5465572ddfe42d6e9693a1232e5733991f29b2ea1297c8fbed63d78debfcf38c",
         "installName": "vulkan-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-crispasr",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -2653,14 +2653,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9253549480477f5d5ff3dbe6cee09acb3344cf9871a1bda91debdb35277e30d8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:59932e297420d18af982efe1864e04540ac461b9f90864ea71e43b156fa70259",
         "installName": "vulkan-crispasr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-crispasr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-crispasr",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -2688,14 +2688,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a5a581046d07c39a7cc49fe013d8726200d35c5e01cba21f19f4b2e45f6ede1b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ca23160684b14023eb8080007b32ac9c6581b36e6832ce9bc5edfd1199079f41",
         "installName": "cpu-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-depth-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "camera-pose",
@@ -2720,14 +2720,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:322ff85964818737a0f74bf2cb253d7cc7e076b68192badf0553cd8a66c64833",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c1747255e9f544ff5f2a2698812d1870a6d688b8331a13b183730235de2770f0",
         "installName": "intel-sycl-f32-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f32-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f32-depth-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "camera-pose",
@@ -2752,14 +2752,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e46c3884034758ebddbbf198f320cbb8b8171713e2007bd1c781bad8ae106dce",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0856622eb44bfc262d74e4126aafba3e6e7a6d6d9d52331199f340cf4c3af9b",
         "installName": "cuda12-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2790,14 +2790,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4b521cac1bbacf1fe9afa7da55705f732daf66322296adbb51e0e4d69db7c677",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9e04da4a33367ac3b894fdb65a6a13728469f0f88aa08b309ead19e3fda74eb7",
         "installName": "cuda13-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2828,14 +2828,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:34cf253cb63c6d3779d5de7e1e5482eacc54e3aefd5c26273af8bf3065a53626",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f13d0a669b8e92fb53e9f9e3ea6d0fc94b70cf43076b365bed067f28109ad6cd",
         "installName": "nvidia-l4t-arm64-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2869,14 +2869,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:413be14af9e754c8d2fcff30671c71103163069be6fe866ade2acd5dfabe443c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0fc27e5082677f99450d19ec14c391724c45cdf77e6f07352723d9f58c7febeb",
         "installName": "cuda13-nvidia-l4t-arm64-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2910,14 +2910,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:34cf253cb63c6d3779d5de7e1e5482eacc54e3aefd5c26273af8bf3065a53626",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f13d0a669b8e92fb53e9f9e3ea6d0fc94b70cf43076b365bed067f28109ad6cd",
         "installName": "nvidia-l4t-arm64-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -2951,14 +2951,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e46c3884034758ebddbbf198f320cbb8b8171713e2007bd1c781bad8ae106dce",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0856622eb44bfc262d74e4126aafba3e6e7a6d6d9d52331199f340cf4c3af9b",
         "installName": "cuda12-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-depth-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -2989,14 +2989,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8f45f465d3a8fb45e64f7d445f7da6a011dbe509ad579e78a9f53bce7c21827d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3ce58ac7fe56527d8acab7765744b448941296572587cb5dd9b75b09728deb82",
         "installName": "vulkan-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-depth-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "camera-pose",
@@ -3021,14 +3021,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3e1381cbe1b9cd5a074827cac81ccf1448ccadffa11a2aef9f28323cb0d70857",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:95bc59ecab09d4d3dc129c67ff6197f2807ba5dff0e83cccf6b7eaea01493091",
         "installName": "vulkan-depth-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-depth-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-depth-anything-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -3056,14 +3056,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:398534348e6156f9b92f54b0e552a8db92b6a78c5fbaa4b4d86e846d7513dd96",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2cecc39bc01aaea5bec682eaff1af1ab372e814b556e6cca9d99660150e10249",
         "installName": "rocm-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-diffusers",
       "systemPackages": [
         "pciutils"
       ],
@@ -3100,14 +3100,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f99c66baf8438808cd037687f71ea0077d266fcf395464428a6b1d17e89b330",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:47f918ada84d6d894d6d04ad17f1d0e4ad74ecac55ebcebf5ea191094d0e682a",
         "installName": "cpu-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-diffusers",
       "runnerProfile": "unsupported",
       "workloads": [
         "diffusion-models",
@@ -3130,14 +3130,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c63c357f72e03b1328c5ba0939cc9e0de351a6dac2ccc6715ab76d6e25d7fc2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:add0bffd29d839bd1fb10cd7607870aa23e2ab6d560332813d6126c864a51be0",
         "installName": "intel-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-diffusers",
       "runnerProfile": "unsupported",
       "workloads": [
         "diffusion-models",
@@ -3160,14 +3160,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cecd430fffa347937753a9595a434e6d560eff36a0dd4ecd1647a10e73788c90",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5b206adc142ede3864549b2be4be965625db3ca21ba07a8f2d0a49ed81ca1fec",
         "installName": "cuda12-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-diffusers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3196,14 +3196,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e81b120482b01d4b9c4d48cdeb61a21049429ef16ea5be0913dc8942a530d1c3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2770092000b17b4d4bc06f80a328b86493916def990b6169c0e37beb57111da5",
         "installName": "cuda13-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-diffusers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3232,14 +3232,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c0a3a307e833c4ca008f1920bad3e5cf343ac06f81bc14197c295e58db2a4ef3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4eace6e5e3c71308587abd4557e77715a37524fb583e2bf1b764ac7906c9a60f",
         "installName": "nvidia-l4t-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-diffusers",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3271,14 +3271,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:58519fe7d1855ba57bd544767eabe3f17002e5164403d7bd2aeab327d1b56d83",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8bea52637838ac05afa2b32b2f2f202b1373b81a6a8896416dc73e83c8e7e515",
         "installName": "cuda13-nvidia-l4t-arm64-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-diffusers",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3310,14 +3310,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c0a3a307e833c4ca008f1920bad3e5cf343ac06f81bc14197c295e58db2a4ef3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4eace6e5e3c71308587abd4557e77715a37524fb583e2bf1b764ac7906c9a60f",
         "installName": "nvidia-l4t-diffusers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-diffusers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-diffusers",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3385,14 +3385,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f1db41dabdb7179b9226779f9d6c4c3204deaab834619c0290bccabda5fabc16",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a875323af85ee1f3a8c72d9237a29815b1536c7dc3accc7a5911d24f6f0e3040",
         "installName": "cpu-ds4"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ds4",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ds4",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3417,14 +3417,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e89f8dee5dc43a314c0b8c6339a054d1be5297c37a0044e9fd1675b077785a8b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:310e6ee5e36f77f8d0711b959b51764e2b2daa81ce5f90f0e70ce158eff5a20e",
         "installName": "cpu-ds4"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ds4",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ds4",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3449,14 +3449,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:46bd4c943d40d134a2234f0a1c4159cd0c6d8e8ee458ed3178208fba77662fee",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:66af57e61ff9702397137ed0952ef04d50c495bd3dd299616fd22f1eaf9147d0",
         "installName": "cuda13-ds4"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-ds4",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-ds4",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3487,14 +3487,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3ca2532563451f04d44808d58451f399fea279a4bd1e7064141715641f3ea9f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50712f0f6d3e2f5195e864de6dee6730596a47b9a22f495e96d15c7242424f58",
         "installName": "cuda13-nvidia-l4t-arm64-ds4"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-ds4",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-ds4",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3528,14 +3528,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:46bd4c943d40d134a2234f0a1c4159cd0c6d8e8ee458ed3178208fba77662fee",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:66af57e61ff9702397137ed0952ef04d50c495bd3dd299616fd22f1eaf9147d0",
         "installName": "cuda13-ds4"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-ds4",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-ds4",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3566,14 +3566,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e47d55e2ff57c7ebba317afb8489ce315e8973aeb4e129c35c595f39b871eae0",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:73519062469f00c1211abb80ca5faf7b328c13f6a556f35d5e4aadeb80dc2f56",
         "installName": "rocm-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-face-detect",
       "systemPackages": [
         "pciutils"
       ],
@@ -3614,14 +3614,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:de993bb9d5b93bd84c9b1ac45c14b968f9713732486ee8aa349b6b648fb00d5c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b2101d1f10a9cdac35c751b96a7070bf33639b5b15c6a0193c6dd9fd62d00baa",
         "installName": "cpu-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-face-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3648,14 +3648,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a527a164b39c0918d6113ce919b4382f8b412a8fc7e134e268ec5c647f452f26",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7531fea1dc34ef618461d8e054a3b6498122e753fc7e5fee7dab033401ba25e1",
         "installName": "cpu-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-face-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3682,14 +3682,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6442db241ddf9f034fc66258ab39d09e8f7598c1a1aa9fd3b8e9a6987347bda3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7c380196a4b5f67c5a7950096d652c1aa58c392dba156020acf083c30aef8647",
         "installName": "intel-sycl-f16-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-face-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3716,14 +3716,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:570a672c7e2a6dfd87d818624e369bb0e416f753c9ebe3da889f43f357b3890d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8780764226ea2dff7d719f7fb82ff3294ec6382e838b89eb68eebacd6e6e8526",
         "installName": "cuda12-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3756,14 +3756,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fafadb12c7456f7a65bd7b91e949fde8cd23bffbbc9170267b71e07808028d3c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a25c36a7a08279ee16208425275e4af5964ba7e721f26dcf84fb36af77365151",
         "installName": "cuda13-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3796,14 +3796,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c139439640581d5034830daf58fea79f75f992599c2eab9129e31be929ef123a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5e2ee4563377282e02286ca09c42fd0df1ecf5b685d08fa04714fa747e205f36",
         "installName": "nvidia-l4t-arm64-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3839,14 +3839,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a9ac68c49b1c169a8bc5437085c16bd7a9b59c35ed83da41b628e69e1ca46ceb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5dc561ca8cf1410356c4bd1438cf13a376a2e0e317fa1d602cebe4239049aa5a",
         "installName": "cuda13-nvidia-l4t-arm64-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3882,14 +3882,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c139439640581d5034830daf58fea79f75f992599c2eab9129e31be929ef123a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5e2ee4563377282e02286ca09c42fd0df1ecf5b685d08fa04714fa747e205f36",
         "installName": "nvidia-l4t-arm64-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -3925,14 +3925,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:570a672c7e2a6dfd87d818624e369bb0e416f753c9ebe3da889f43f357b3890d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8780764226ea2dff7d719f7fb82ff3294ec6382e838b89eb68eebacd6e6e8526",
         "installName": "cuda12-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-face-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -3965,14 +3965,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ca1f54cefc7a9ffd6d17d8c4ef3e6477b849b002204ba892247f25ff47db7148",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6ad0537cea217dc10adb98f669ba8b608ef033dcfed5af4424e71aa024c1d488",
         "installName": "vulkan-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-face-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -3999,14 +3999,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0f9948684ea9d038ca23eebb5384d4aa3ad10eb43d76aa96f4751ab57bfd2d49",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7556028e532f7b8adbbfe4eb5b01dcb15013f35f265ae3b3af798b15c9b76978",
         "installName": "vulkan-face-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-face-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-face-detect",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -4036,14 +4036,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9d8805652b88ccf08708feea413b9ae3a9ee965a0e4c2dde99b1c6914d7eb778",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4e3e99b362a9f2382d1df21b5cd0bc387bc3057cd06b015483e634ffeb51edb",
         "installName": "cuda12-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4072,14 +4072,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9d8805652b88ccf08708feea413b9ae3a9ee965a0e4c2dde99b1c6914d7eb778",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4e3e99b362a9f2382d1df21b5cd0bc387bc3057cd06b015483e634ffeb51edb",
         "installName": "cuda12-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4108,14 +4108,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ca2dac497da966d772a9156192cd12bfff3fc8aec12f9ff82c9b2ce1fedfe133",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:57f3572d60d53de885531f5d710fd41acd4bf524b8a9e2771e806b9f067c98c6",
         "installName": "cuda13-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4144,14 +4144,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64f6dec47f11003a0600c3f3fd2c2f1fb023fec6fd57a162647107f62cdae2a8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e235be9fa309520f1263fee8911a3129ad77f5bd5b4f3d1e82a187babae9791b",
         "installName": "nvidia-l4t-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4183,14 +4183,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:14ccf9b69b4e8d32f02c6b9061898986e1ed8acacce7804e425a2f9712032878",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5d0c99b6b8b9095bdc7e485196d0b08c140a9e5a35024eef7c9a16682503382d",
         "installName": "cuda13-nvidia-l4t-arm64-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4222,14 +4222,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64f6dec47f11003a0600c3f3fd2c2f1fb023fec6fd57a162647107f62cdae2a8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e235be9fa309520f1263fee8911a3129ad77f5bd5b4f3d1e82a187babae9791b",
         "installName": "nvidia-l4t-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4261,14 +4261,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9d8805652b88ccf08708feea413b9ae3a9ee965a0e4c2dde99b1c6914d7eb778",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4e3e99b362a9f2382d1df21b5cd0bc387bc3057cd06b015483e634ffeb51edb",
         "installName": "cuda12-faster-qwen3-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-faster-qwen3-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-faster-qwen3-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4297,14 +4297,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a3bdc9d8e99a074c60375cb5e444a2675edb51ef2f4fcbdf778a007dec996477",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a0d208a104c636cfae293e910c553103afde694c3d439460a6db63a3c626d05",
         "installName": "rocm-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-faster-whisper",
       "systemPackages": [
         "pciutils"
       ],
@@ -4340,14 +4340,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8e73a32d707d9beb68fc899ec21e774d6f0d612578a4e3b1db68bf7d521c36b3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cbd973c8c2f5cc284dc3c98cb48873ad9d6f89439b9995e098e8c506599d2017",
         "installName": "cpu-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-faster-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "speech-to-text",
@@ -4369,14 +4369,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:914dc817b2240f13d3bac5eb85eda2f0e62c79f54f17db2056b8da86e803484e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f3bf857e26f0b94a8430e7f6297d82565981e18a20210888b65c863d11978eb",
         "installName": "cpu-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-faster-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "speech-to-text",
@@ -4398,14 +4398,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:212f69829800db76154cba0956a7594048479d5b64aa87b0fac8da0dab3fd823",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f6d243375762833e126985402dd14e0162d40c104f15690c452dbbb36933c7e5",
         "installName": "intel-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-faster-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "speech-to-text",
@@ -4427,14 +4427,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c4910d4a0e479195260350e29e1c061a5fbb400a078aac5c7f9cd735cd1585b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f7039ad4ba760c369cf343403d93ff29838479322f6d52480aff032214879402",
         "installName": "cuda12-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-faster-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4462,14 +4462,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0ffaad96b538d5e9e17b18a1b5afe0c0b647f48f50da55580a3432096cda571",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:41baa10af7a6ba1d3292a7633c3af91f56a28a60a2b5abcc9fdcfb074037d2e5",
         "installName": "cuda13-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-faster-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4497,14 +4497,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ba8036809c5b0715999f39f842fd1180ae4e2eb5cd852a3587dbbf3bc22c622e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e5f525a04843cb441f405b55c79bae8b092955468ba0d95f3911fab852249745",
         "installName": "nvidia-l4t-arm64-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-faster-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4535,14 +4535,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ba8036809c5b0715999f39f842fd1180ae4e2eb5cd852a3587dbbf3bc22c622e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e5f525a04843cb441f405b55c79bae8b092955468ba0d95f3911fab852249745",
         "installName": "nvidia-l4t-arm64-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-faster-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4573,14 +4573,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c4910d4a0e479195260350e29e1c061a5fbb400a078aac5c7f9cd735cd1585b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f7039ad4ba760c369cf343403d93ff29838479322f6d52480aff032214879402",
         "installName": "cuda12-faster-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-faster-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-faster-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4608,14 +4608,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6350ba0e713f34f958e4b2a03235f1a72d12547da8a50d33fdfc4ccbad6e7cb7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f9b61a2f5787e0c79f890b5036810511270a874521b88742860e39cc8bbd7582",
         "installName": "rocm-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-fish-speech",
       "systemPackages": [
         "pciutils"
       ],
@@ -4652,14 +4652,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e9609b438e0716ea3558a585f5d489b3582309e7fcfa115fb62e5319197ed93",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f063b79c5ab1f35f73593ece479d80b621577e0a694df15195fad7d36738b0b3",
         "installName": "cpu-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-fish-speech",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -4682,14 +4682,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b78894036fe39e4fb3286075d77d3c9cdcabe1d1dd9f51a43cbb57d7da659544",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7683e54a24cdb7cc29014bb91ef281dc76e3bb8fbf0bb153cdf2688fbb5e2313",
         "installName": "cpu-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-fish-speech",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -4712,14 +4712,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e8206c84eea083de8eca687f1a1979c9a78207a4e37a3c2be7b840f26a46c95d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ca4bbfa8894050e119b76378a6445f56b8d2ad4eb5f4316412645c564c823a35",
         "installName": "intel-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-fish-speech",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -4742,14 +4742,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2de746728cfcc3da5f8dd623bc2ec6d6a8f73b17ef8ea01f7588782016a620e5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c67aa18fd6621ff7e4bae80b4538a5f6669d443aad5cc0238f17762d6dda6c2d",
         "installName": "cuda12-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4778,14 +4778,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62f5307c4bf85a7c230d6a22ead8fa83a27f8ec17483860922ed49ce4039d61d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eb3a4523e053db7f054fdbba253504ba25eeaa3db3d77ba5732211b40caf84cf",
         "installName": "cuda13-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4814,14 +4814,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1647325df28ab0635b6705404f17128b752fcc3e6b2349645a0d57f6d9b7bc18",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:94463044912f8f98d02e56dd993aa565ea925347405ab9122e6e42b834eb1f06",
         "installName": "nvidia-l4t-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4853,14 +4853,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c226fed063b540afbdc444795396187eaff1fcc135daf8e0b1592737c1b63f50",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:32cda2de0adf4e94446d6e8106d5a6841da938361c11187fe5513d7a5367585b",
         "installName": "cuda13-nvidia-l4t-arm64-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4892,14 +4892,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1647325df28ab0635b6705404f17128b752fcc3e6b2349645a0d57f6d9b7bc18",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:94463044912f8f98d02e56dd993aa565ea925347405ab9122e6e42b834eb1f06",
         "installName": "nvidia-l4t-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -4931,14 +4931,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2de746728cfcc3da5f8dd623bc2ec6d6a8f73b17ef8ea01f7588782016a620e5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c67aa18fd6621ff7e4bae80b4538a5f6669d443aad5cc0238f17762d6dda6c2d",
         "installName": "cuda12-fish-speech"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-fish-speech",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-fish-speech",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -4967,14 +4967,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6c1d4c09a3e450b883f7122364d67c4192ea34d197c9159074945593e4f1e664",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:20fb03301d6467a3414393134f603b94c9aaadc41d5017c1462d8b0f33be25ff",
         "installName": "cpu-ik-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-ik-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-ik-llama-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -4997,14 +4997,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9bb565d74fe55f5691e79f0a0ffc6912326318a25e17a9006af032b5dae3e232",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4b7ff8919c1fb46451c723ac12d2a0925aba50ae922e494bc2e956b49ec26708",
         "installName": "cpu-insightface"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-insightface",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-insightface",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -5029,14 +5029,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:52fdfab2bda30b8b6d7dbc3688a494ae19f3c17b60474deec2f5a579386a3d50",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5424d2d859a149e2d60cace2994dce7b18f0b9586c96e74c2f4e5a0c48e6f712",
         "installName": "cpu-insightface"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-insightface",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-insightface",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -5061,14 +5061,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0556b10c4fa0f2bb5fac39ae28b11b853d3f51873b207f5760fbccc00bff982b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7235a9c42495d516a8f0882ec71ee91f4472efa4ac57f85dff33b749dd23bd3c",
         "installName": "cuda12-insightface"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-insightface",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-insightface",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5099,14 +5099,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0556b10c4fa0f2bb5fac39ae28b11b853d3f51873b207f5760fbccc00bff982b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7235a9c42495d516a8f0882ec71ee91f4472efa4ac57f85dff33b749dd23bd3c",
         "installName": "cuda12-insightface"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-insightface",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-insightface",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5137,14 +5137,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:beb7a89166d321396baf76a45346b2ef5d7914e30c9bb8a8c39cac7c2f428557",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6268c299595bc079792a087eed65ac00710aab1fa9a5aeae2c23151dbc613cd7",
         "installName": "cpu-kitten-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-kitten-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-kitten-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -5166,14 +5166,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3eec57021dc09121e6b67efb38669c49d65ba8820dc514fd3c71f29b1b027f10",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6766380cd298d54cb5f83731d6ce6aebdbcaa9b556ce58a8ad381d2024eeaf1d",
         "installName": "cpu-kitten-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-kitten-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-kitten-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -5195,14 +5195,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:825517e7f0025863bca63b6320a98ab6410d99424bafbe4ec7b7c66b9851cb3d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8fb50f54d4462ffe0d095dbf28ed6a1704004e7caa48166cf3f0017850d45d82",
         "installName": "rocm-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-kokoro",
       "systemPackages": [
         "pciutils"
       ],
@@ -5239,14 +5239,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:12dc454b340cb4bc4175c1ea135e122bc88a8857bd3027f9bff760128bf0a23e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4804f630bbd953aa76e171ccd3d7739a9ba14e866d1c277f57eca7bc9fee1aaf",
         "installName": "cpu-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-kokoro",
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
@@ -5269,14 +5269,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e7e18437db53b38eb69285b23a2aff3c78858ccb446af1c54a12075d11cf6f7e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a0f5def11a2b9655253fa2c58725767a9e76acf4aa1df291e4e9cb88d2b63ee2",
         "installName": "cpu-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-kokoro",
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
@@ -5299,14 +5299,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5ebf8d7358cfa3f328a8ab970fc6a3c89c3ffc28544e6395d4e42972c6ffb85b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:33aca20eeec74e66d0619e44a760061ad6ac1271de934cd56c66e53de7301755",
         "installName": "intel-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-kokoro",
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
@@ -5329,14 +5329,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db7100d181848d46c7de25fd95bb31f9dcfe5f4bb7204acc6a212b913d4d2280",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e5e8d8a8553b3a845b6648e846ca61b95b015393202c2bba188923e1004aa84e",
         "installName": "cuda12-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-kokoro",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5365,14 +5365,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1d10aac2e1d8a36d06d81dca45451cd14dd0a6bf83653992242068f7a7db7aa6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:756eed56513fd65bfdda8b2d318becf46db7c37620648d32942fa9bf4c577e0a",
         "installName": "cuda13-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-kokoro",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5401,14 +5401,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9911a7f38302d24f2094fee7dd46fc94ced3d4f35bbc2856fd9c7fe3a004aadf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:944f75563f05b4824a2eeeae47b269a9198210c9bee5b382059b5e2fca1373da",
         "installName": "nvidia-l4t-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-kokoro",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -5440,14 +5440,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9911a7f38302d24f2094fee7dd46fc94ced3d4f35bbc2856fd9c7fe3a004aadf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:944f75563f05b4824a2eeeae47b269a9198210c9bee5b382059b5e2fca1373da",
         "installName": "nvidia-l4t-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-kokoro",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -5479,14 +5479,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db7100d181848d46c7de25fd95bb31f9dcfe5f4bb7204acc6a212b913d4d2280",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e5e8d8a8553b3a845b6648e846ca61b95b015393202c2bba188923e1004aa84e",
         "installName": "cuda12-kokoro"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-kokoro",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-kokoro",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5496,6 +5496,37 @@
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
+        "text-to-speech",
+        "tts"
+      ]
+    },
+    {
+      "family": "kokoros",
+      "selector": "default",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      },
+      "runtime": "cpu",
+      "targetProfile": "cpu",
+      "status": "experimental",
+      "channel": "stable",
+      "runtimeBase": {
+        "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
+      },
+      "core": {
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
+      },
+      "backend": {
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1476fd8d8821094151f589f48890edf0d6368e1015d6bf243ec6250ee5c58e49",
+        "installName": "cpu-kokoros"
+      },
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-kokoros",
+      "runnerProfile": "unsupported",
+      "workloads": [
+        "onnx",
+        "rust",
         "text-to-speech",
         "tts"
       ]
@@ -5515,14 +5546,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7d90a9dc126b4ab51df0a491a449bd274a723f6ada9ed493d36cb50ac7bdde04",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:401cf0281c523adb6e19be85ebcd5754e9c67df9c0e122e5321690e99e9dec03",
         "installName": "rocm-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-liquid-audio",
       "systemPackages": [
         "pciutils"
       ],
@@ -5563,14 +5594,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fb8b5b88bd80bb9206b13c50c585a0369f7b2cbd585f00557f42f3d96bd764fe",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:20ab3f06687d1b86f67c1bc0da2abb796e3b1bdc5ac07bb9cdc362328c82869a",
         "installName": "cpu-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-liquid-audio",
       "runnerProfile": "unsupported",
       "workloads": [
         "any-to-any",
@@ -5597,14 +5628,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c93ebc55913060eac413f97bacd668e5c83d7048e7a5b48bd222fce1981717d1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c472d4db4c2557c4378d4de1a5034feb50ea2f67767d5a391f31b5301a3432f2",
         "installName": "intel-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-liquid-audio",
       "runnerProfile": "unsupported",
       "workloads": [
         "any-to-any",
@@ -5631,14 +5662,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aee6b99fb6a674636c8d7d36451950866ddb758f6885ba342611866144baa3d4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64d0d81dffb2463822785f8c92532310372e92695346e537e620f9deac18ad2b",
         "installName": "cuda12-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-liquid-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5671,14 +5702,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e72c12f1d7e434afc79517ee44a97157a327d7c2e945ab80a856fb21d912e684",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ffff06daf5715144a807d9f2792660092732ff900dd67cc2e46acb38028dbf6d",
         "installName": "cuda13-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-liquid-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5711,14 +5742,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:96921cb0d89af05d356ab20a67a5ef0e0d55087e8405cb466d65e706ec7377be",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:85a94319888d22fe7d4ef916c6d19049306efbcbb0d41ffcfd96e23c960ab2f0",
         "installName": "cuda13-nvidia-l4t-arm64-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-liquid-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -5754,14 +5785,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aee6b99fb6a674636c8d7d36451950866ddb758f6885ba342611866144baa3d4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64d0d81dffb2463822785f8c92532310372e92695346e537e620f9deac18ad2b",
         "installName": "cuda12-liquid-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-liquid-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-liquid-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -5794,14 +5825,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5665aa880eb167784a2a1b8ff47154dd95ad4dfb10bb4b4a247ddefeefac9d77",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3893ee808e85d1ec85f66b697d2e05a250131bb6d4c6ba65eb925043dea3c0d2",
         "installName": "cpu-llama-cpp-quantization"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp-quantization",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp-quantization",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -5824,14 +5855,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6cbac8dbdcf9ff3a1f31c9dc4aafafc7dbb9de2f2546fab5869cb7eba9a42dc1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:750f2a068e8a2a0d91d058c90c07f2d034ddaa8d08653cfdf58c4d4231c6cf21",
         "installName": "cpu-llama-cpp-quantization"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp-quantization",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp-quantization",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -5854,20 +5885,20 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:395713c86d7e3ca5766fb66d83876b928012847c1bfd00d62be0960ac1e60dcd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:975971a772f4a880ba3735f599a76e6c239329bf7e5de6de42cb2e9567e8118d",
         "installName": "hipblas-llama-cpp"
       },
       "fallbacks": [
         {
-          "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3314c17bc95edfb097566335e5ef60c054fe762cdbee48611e8a4d76b103736",
+          "ref": "quay.io/go-skynet/local-ai-backends@sha256:64627220c1c35c3b2114d5226462749aed038d1017447eb3d9b6badf775326cc",
           "installName": "cpu-llama-cpp"
         }
       ],
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-llama-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -5890,7 +5921,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -5911,14 +5944,14 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3314c17bc95edfb097566335e5ef60c054fe762cdbee48611e8a4d76b103736",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64627220c1c35c3b2114d5226462749aed038d1017447eb3d9b6badf775326cc",
         "installName": "cpu-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp",
       "runnerProfile": "llama-cpp",
       "workloads": [
         "cpu",
@@ -5927,7 +5960,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -5948,14 +5983,14 @@
         "ref": "docker.io/library/ubuntu@sha256:a8cdd2158a73d7e5c02aa351fe269f48f57cf710a241db86e9ede371fc150149"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e9b0ce2e97884821499a1ffbe2c494d4804639cd219efb481dd6f12a13b7eeb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:57ce9418a5d65ed085854c2e5482b2316393e5194a01faf9592a2c0f48922460",
         "installName": "cpu-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-llama-cpp",
       "runnerProfile": "llama-cpp",
       "workloads": [
         "cpu",
@@ -5964,7 +5999,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -5982,14 +6019,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6a181776a50c7601fe6aea036961a2f6c97b7a7d9ee2c1b4059c871f9d7acb30",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:889c0af520f7de53c1965e2dce727cee9140a32dd9d74a7a756d520018bb36d4",
         "installName": "intel-sycl-f16-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-llama-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -5998,7 +6035,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6016,14 +6055,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7d91387e6ebbe1ff689ce8de0d4f2e94903db42abb0e27cee1e5c5c40da2d4d8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cc8c4c4945715d6d70f172a217691f973c2eabd81140476d992c047a418cfad8",
         "installName": "cuda12-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -6038,7 +6077,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6056,14 +6097,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b1c73215c60230144fe17e256a9be3855c27abef858530acd8791d06dbcb19be",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:99d560b7c6e314257fef0a8a92a252791ab462f85f88ff8467d22ea31a74de51",
         "installName": "cuda13-llama-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -6078,7 +6119,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6096,20 +6139,20 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:029f2dea8c2dc12edf171575b0bfad128679d655ceb64d29df0fe75f31ae8fd9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2c7099edf17ef4d7aadd1e975e25c08de5ca248cf4f87640ea070f0b0769d9a9",
         "installName": "nvidia-l4t-arm64-llama-cpp"
       },
       "fallbacks": [
         {
-          "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e9b0ce2e97884821499a1ffbe2c494d4804639cd219efb481dd6f12a13b7eeb",
+          "ref": "quay.io/go-skynet/local-ai-backends@sha256:57ce9418a5d65ed085854c2e5482b2316393e5194a01faf9592a2c0f48922460",
           "installName": "cpu-llama-cpp"
         }
       ],
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6127,7 +6170,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6145,20 +6190,20 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7d6d660c3978a63c10d073e9c16bf41fcb8a238fc36e21e0336c10c9dca4efcd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5271f3595f47a7954dfdb71f27325af1afb9de7faae388ac43011eb015162152",
         "installName": "cuda13-nvidia-l4t-arm64-llama-cpp"
       },
       "fallbacks": [
         {
-          "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e9b0ce2e97884821499a1ffbe2c494d4804639cd219efb481dd6f12a13b7eeb",
+          "ref": "quay.io/go-skynet/local-ai-backends@sha256:57ce9418a5d65ed085854c2e5482b2316393e5194a01faf9592a2c0f48922460",
           "installName": "cpu-llama-cpp"
         }
       ],
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6176,7 +6221,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6194,20 +6241,20 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:029f2dea8c2dc12edf171575b0bfad128679d655ceb64d29df0fe75f31ae8fd9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2c7099edf17ef4d7aadd1e975e25c08de5ca248cf4f87640ea070f0b0769d9a9",
         "installName": "nvidia-l4t-arm64-llama-cpp"
       },
       "fallbacks": [
         {
-          "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e9b0ce2e97884821499a1ffbe2c494d4804639cd219efb481dd6f12a13b7eeb",
+          "ref": "quay.io/go-skynet/local-ai-backends@sha256:57ce9418a5d65ed085854c2e5482b2316393e5194a01faf9592a2c0f48922460",
           "installName": "cpu-llama-cpp"
         }
       ],
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6225,7 +6272,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6246,20 +6295,20 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7d91387e6ebbe1ff689ce8de0d4f2e94903db42abb0e27cee1e5c5c40da2d4d8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cc8c4c4945715d6d70f172a217691f973c2eabd81140476d992c047a418cfad8",
         "installName": "cuda12-llama-cpp"
       },
       "fallbacks": [
         {
-          "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3314c17bc95edfb097566335e5ef60c054fe762cdbee48611e8a4d76b103736",
+          "ref": "quay.io/go-skynet/local-ai-backends@sha256:64627220c1c35c3b2114d5226462749aed038d1017447eb3d9b6badf775326cc",
           "installName": "cpu-llama-cpp"
         }
       ],
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-llama-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -6274,7 +6323,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6308,7 +6359,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6345,7 +6398,9 @@
         "hip",
         "llm",
         "metal",
-        "text-to-text"
+        "text-to-speech",
+        "text-to-text",
+        "tts"
       ]
     },
     {
@@ -6363,14 +6418,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:138270bbea4e4029b2b201f61bf339fab093e45493762a805a04a1b9d4900d6c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fbf4f5f928d71a2fd8372698f18c39d3cbbcbad8b8d84450f7e191a0070b9f2c",
         "installName": "cpu-local-store"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-local-store",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-local-store",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -6394,14 +6449,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:202e94bec59f9ad8467060f0ba0477eca4cebad6f1a382ea5bd50d1c37a81111",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:caab5c167dc556b7afd0e62e6f103b775bcbbd91155652a3df47ac01e12646c3",
         "installName": "cpu-local-store"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-local-store",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-local-store",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -6425,14 +6480,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "systemPackages": [
         "pciutils"
       ],
@@ -6471,14 +6526,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1839275444d8a3de4de7a3adac823c2ea8e0d9f3dc386ac2ffdfa216b9eff4e1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:65f7aa60c84dcf69ad644ca63255de7431d61663a87dba311b205c4ddcd1d898",
         "installName": "cpu-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-localvqe",
       "runnerProfile": "unsupported",
       "workloads": [
         "acoustic-echo-cancellation",
@@ -6503,14 +6558,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2733ad8a9077341a7fc7c27537ca0bf283f9fc31f6858280a995000b8c7a6446",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:074f18c15a53d542f3575023b27e938e5e78a6e1b0e06043f19cb5fa8f445bed",
         "installName": "cpu-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-localvqe",
       "runnerProfile": "unsupported",
       "workloads": [
         "acoustic-echo-cancellation",
@@ -6535,14 +6590,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "runnerProfile": "unsupported",
       "workloads": [
         "acoustic-echo-cancellation",
@@ -6567,14 +6622,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -6602,14 +6657,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6640,14 +6695,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6678,14 +6733,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6716,14 +6771,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6754,14 +6809,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6795,14 +6850,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6836,14 +6891,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -6877,14 +6932,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6915,14 +6970,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -6953,14 +7008,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f9a5e04b32e1f73b505b4c85f5e2737ab58019a6e9000c14ec709d8eee817a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51cbdd2436f4bf04a6febcaec43bb52c4dce3872a8198a91cb2b375979dc604a",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "runnerProfile": "unsupported",
       "workloads": [
         "acoustic-echo-cancellation",
@@ -6985,14 +7040,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06cb4ea4f2296249f9ecea001c473210c39cd358b3727ec2329c80daa6b09017",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:088eba6bf8bfb9eeeb135ed8af27b356f110386b5afa4062bff609ec14f40df6",
         "installName": "vulkan-localvqe"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-localvqe",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-localvqe",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -7020,14 +7075,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6e0e969ac301f1369f983aa2dade5cdf64021f647fc1a4109fa0b023005e50cc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d47aff47f982a735b3e6d2d1cb21b91e54990b6dfab6028e109f92c1bf3168df",
         "installName": "cpu-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-locate-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -7053,14 +7108,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cfc325715ba26e48a59c770c88090f7b5a8c45b75e6a475b98dea17352677c13",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4bcf8b9e23e4a01ecdf35f81fc71ba76d2ec2017591d1334a7a458da2b660e2d",
         "installName": "intel-sycl-f32-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f32-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f32-locate-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -7086,14 +7141,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:066864060debb3a599b2396a14b143cb13e25a70ff38d8c727c6ca41f50dca47",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d91237aec164a92ca031e313703c0cb645c9293f9c24e8d47996ea4a02aa317d",
         "installName": "cuda12-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7125,14 +7180,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:643ee5343cf80f718279994b2d2d66f646dd9da1ad29b827cc15aab2f0fbbd43",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:41afa2deb7eacbb97577b813bf0c98e93b701f3413718b6d66281ed11f44d49b",
         "installName": "cuda13-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7164,14 +7219,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:750105021c413be0e8c70aa731063f92f8ec762e19333084d13aa5867fa10e54",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:71f4a842ab4b3c81c7f369c8074de49feb60d712fbb74c1a6cb8a87c123f4426",
         "installName": "nvidia-l4t-arm64-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7206,14 +7261,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:79720843e8c759af35712dd4eb7446350c3fffee320289bf9ccf57787946050c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:41b88bbbcf79ff11d3e832961fa55405a842bd043c7faf5031463496a5bb89db",
         "installName": "cuda13-nvidia-l4t-arm64-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7248,14 +7303,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:750105021c413be0e8c70aa731063f92f8ec762e19333084d13aa5867fa10e54",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:71f4a842ab4b3c81c7f369c8074de49feb60d712fbb74c1a6cb8a87c123f4426",
         "installName": "nvidia-l4t-arm64-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7290,14 +7345,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:066864060debb3a599b2396a14b143cb13e25a70ff38d8c727c6ca41f50dca47",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d91237aec164a92ca031e313703c0cb645c9293f9c24e8d47996ea4a02aa317d",
         "installName": "cuda12-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-locate-anything-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7329,14 +7384,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:894764ab6ed8d94300cacc701db133817c1269cc18d30fd9deae2fe066e6838e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cb50297dfa07628420b2255da479e14b00c33e57f0aa631fe88d9ae6c124c590",
         "installName": "vulkan-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-locate-anything-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -7362,14 +7417,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:482754dba17b6809c555dc32656dac784a870020034bb26f14aa0fc3559218e6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2ef1cb46e18ea97b2b5852d90bca98ecf3b3032176db2b694fe4d62880b13ae7",
         "installName": "vulkan-locate-anything-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-locate-anything-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-locate-anything-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -7398,14 +7453,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ad2d68b1b83efd7a6f4aa2d66c6d0d6880d3571040135826b5cd928596d30f92",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:56a8db6fbec15a44f57db3ecced4753fc234843a4c18ab0543c895a0c089e16d",
         "installName": "cuda12-longcat-video"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-longcat-video",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-longcat-video",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7437,14 +7492,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:da1811b076074319f883fe25dd958630974438ac8fa5946cf2e5e77058ff29e1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7e2ea1eb961c1013cd73dddc4923bcbb919cb5910324dd4f511ed69281ddb542",
         "installName": "cuda13-longcat-video"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-longcat-video",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-longcat-video",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7476,14 +7531,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9581306416a7d5370615be2df0a317b2dc3d0e73812bee89a4f7f91dff0bc250",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:94824e8524c3e617ed0f76b05743d4d6f948ad05954601ee508ced7ed2010211",
         "installName": "cuda13-nvidia-l4t-arm64-longcat-video"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-longcat-video",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-longcat-video",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7518,14 +7573,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ad2d68b1b83efd7a6f4aa2d66c6d0d6880d3571040135826b5cd928596d30f92",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:56a8db6fbec15a44f57db3ecced4753fc234843a4c18ab0543c895a0c089e16d",
         "installName": "cuda12-longcat-video"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-longcat-video",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-longcat-video",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7557,14 +7612,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ad74c81140d47a247f6c656619ceec09ce0f0b25084daedc9a871a4f9d706d3c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d6c0ab4f25765e5c30d2fce9b71f34b61264c435d6e8195653a1917072377db0",
         "installName": "rocm-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-magpie-tts-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -7600,14 +7655,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8ca86996d7e3a75b08c773aa1b89b41fd3fc1914f6edcd2967df63187b53573a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ee7c6fb6c0d800dca257da74e2b34d4184add24526ca7d23e4ea07d453e9104a",
         "installName": "cpu-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-magpie-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -7629,14 +7684,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:241827c4f29933e02531f23aa22cc6f0dc917d3e2089c70ba045ec2c7cb2ae52",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3947a29977091324a5556104ebd94ede3e081968ec8529615e4471b93d98125f",
         "installName": "cpu-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-magpie-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -7658,14 +7713,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fa3359b1d99dcf67568ed788fe65ccad0c886412b98c391b21f846367cf7f5b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:53b8c888ce80a704e814ce713ff01e626a7be50f96e929350106b38dd2730aed",
         "installName": "intel-sycl-f16-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-magpie-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -7687,14 +7742,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:58efd911e792331cba668abdc27b021d9252953c8ab77d8c91636409c7c4e4b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e55bdf46222dd84ea4f42d1b817cb4a49c7dfa3611fe5abe8e6383ac8dd255a",
         "installName": "cuda12-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7722,14 +7777,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cc5206e01cda87f239c9608f8cce916a1d03df38c89c2cfd693a3cb83e77ff8b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fab84d3597cf94a98645aead61b86cf9de10f428efae04cb7812caa2fc23f58c",
         "installName": "cuda13-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7757,14 +7812,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e77ef66c13329923c10e32b1ceecfb232808ae3387532c2c3af5be97bfecdb8c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ba421ca6906a0f41025b7747c1a5115b3bb3797bea17c1cf44d63ae0444f5ccf",
         "installName": "nvidia-l4t-arm64-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7795,14 +7850,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d69ca5af50a85e8325f0c5e13727d184b99b46af668ed8f13ccf0ff594aef223",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5316d7cc1f5c4aa4ff26d93cebcd8cf5193c136dfcddd61c0eeb4b069d57f169",
         "installName": "cuda13-nvidia-l4t-arm64-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7833,14 +7888,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e77ef66c13329923c10e32b1ceecfb232808ae3387532c2c3af5be97bfecdb8c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ba421ca6906a0f41025b7747c1a5115b3bb3797bea17c1cf44d63ae0444f5ccf",
         "installName": "nvidia-l4t-arm64-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -7871,14 +7926,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:58efd911e792331cba668abdc27b021d9252953c8ab77d8c91636409c7c4e4b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e55bdf46222dd84ea4f42d1b817cb4a49c7dfa3611fe5abe8e6383ac8dd255a",
         "installName": "cuda12-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-magpie-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -7906,14 +7961,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6aacb79f34857d580a99bdf42f077c9905ab7c60be5bef32a943eae5794c21a7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0377b877a0180a27d0482755a8512abc55b31e2621293d84e0e6c25318e2e7dd",
         "installName": "vulkan-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-magpie-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -7935,14 +7990,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:309289514e0cd031fd02886cd1fb31c4142c8779a4ece5cdf1de6b82bbfc5c47",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:60e18105c43a5c9a8570f978caf25836fa4ce42b09898310d5c6c46baa6b7a79",
         "installName": "vulkan-magpie-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-magpie-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-magpie-tts-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -7967,14 +8022,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a5458af23f08b25f2ee6edaada7af73c957e616ec08aa70632b34ff75095d558",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:869a78b5cbb7b4d768c07c65bd4e030ac543c4085837fdd258c56028227d9327",
         "installName": "cpu-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-mlx-audio",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-generation",
@@ -7999,14 +8054,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5166c27cced6e283966353dcd9e8ba22d1832d6e1fecdc98c8b39f562555d30b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b43f29b373b97b18ce9ccf6b4c869939dc0df6844d9e35321ad82761ebc11354",
         "installName": "cuda12-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8037,14 +8092,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9060ce00a82a54cceef165af1d3c0c3342b45379b052af3013a541ab5030f58b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:886893908e9f2fee6df5b8b44f4ba27b2c0dba5f8d32d751b22734392cb31e4c",
         "installName": "cuda13-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8075,14 +8130,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:99ef804c3a673bd58a1f84da50316499c514147f9800cb81fd8dfab482c71e59",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c8a861bed25d30f2e78b2106e0482d3aef35fceec02daea261f25455213710d",
         "installName": "nvidia-l4t-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8116,14 +8171,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4b8530a93f17ae6388f3e8afe3963bfdd4294bf61a7c730f9ae0a6cf28a5d29",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3c9bb922c750516798590b66e96d057d881cbfd7d06a402102ee302ed76726f0",
         "installName": "cuda13-nvidia-l4t-arm64-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8157,14 +8212,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:99ef804c3a673bd58a1f84da50316499c514147f9800cb81fd8dfab482c71e59",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c8a861bed25d30f2e78b2106e0482d3aef35fceec02daea261f25455213710d",
         "installName": "nvidia-l4t-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8198,14 +8253,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5166c27cced6e283966353dcd9e8ba22d1832d6e1fecdc98c8b39f562555d30b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b43f29b373b97b18ce9ccf6b4c869939dc0df6844d9e35321ad82761ebc11354",
         "installName": "cuda12-mlx-audio"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-audio",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-audio",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8236,14 +8291,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b6e53bf82c0a002932118f6a93b88e17033c0abb285d6f0113133f31db96fe34",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0f367887c7ff3b976ae28b895bf532bfdf9fa655f2e74424c15d7430e0f69d9e",
         "installName": "cpu-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-mlx-distributed",
       "runnerProfile": "unsupported",
       "workloads": [
         "distributed",
@@ -8267,14 +8322,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3ee0880b0f2394a2f28348341c689090648bcfab76e469073c2eb3eb149010e6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b3babf00eae95426757f27e4573ed4f8901f309a0fe5806248d8fb0ca4c584d8",
         "installName": "cuda12-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8304,14 +8359,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4ebcb0fdc6497d9cd9fffbbe6750e262fa5786368f63f47858b0e4075208ac00",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:20d2e4d9f40005e24b6349a0d5b60aa0881794ffb50fdf5e5f60d1f43ac2caaa",
         "installName": "cuda13-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8341,14 +8396,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dba9920bf90d3d1837e5b74e65ef9c984073e9b91614ee7263ca11cfe86ff0dd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:35563638d6768d187691d0152fd125b45e49774d8ce302a4f68651e6c914f224",
         "installName": "nvidia-l4t-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8381,14 +8436,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:74cc4146534db5f3178c80e0d96ebe69f57ac273acca54e9f06604c2c016d489",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9afd221dc75517d54af8e9b12b31f35e2c8b909f1d44bbfa9e741c5a1bbbf93d",
         "installName": "cuda13-nvidia-l4t-arm64-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8421,14 +8476,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dba9920bf90d3d1837e5b74e65ef9c984073e9b91614ee7263ca11cfe86ff0dd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:35563638d6768d187691d0152fd125b45e49774d8ce302a4f68651e6c914f224",
         "installName": "nvidia-l4t-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8461,14 +8516,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3ee0880b0f2394a2f28348341c689090648bcfab76e469073c2eb3eb149010e6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b3babf00eae95426757f27e4573ed4f8901f309a0fe5806248d8fb0ca4c584d8",
         "installName": "cuda12-mlx-distributed"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-distributed",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-distributed",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8498,14 +8553,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c288d8f8349988171a5de9d40b7b6c662c0e344c3b244711c0cc832d3389fd16",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dde81bdd6c3bf39b5fcb4f113b8252819986e8a85b6dcfe6105a22cc7ecbb552",
         "installName": "cpu-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-mlx-vlm",
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
@@ -8530,14 +8585,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:77785c5e9305a23e3364cf4e735394cb51cc1685c9d3942bc073379ec1582f7e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a3a6a8337accf56609131701eb1e4fdb51c62aff4f5d25198610b218df57b3ac",
         "installName": "cuda12-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8568,14 +8623,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3ce640bacc9765b0106a204ac62c007c72bbfc3182291252f5d4475f88788de",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:27f377e2f9e73d10158c8b2828ffc70256e9345feb8a7bf951dfa18cc1ef3542",
         "installName": "cuda13-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8606,14 +8661,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:10b3f0dd0b686e34909890e70998ed5c108fbe4dd858bf2e0c0bfc1343a30861",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a8e9bee4ab73197ce64545a3b64fa7c9c90e6b1497bda1655337aeee35e45503",
         "installName": "nvidia-l4t-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8647,14 +8702,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:167e62d8693ecf02e5182e08a84a14aed51d1e3d8004d087c734db7998ea4268",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4bfa3593019a951e67c72413b92c1cc1a74545f7157720165af4da9df602f020",
         "installName": "cuda13-nvidia-l4t-arm64-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8688,14 +8743,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:10b3f0dd0b686e34909890e70998ed5c108fbe4dd858bf2e0c0bfc1343a30861",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a8e9bee4ab73197ce64545a3b64fa7c9c90e6b1497bda1655337aeee35e45503",
         "installName": "nvidia-l4t-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8729,14 +8784,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:77785c5e9305a23e3364cf4e735394cb51cc1685c9d3942bc073379ec1582f7e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a3a6a8337accf56609131701eb1e4fdb51c62aff4f5d25198610b218df57b3ac",
         "installName": "cuda12-mlx-vlm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx-vlm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx-vlm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8767,14 +8822,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:31243ebcf94a65d27b7fb0adb0cb9e502e62b781db7e6d51342994e9d662b069",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e615fc43d537cb76c428d3ae57beef130128bee65989afe81ad8bc4b5b03afb2",
         "installName": "cpu-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-mlx",
       "runnerProfile": "unsupported",
       "workloads": [
         "llm",
@@ -8797,14 +8852,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:17f38eeaef2d1f9771d521100202c331c978c9e0085a907781f52634b6eada73",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4d90db5229736b07e3e0f9fa0318bbb384467ca9875ff4c9679e911b7421203b",
         "installName": "cuda12-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8833,14 +8888,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6368e3dac39d5a02a4d2eba326ae640bc798c548f197147fecc7509cf160e50d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ff670a5888547f42409b07c65e00f829320d07578958b6e925a6e0176a0edae7",
         "installName": "cuda13-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -8869,14 +8924,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d666dc96ceaa7b21a7c6aaaeb7cc5381087316c24280276c4b704f3655bbbb98",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db357f2a38c5b2ac2666dda6ffabd255f25965a3f65693601838354e91f72deb",
         "installName": "nvidia-l4t-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8908,14 +8963,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b55c7cb79e57d9931f1e3b39b0d9ad52f97ab041f10cdb2e634bf34dd0faefe1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cb35999a2932267147fa50850c53c6b9f6bb0ec2b27da4a31863c119607ffddd",
         "installName": "cuda13-nvidia-l4t-arm64-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8947,14 +9002,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d666dc96ceaa7b21a7c6aaaeb7cc5381087316c24280276c4b704f3655bbbb98",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db357f2a38c5b2ac2666dda6ffabd255f25965a3f65693601838354e91f72deb",
         "installName": "nvidia-l4t-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -8986,14 +9041,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:17f38eeaef2d1f9771d521100202c331c978c9e0085a907781f52634b6eada73",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4d90db5229736b07e3e0f9fa0318bbb384467ca9875ff4c9679e911b7421203b",
         "installName": "cuda12-mlx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-mlx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-mlx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9022,14 +9077,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ad4085285b02e95a6914f63ef2bbe869d4a57f2bd8490b544c9d8f5c3c71ee0d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c1447fcf3bf2a5fc891b8f707de368b4f9a677eb87720eda508bae808c612847",
         "installName": "cpu-moonshine"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-moonshine",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-moonshine",
       "runnerProfile": "unsupported",
       "workloads": [
         "onnx",
@@ -9052,14 +9107,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0eff36e04aa0082648eaf74ec25722ab193e01655eb7a15cfdd71f92bb0a4db5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d9decb374a024b5f81f3fc39c6e4dc3fa36eec08d84d8c2c7069ba0a591c9cb2",
         "installName": "cuda12-moonshine"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moonshine",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moonshine",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9088,14 +9143,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ae55e5cbbcfad8c65f93b703ad6352c97b2952f7a62d333632bdf79015585d45",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5f39a02119806ac41f5fa1a2cf4dad826663111c325ff88fb33f1f38c4bb56b1",
         "installName": "cuda13-moonshine"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-moonshine",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-moonshine",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9124,14 +9179,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0eff36e04aa0082648eaf74ec25722ab193e01655eb7a15cfdd71f92bb0a4db5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d9decb374a024b5f81f3fc39c6e4dc3fa36eec08d84d8c2c7069ba0a591c9cb2",
         "installName": "cuda12-moonshine"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moonshine",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moonshine",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9160,14 +9215,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2c1a3603d9b5a1de3f35dbe699e329457f47b0de50a72bf39d71343b16977e2b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c54fe06984d719a4f6b9fb87fc28d5fe35fc0392edd52fd86d11416ab8349188",
         "installName": "rocm-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-moss-transcribe-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -9206,14 +9261,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4f295cf35ebdd8d5b988ec6ac789dd331892bb340ed4f2c24764105188e16076",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:69b4a83670701d321d045894620d1af8e515434c0e4f04922766908b67eca0f9",
         "installName": "cpu-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-moss-transcribe-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -9238,14 +9293,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:241034df4d852c9034a035dc19928513a88f49c04358908e15d081e8a80de354",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7e7e90c9885564d777ac65821bd0dc31c52e55dbe5eb9dc867d9f849d074d75b",
         "installName": "cpu-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-moss-transcribe-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -9270,14 +9325,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db6ea30d6b4ccc6449ac6e1700ccd58b4725b3f2cc386f6a32d614931e194117",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dae0e1560ebe4fb70a88612ba14c18b4ae93661eaf26345d456cccb85c0dad8f",
         "installName": "intel-sycl-f16-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-moss-transcribe-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -9302,14 +9357,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dd7967140a22d1392ecb2ddb5194c785c9b97f1d026faeb366ec8808f5094879",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bbcf63883e65b9e1ba2f17ebe88461f8298b506d674c8a22b82005bd02b1266a",
         "installName": "cuda12-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9340,14 +9395,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:013a0b3530efd5b5ffd0bccc573dfbbe5c0fecbdd8ab1cfda0a3c237a623b607",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b1d3d586ccd6be7d51f1cd4a6d4d54169176a8af52b885be7dd25528f33e29c1",
         "installName": "cuda13-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9378,14 +9433,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5114164aff41d8761cc14d3d2260cc03d8b0825536be26f3e44ec2238a546b43",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:31cc91415e7807ac441a7e2ddc9611eb3b56bf985c7462118545e511305ad368",
         "installName": "nvidia-l4t-arm64-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9419,14 +9474,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:09e175d69fc4319019e9fd56ddec08837b68bf81ea168d5309db42bf994e02e5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:17121d08394814f43ffccb03afbc755b5bfb394c286c69d7f1133f8f85f3b6a7",
         "installName": "cuda13-nvidia-l4t-arm64-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9460,14 +9515,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5114164aff41d8761cc14d3d2260cc03d8b0825536be26f3e44ec2238a546b43",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:31cc91415e7807ac441a7e2ddc9611eb3b56bf985c7462118545e511305ad368",
         "installName": "nvidia-l4t-arm64-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9501,14 +9556,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dd7967140a22d1392ecb2ddb5194c785c9b97f1d026faeb366ec8808f5094879",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bbcf63883e65b9e1ba2f17ebe88461f8298b506d674c8a22b82005bd02b1266a",
         "installName": "cuda12-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moss-transcribe-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9539,14 +9594,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1eeabe40ab8172df8f08274d2d8952eb14ef3be4323eebd96cee5a1cd200985e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ed10babc1bad3f98b353a0cc04fe29e25f23c68367ec578bccdd84c5392fc78f",
         "installName": "vulkan-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-moss-transcribe-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -9571,14 +9626,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:baae145cf75338b5eb164373b3478497d5ff837e7c7a3e730ed4ceae4215c9df",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:309f8be516b8f82d961b59a7ee38927ac277f320de76ac398a38a75afae605a4",
         "installName": "vulkan-moss-transcribe-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-moss-transcribe-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-moss-transcribe-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -9606,14 +9661,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d95bb99b59da1b0e7938d5c3bbf20fdee8ac7bb25766f667bfd0c8ea5b0b3cfe",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2f04b8f1798aa0afc554db35a7a4bc9dd66c3155c32cfc4b9d9f75eb0b529aff",
         "installName": "rocm-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-moss-tts-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -9650,14 +9705,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f6e06b9b322070a5f65d922176db1ae93a478fa9228eb106193fbb13ab3ecabd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:69e18acdc1590dd8d88fdc321b1d44eaf4a2bff5cbcc523a1bb602fa5a409bbb",
         "installName": "cpu-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-moss-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -9680,14 +9735,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0ca885c4b56030231b5fa711fcd5106159ad28d551a3afc87f75dccc1f923e2c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2029e3e5a1f8cf537bdaf56f5f3a4546477c5c80a27dfeac8c015c56277f6ce8",
         "installName": "cpu-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-moss-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -9710,14 +9765,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:93e6c9fe2d5dff0e2b2015153deae7f44a19003ed60341a7fc1d87b26a9e08b4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:405a601d692872a52aa4d059e39b3a2b4b67665b08dbf7df6800fc57b6a7b048",
         "installName": "intel-sycl-f16-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-moss-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -9740,14 +9795,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:49bcc662557648a2389d9906d2e2ecc3599e97cb3a03b42a06a3ce6a8177c875",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b59cbcf7f53a05cdc2bd330f6e1e08f1155549932156adf6bfa514482985faf8",
         "installName": "cuda12-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9776,14 +9831,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5d99b4591064ebb2bc7794ed8e563918ce55cba0131b37612f702dec1ba4ad7a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2f8dba2a195d6edb04b2d7fb5ead033d809ded2726cb366c52848b9f3148b1e6",
         "installName": "cuda13-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9812,14 +9867,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aeb61165756fc4af63dbc77309ab2f5166b89647df1c4fec72f71ac85cb5abf7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7cb9a1d4371a12865f390ef2cf996be695839b0473c98eb74f5d028ce0974d5d",
         "installName": "nvidia-l4t-arm64-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9851,14 +9906,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50969da24e02bc0c110726449814a91af4ddb262995c7ce682339efb81caeb3c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1dcabd172b0d6ac60557a2ade65d3986aa6cee77b035d4007a05fbf65b54d7d3",
         "installName": "cuda13-nvidia-l4t-arm64-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9890,14 +9945,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aeb61165756fc4af63dbc77309ab2f5166b89647df1c4fec72f71ac85cb5abf7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7cb9a1d4371a12865f390ef2cf996be695839b0473c98eb74f5d028ce0974d5d",
         "installName": "nvidia-l4t-arm64-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -9929,14 +9984,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:49bcc662557648a2389d9906d2e2ecc3599e97cb3a03b42a06a3ce6a8177c875",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b59cbcf7f53a05cdc2bd330f6e1e08f1155549932156adf6bfa514482985faf8",
         "installName": "cuda12-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-moss-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -9965,14 +10020,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e8064a730947039348ff820eff25e3fd6f9db2bd48e389a7fff210d9a91c94ed",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:af519e90eeb1cbdef81f06a70e4d16620d988dff3e88b3a77368eb70ef691c24",
         "installName": "vulkan-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-moss-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -9995,14 +10050,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:53d7bdd3bc8ff5bdacd06cc13ecdda8ed5b5e2313f9c65e9c7400e98fb6076b2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:501dd276424e78f66b816d98a7478fe525d9748af036be41552aa3a34f7620d9",
         "installName": "vulkan-moss-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-moss-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-moss-tts-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -10028,14 +10083,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9c7ccf1fac9150a7df70eed5c0897ce8704e1b2891e90dc3f6ff91200f266508",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a882aae94ad91ca935f803c664c25cf43a08158b1e42ddef3af0a0425506b095",
         "installName": "cpu-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-nemo-speech-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -10063,14 +10118,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c35cfe011656289fa290afdd77537a74f9ae5911aae60a403447c3a4267c09fc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50401bccef778d9138467bbcd04ee5ce0c6289abc44e93227660f17f5b7033a2",
         "installName": "cpu-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-nemo-speech-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -10098,14 +10153,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f18ff69987a4d85577686e15d8c95cae85db497bad1be21cf763f67b9e167ffd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fc41a4c215a7dd792b7e17d73bc62042080eb13e452f498e43755080a7bbbf75",
         "installName": "cuda12-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10139,14 +10194,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d37fd20b16ce1f7c8fc7cc7bbc1a481b955932c91f108a34e5e652c4523601c8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dc5afb49f39c0e2e57c19427fe7f2dd36cc83de970c48c737810d21f149fc92d",
         "installName": "cuda13-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10180,14 +10235,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bd53174bff85a6e8d89f64ece25b1625dcde036b1c54718f7d6172c0a669710c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:28d175652a12e23fedb4cfbcd0fe35267f95ba7776ff76a90022a5fa648911e0",
         "installName": "nvidia-l4t-arm64-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -10224,14 +10279,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f661a85fa9a74e1521f3b1408e776f27da84449c473ccfa1f23e3ac38ba9553b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5b46985e0ed7dbd3ca69462b3a59528ef7fbcf8d6020048a96ed3d01d8079c35",
         "installName": "cuda13-nvidia-l4t-arm64-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -10268,14 +10323,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bd53174bff85a6e8d89f64ece25b1625dcde036b1c54718f7d6172c0a669710c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:28d175652a12e23fedb4cfbcd0fe35267f95ba7776ff76a90022a5fa648911e0",
         "installName": "nvidia-l4t-arm64-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -10312,14 +10367,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f18ff69987a4d85577686e15d8c95cae85db497bad1be21cf763f67b9e167ffd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fc41a4c215a7dd792b7e17d73bc62042080eb13e452f498e43755080a7bbbf75",
         "installName": "cuda12-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-nemo-speech-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10353,14 +10408,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9321748dd4b533d33737bb84f89cbaca5fea0f58b9fbb1ef40e3ca7f66ef4823",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9a9f817071f3f81761ef88a629b467d5d904126d2ae6f90032ec36983d7d5611",
         "installName": "vulkan-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-nemo-speech-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -10388,14 +10443,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9aea81198590e9163172c18fb5f3a5ac67f4d5cb46aaaaccb04989c8d24ec474",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b843b1513adf32e79b12e181f84bab8a6de35463fe5282a91086f99bd6dac5d6",
         "installName": "vulkan-nemo-speech-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-nemo-speech-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-nemo-speech-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -10426,14 +10481,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b40d320fce57dc6760c04e990b27abd609f6e77160191ae1f21f434d104d274b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:182ee1afd3c03f5ba03bfc9ff251f077812b78a73e46ce1e3910cec396967abd",
         "installName": "rocm-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-nemo",
       "systemPackages": [
         "pciutils"
       ],
@@ -10470,14 +10525,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1c262ed38fd166719021aff9bef9aabc38e26f9e8a3b0f1f92f7ae4fc4f1d4d7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5800e6e9c9138b772dc9ce262fb3e7d8214b210b847b3faffa9b469dccfa4266",
         "installName": "cpu-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-nemo",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -10500,14 +10555,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b8aa72f0e32b233699d77f19b2a350d679c2a94a8cd13e547b5e686d56203ae3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e65a9c3d0c45da9b41f65ce648f1ea5bf9e60ab29907c51b8881bcd01d92d2e7",
         "installName": "cpu-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-nemo",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -10530,14 +10585,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3de3d711a7a6db5234e46c176a43963e23de2a20bd14a295bb5e48dde687e6dc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c0efbbbc4499b2c902b3bad65d971a28f5063bbbbaa6b9bf8255c3548ccceb9d",
         "installName": "intel-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-nemo",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -10560,14 +10615,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:544a07a04da5a3e9b375c8a010f17fea6a08d7ac033a1eaed70853bc5ee212ee",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:104dc768f6789e8f0870071d033f7142c80901893a9b36622c1ba0fe03cd01e8",
         "installName": "cuda12-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-nemo",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10596,14 +10651,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:915365bcbfb3a91862eff990095d70b406c6902c86e121c2527bb3647f36d529",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e1bba5cc40378eed90ca8aa070d99797e39fee4003587b595d0a457bfd55f213",
         "installName": "cuda13-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-nemo",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10632,14 +10687,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:544a07a04da5a3e9b375c8a010f17fea6a08d7ac033a1eaed70853bc5ee212ee",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:104dc768f6789e8f0870071d033f7142c80901893a9b36622c1ba0fe03cd01e8",
         "installName": "cuda12-nemo"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-nemo",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-nemo",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10668,14 +10723,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6f943e7ce2dafdb203ea7b50ede637ffb82f7d605453ce4eee5c8be617164f38",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:705c40065bdc2d07dfebe896277172007cb9c32b7014b2ead504abd997d2a20e",
         "installName": "rocm-neutts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-neutts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-neutts",
       "systemPackages": [
         "pciutils"
       ],
@@ -10711,14 +10766,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:42ba5d3904542eb851e3d2569c23829588f24792c135e1dac9198dee162517c1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cdb3f1de0334471a12a0a799763479d5e70737681b58a5dde40540144cc4da8f",
         "installName": "cpu-neutts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-neutts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-neutts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -10740,14 +10795,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4a1666efd7328e1208f0d60a1cce8127561dad9aa29b099a2483cb8e2f7b6fce",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dc9891e66c12ab8f02ab70d5ba8424b64901c97cb23caadeb2b5748e9c7c7d18",
         "installName": "cpu-neutts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-neutts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-neutts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -10769,14 +10824,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a71e1821235d0354f4ca41f57edddf06257b4baeb6ab6da303bc8e3d6ff4f6af",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b56ba2d215932f21997679e4405a085de8887238dbd4b4cfd1c1a029dbfc8731",
         "installName": "cuda12-neutts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-neutts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-neutts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10804,14 +10859,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a71e1821235d0354f4ca41f57edddf06257b4baeb6ab6da303bc8e3d6ff4f6af",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b56ba2d215932f21997679e4405a085de8887238dbd4b4cfd1c1a029dbfc8731",
         "installName": "cuda12-neutts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-neutts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-neutts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -10839,14 +10894,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9b41d0d106784bf1d52dcf76ca35e69a44488fb2470dcabadfac2132806559cc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ec6ccfdf8e453b28d76b9900ef05430c2ddc16524fcf16b3adb9d9f09b0bf5ff",
         "installName": "rocm-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-omnivoice-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -10884,14 +10939,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e8d59a0ccf4d47ee30e3c143af4e8332f9ee2e0d1d185511691c36bb75a845f9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4d209e3b03247739eaf52deb5997e6d354ac4c2e9f26d34870b0edb3df35d48f",
         "installName": "cpu-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-omnivoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -10915,14 +10970,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a12513da9e3ec1cfc7677e2f5150afdcacd3d658e7ad25350b63f92e2297134a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7ce2544eac9eb8f914c084a25ea268a21243044c1ad1cb5b4e13f3d7407aa70c",
         "installName": "cpu-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-omnivoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -10946,14 +11001,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:03d45520a6b05b8b412043cd095450eb0fe11c58f8e293a2558b1fcc138ae086",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0fa0ba754d14c052f46576596c467012a6ab4c6e860344b5664dfaafd9cf5110",
         "installName": "intel-sycl-f16-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-omnivoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -10977,14 +11032,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:619b1aae7529ecacc1bebca2b6bee773aaa0bf9586f97e9490c337d51ae2e2c9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c36a03e571e92c1d2b6eb33fcb9a27a3adf3e4b280aebc99efc9783711e9621",
         "installName": "cuda12-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11014,14 +11069,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:188c25102997a4d87a09840b32b7f01a08e7407b27e68527a3d852bc670c43c6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a91ed7d8569686b194f01d94c622e714a450963859b9662733621f4a7efdd0ec",
         "installName": "cuda13-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11051,14 +11106,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:79d048fda9074e1f178c2629f880c5675bca6eca995dd2194517394a73a1424d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e8a16e6d2bc017c28f0bb6ecf9204dd311da41baf3a496e02afb047529ca80c",
         "installName": "nvidia-l4t-arm64-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11091,14 +11146,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ac0dcb703b5febf944a29785bac96b3250833d6ed4d7802c5afd209f6d9be363",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:91c3a9e5790bc9e6dd70929f6cbf958cffa753073e8fc46e5b5ca1dd53730efd",
         "installName": "cuda13-nvidia-l4t-arm64-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11131,14 +11186,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:79d048fda9074e1f178c2629f880c5675bca6eca995dd2194517394a73a1424d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e8a16e6d2bc017c28f0bb6ecf9204dd311da41baf3a496e02afb047529ca80c",
         "installName": "nvidia-l4t-arm64-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11171,14 +11226,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:619b1aae7529ecacc1bebca2b6bee773aaa0bf9586f97e9490c337d51ae2e2c9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c36a03e571e92c1d2b6eb33fcb9a27a3adf3e4b280aebc99efc9783711e9621",
         "installName": "cuda12-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-omnivoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11208,14 +11263,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:80a733ce919ee1647d55bb90bbb9e577a8288acd0ad31f6c01d024ca794633ef",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:36a7e4594196ca15a7a0a01d9ddb7afcc49154715ffd796b45650b9d307defdf",
         "installName": "vulkan-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-omnivoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -11239,14 +11294,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:761fa9492467cde879d51421341357c4f9f78537d8adf6449b2762df4f9a7e77",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6491c86d39b15a2b2d6c48a6e4cd413baf15e0af102bed208e51ebf189dc6940",
         "installName": "vulkan-omnivoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-omnivoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-omnivoice-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -11273,14 +11328,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:86a87e4dfd173fe8e2d2ae60706bf8887a32e5524bf26375d5c5fb4082a08873",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a43fa39cec5f3bc35a4f4b35c66fb5b5b16f4bfd736888c062ca23facf142157",
         "installName": "cpu-opus"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-opus",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-opus",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-codec",
@@ -11304,14 +11359,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50c96b58c06e4de80dd418e2509d5587dd82e760ca20b17908bca7672b2cba9c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0b13c3f6328e79c03cdb52e16f31d08c8a94d4ca5e0571451f60ef549eef449b",
         "installName": "cpu-opus"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-opus",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-opus",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-codec",
@@ -11335,14 +11390,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d36199734ee4e08dd3e6f0e6be545f56dce70ea7731d879d91daeaec5ed8eceb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d2956858c1be2dca39b20c1f5dd7dd7b58d5298d4eca5bfda1b3222ab1a227fd",
         "installName": "cpu-outetts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-outetts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-outetts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -11364,14 +11419,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9e33c6784111e4508ec0fd8fa53feb4da337ba206f84b1c70a6754081c99f450",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7c1286f4f88ea4c845928c58998b5733b46c8ab81069a024b32124251a3dd6fa",
         "installName": "cuda12-outetts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-outetts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-outetts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11399,14 +11454,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6a4a9ed6441278f5d30a9c4b5119a1b359876317b7f06279ce22742117864b1c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c86a400a8f64a6f054f2559f77ea454e98afd5a33a05e267595e70568e60855a",
         "installName": "rocm-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-parakeet-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -11445,14 +11500,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7e026066140989f30ff90c2e9133aeddf3d6f241597dbb42dfcf64c11e02b6ef",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0a05ba041314114756424102f02c9be53fccaf85af46fd7e9f750313134d5934",
         "installName": "cpu-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-parakeet-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -11477,14 +11532,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6353fd7be8e59fd94ebf77e0e308dd3a23564924870a906f831d5fb116ac8360",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e50b808180f9fb59a7147b0f7759fa77739da260dd340433db5d447d200f9cd7",
         "installName": "cpu-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-parakeet-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -11509,14 +11564,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bf7b13347d1470cd27e914d48dc7d263dfa3933bfa3b19830f619f2159b4fbd1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a08ff633b22dcc8d988c0b5512894542271320b2591c2bd1c119ab19176b1e5",
         "installName": "intel-sycl-f16-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-parakeet-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -11541,14 +11596,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:69b42532b6956007a4b3f59dece290467d8584f57a7bd0a19a0437a3d6152841",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c54b450084092084c3acbb0db0cdebf88aa5e5cdc774d0b84caf0b5ce2567b5f",
         "installName": "cuda12-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11579,14 +11634,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b438ffe4c7f38fd105879fb0170ead6d78cb6ea056a94c615bfc5a4e0fdd2f90",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:97c1b98a8cb76c02470a74a5b375a554ba8f59f42e89377758e4f88dbce2d018",
         "installName": "cuda13-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11617,14 +11672,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:182dae6b8659c313e91831fee07966f3c19b4cd7d1783fe512ee6c175fdbaaa1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db2069e2cebf232c2d1c2473b913cd0a6bb65f8d973874cc155b1c9800554a27",
         "installName": "nvidia-l4t-arm64-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11658,14 +11713,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5fea834ced7cba7bf3938ac010bf98a75ce54da1be8fadb7174292c698cb9102",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:27e1f165bd3f09a5d551d8ccb7fbccec1d2371d87a95c3fa83b8c924baef71e7",
         "installName": "cuda13-nvidia-l4t-arm64-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11699,14 +11754,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:182dae6b8659c313e91831fee07966f3c19b4cd7d1783fe512ee6c175fdbaaa1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db2069e2cebf232c2d1c2473b913cd0a6bb65f8d973874cc155b1c9800554a27",
         "installName": "nvidia-l4t-arm64-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -11740,14 +11795,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:69b42532b6956007a4b3f59dece290467d8584f57a7bd0a19a0437a3d6152841",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c54b450084092084c3acbb0db0cdebf88aa5e5cdc774d0b84caf0b5ce2567b5f",
         "installName": "cuda12-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-parakeet-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -11778,14 +11833,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b9d29bb08478ed65440f4159b6cf08719a2c2378f08fab98e30c16f247fe0134",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:acdbfdddfe4cf6aaf336bc7e77c4d4ab563b2dee771d0c56c68a1ec5b98e53ec",
         "installName": "vulkan-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-parakeet-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -11810,14 +11865,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:87d4384860a007ed88f5f2629902d1b18edd7844fd2a81a02f8535de1e1b95b3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f7bb8f4bf9e2e3bacf59b3e926cb5a6976cf27be16323cde4dc0aa3f207d0e3a",
         "installName": "vulkan-parakeet-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-parakeet-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-parakeet-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -11845,14 +11900,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:180c4e0f85d4801f508cc92442865b3ea2d272f87196fd9e3708b27432990bb7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:373aa02b18b8deecff7b8962c12fedbe3eb1602e7e9655ef918d3d793fd94ef3",
         "installName": "cpu-piper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-piper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-piper",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -11874,14 +11929,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:501fb22f4eafed20aeabe35ad834d0c0945e1679b68b0fb8aa9810cf2cfe9bd0",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6777fb9e45a3c1f2cb838769365752f9a4c1a2d1f59b9bdfda01c57a6a62ed88",
         "installName": "cpu-piper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-piper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-piper",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -11903,14 +11958,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c413d8cd3f0da2bc53f9b72e68d67d164d16fd990d38b4a912fdafa48bfe1b66",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7c7b7b80cd2c4271b6519d135d9585b975b8059b1b1dbc65fb610f01cc4d5181",
         "installName": "rocm-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-pocket-tts",
       "systemPackages": [
         "pciutils"
       ],
@@ -11946,14 +12001,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5596af81b99a17181c753f5dee10c373a32c7a85db407827aa56b68933f5958c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e4e3ab621141bae3cb04c97303e0daf56b8287f49c35ed053a335d28c9271057",
         "installName": "cpu-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-pocket-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -11975,14 +12030,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f4cfc4a5101025a28cf20c495eb5c35e02a7b90ac7680bb6baa3d29d04d064bf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8f25454223a4a27916b488a0f6eb498387eb9c0029a28eee362b30296d01ac89",
         "installName": "cpu-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-pocket-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -12004,14 +12059,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:96777e350bea3500660dfcd75569256ddf2965f3d5071ca573f1f88971f9b99d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e73646668b28fda7523db98eb158cf55937ca1129b93a46d98edfbbffc4ea539",
         "installName": "intel-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-pocket-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -12033,14 +12088,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c4821efa1a548a36643fdde901dfa64016c0f31b26cc4663fa8a52ae050a1629",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f0e509e6ba88ebfcf81404a1492a30aa2f16ea9ab22a2d848c6c673ffb78b94",
         "installName": "cuda12-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12068,14 +12123,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:72cbd2ed3e7d0acb65dd60f9e6e52f1cceeb56d0394e7d04532c8286f5093033",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ca5b08932ed2fcf48c77c7d7b8f5e5699cccce0c39ffcff31f1432bb101911a0",
         "installName": "cuda13-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12103,14 +12158,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:74ca49ad61565298951177f714e62e223e27498dc87084160cac1ec7e018c6c9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:81bf35ec446683d51112294bb1b94684d815ead324081107ddc72e4b9a50dc56",
         "installName": "nvidia-l4t-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12141,14 +12196,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:91c00c12c471ac2b9075141926a203d7fee8e49d5bda34155b3083cd48287b98",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6c1bf398a34f7e549180af68708237ca29ac2c765e4823eea023b21e3cfa451d",
         "installName": "cuda13-nvidia-l4t-arm64-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12179,14 +12234,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:74ca49ad61565298951177f714e62e223e27498dc87084160cac1ec7e018c6c9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:81bf35ec446683d51112294bb1b94684d815ead324081107ddc72e4b9a50dc56",
         "installName": "nvidia-l4t-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12217,14 +12272,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c4821efa1a548a36643fdde901dfa64016c0f31b26cc4663fa8a52ae050a1629",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f0e509e6ba88ebfcf81404a1492a30aa2f16ea9ab22a2d848c6c673ffb78b94",
         "installName": "cuda12-pocket-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-pocket-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-pocket-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12252,14 +12307,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aac75e1145f0784f79722f2314a5a15f39dac2d11d310e458445a312cf3d3737",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f259ce419216e03225e5e4b4b273c9ef72a9fd1f4bad3ed796a72d4d5ae28de2",
         "installName": "vulkan-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-privacy-filter",
       "systemPackages": [
         "pciutils"
       ],
@@ -12299,14 +12354,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d703e13d753a1e6e173d6cffc8f6121c8f01ed28da6577deea35192c5484464c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8344f2857760a6c271d25a78ac408414185e0b4b8ec7fa6a46c73bf6ed8eacee",
         "installName": "cpu-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-privacy-filter",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -12332,14 +12387,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d35a26e27dab4ffededa3c51e1c4ab05f82fe7e77a0ac21787d8372d60f2b788",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0c69020196e003f7c0c97e1a606cbbc33cc4e31180478868afcbebb7b972496a",
         "installName": "cpu-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-privacy-filter",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -12365,14 +12420,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aac75e1145f0784f79722f2314a5a15f39dac2d11d310e458445a312cf3d3737",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f259ce419216e03225e5e4b4b273c9ef72a9fd1f4bad3ed796a72d4d5ae28de2",
         "installName": "vulkan-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-privacy-filter",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -12398,14 +12453,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aac75e1145f0784f79722f2314a5a15f39dac2d11d310e458445a312cf3d3737",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f259ce419216e03225e5e4b4b273c9ef72a9fd1f4bad3ed796a72d4d5ae28de2",
         "installName": "vulkan-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-privacy-filter",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -12437,14 +12492,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:adf83b1446204533d33b828d043567c6fb8e0d9fd7edc1c0bac6b517b50764d8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:33df385a80d89a39ba94963604e0a74448a247cfd3fd4843305e5a3b52afa7c5",
         "installName": "cuda13-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-privacy-filter",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12476,14 +12531,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aac75e1145f0784f79722f2314a5a15f39dac2d11d310e458445a312cf3d3737",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f259ce419216e03225e5e4b4b273c9ef72a9fd1f4bad3ed796a72d4d5ae28de2",
         "installName": "vulkan-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-privacy-filter",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=all",
@@ -12515,14 +12570,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aac75e1145f0784f79722f2314a5a15f39dac2d11d310e458445a312cf3d3737",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f259ce419216e03225e5e4b4b273c9ef72a9fd1f4bad3ed796a72d4d5ae28de2",
         "installName": "vulkan-privacy-filter"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-privacy-filter",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-privacy-filter",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -12548,14 +12603,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2eebf4f380acd33727444f25e7113b9213fd6a306a156d46fe0d405a0db7b5cd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e19a8fbb8f2ee11508bc8191dd40e46cf784207b90aa216f84621befe1808931",
         "installName": "rocm-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-qwen-asr",
       "systemPackages": [
         "pciutils"
       ],
@@ -12591,14 +12646,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a8697b9e507ddc166420dff37182d72fdee40ca2c491d8daf330d9b2ae141e7f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2c2a0e780af065f4c0d09ac7453957f4726d247cef519d5cf094f298ae7572fb",
         "installName": "cpu-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen-asr",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -12620,14 +12675,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:be7e78f024b990dc9359d4e1cc187d22fc1058691cde3f4084dd3b68535c0180",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5a53de15cfa01bf83ebd93fc583ad18b184216965023f4d74a3534c1c47e9b11",
         "installName": "cpu-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen-asr",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -12649,14 +12704,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ade09689394198163999f1dc82be333467ff003c3d34477522c87d84aa279f80",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9ed2decf7abe6ab8aecc76471e8a883c6e69e245f25d3424de9f4378d4ae3f3b",
         "installName": "intel-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-qwen-asr",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -12678,14 +12733,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bfdc64c85ba8914d99cb05318632c9030362ef4d833f0ec43a18533594372962",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3168a7f0ccdbb53a26d1fc83bf6742576022e1ae214388374197941e949abc40",
         "installName": "cuda12-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12713,14 +12768,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9ddb6c4af2c8c460591263190c4193384af89feca3cc8993fb5e72fe0861d880",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8d5c0bd041adca6f423a0d86d64acde978dc04e54f9eb49f59ce37f0c9407d62",
         "installName": "cuda13-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12748,14 +12803,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4cb6cf4c59ae488d3b6bc80d13028a44a55412c4e671c244be685094f7b7182",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:193594ff9a75ea2c401a496969123120c02d2f35ad953365679d69c479b44ebf",
         "installName": "nvidia-l4t-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12786,14 +12841,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6763c419a388525bffa089c82e756cc709c536840a1e6216c1a42e1f5216055c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bbbd2877e490ca89c6efbc115893c2027efaa82efd760beebba375dec00eb972",
         "installName": "cuda13-nvidia-l4t-arm64-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12824,14 +12879,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a4cb6cf4c59ae488d3b6bc80d13028a44a55412c4e671c244be685094f7b7182",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:193594ff9a75ea2c401a496969123120c02d2f35ad953365679d69c479b44ebf",
         "installName": "nvidia-l4t-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -12862,14 +12917,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bfdc64c85ba8914d99cb05318632c9030362ef4d833f0ec43a18533594372962",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3168a7f0ccdbb53a26d1fc83bf6742576022e1ae214388374197941e949abc40",
         "installName": "cuda12-qwen-asr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen-asr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen-asr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -12897,14 +12952,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9f804cbc1d397575984c59db94dd26f1abdf0d87466fd674333d7d2027f6311d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2045c998b27637a809ecc19afa90b9f8711208fa446f3643d57f0adfe504f712",
         "installName": "rocm-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-qwen-tts",
       "systemPackages": [
         "pciutils"
       ],
@@ -12940,14 +12995,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:db8dd4aae570ed596ae860cc2dc93f6b3351318e5243a54bcf4c31bfd4ae9466",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9d34d1408b063921ed188f4dbdc09aef1a3c8c1924c39b8cf1220d5291c3f03a",
         "installName": "cpu-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -12969,14 +13024,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7b2cd2fd9d261a65d9f8bd0215ec61d7055312202e4d2bea8daf2ff3fc385fab",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:42e30b933ed4a9851ee106cc3b623f331a9a6c421f45fdcbca8483be4c3dce5b",
         "installName": "cpu-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -12998,14 +13053,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88c8fdc49d87613a810ce2a46bdc86394eccd5b2c26ec3fd2dc9315e97412fd1",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:17ac644af602c1ae00244165cc03850ffca4036c2f327699cfff33329e86741e",
         "installName": "intel-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-qwen-tts",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -13027,14 +13082,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e716545735aa5dddadb3037f45343e11cf0e16afd4ddaea11af2497c54f84ec",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:65ca0767c578cda3f62b5135397634bd9b3478eafadbd0a2c06fa58c42db0774",
         "installName": "cuda12-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13062,14 +13117,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6af58f0b14df492d3775c83561485c1f6c650c6aaa03deb27992f5b81572e661",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f3f686ca04b74309396c3b0ae084a47b9ae49a9899c6847cded34102511f6408",
         "installName": "cuda13-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13097,14 +13152,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:32cb3c348600cb04f3fb22bcca64115b04d97f40aabd8e73b47bea7619d29ce8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6a0951f235b05b6df22796f98d1a125cdf54b74f392ecda6eb6010ae054829c8",
         "installName": "nvidia-l4t-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13135,14 +13190,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06dd2c8670ddf911857fc57e350996f246691f3506ed6b7929332e761c9ab495",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:71b0754a09854885720e80f810ab3b8ef9b8f9204691144b5cb9f9b769dacf93",
         "installName": "cuda13-nvidia-l4t-arm64-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13173,14 +13228,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:32cb3c348600cb04f3fb22bcca64115b04d97f40aabd8e73b47bea7619d29ce8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6a0951f235b05b6df22796f98d1a125cdf54b74f392ecda6eb6010ae054829c8",
         "installName": "nvidia-l4t-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13211,14 +13266,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e716545735aa5dddadb3037f45343e11cf0e16afd4ddaea11af2497c54f84ec",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:65ca0767c578cda3f62b5135397634bd9b3478eafadbd0a2c06fa58c42db0774",
         "installName": "cuda12-qwen-tts"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen-tts",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen-tts",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13246,14 +13301,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3a5184ad3d809a74e29609a3671d82a175d938e42260357375120c9a5740b8d9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b1dfff4d2dac36a7938d83ea8059dcee55a7ab242a1cafdbddd1dcea7d0ae08d",
         "installName": "rocm-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-qwen3-tts-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -13291,14 +13346,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8d60c0c8a2221775f4235c38583af87de8edcad0be780b00fd4b627cde2a4e4b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:86e987ea4cc2f65d8e8740ebd5391d4ebd48beea4ea52d7aa5dba1a923ba91c6",
         "installName": "cpu-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen3-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "streaming",
@@ -13322,14 +13377,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:da01451a1f358f460c9e8a0390c82b6897c107fb97ed89868c2583791801241c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:77752f181fbdd1b22124cde6196f5aff23eb6d28b08825fe481196dadf58f85b",
         "installName": "cpu-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-qwen3-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "streaming",
@@ -13353,14 +13408,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:85e9fb2f0abd6834dcf8bcc85b47565182be4bc2112580a97f785a4f500ea428",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b9a900ac615902975647b39869abd6cdcc6972ec4e69322cc56ab70d8032cf25",
         "installName": "intel-sycl-f16-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-qwen3-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "streaming",
@@ -13384,14 +13439,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:78776bc9da9222e67c7ae883eb20fe569c9fbafbac4962dde1e6576473c86d52",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:893ef67b03a63d08e96e6113083fd96a45c244b28e9c3e30b4fd3885739eb8ac",
         "installName": "cuda12-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13421,14 +13476,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:af002aff6cb762667737cc7a8cf11355cceb7c96ba917a0157e7194f56d59536",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:006574ac3564908bcac8dd346b952fb22cffb46801ffc92646b34273360be58e",
         "installName": "cuda13-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13458,14 +13513,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6d2f05cb2bdcf69039913560c4d1738f1ec341dfb669002a8ae387dc520ab17b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:00aae81f20d989495fb1785e3f4e930ca4431ce03f2c363ff52aef9123c7dd17",
         "installName": "nvidia-l4t-arm64-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13498,14 +13553,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:434a63ad0bb521c22bc8bd05ff60f7eab8986285a68a0bef5d01582853e0a33b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f45043feede40e1116d69dda7d302ac7b2195ca3c2ce6db6d3c933621110da4",
         "installName": "cuda13-nvidia-l4t-arm64-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13538,14 +13593,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6d2f05cb2bdcf69039913560c4d1738f1ec341dfb669002a8ae387dc520ab17b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:00aae81f20d989495fb1785e3f4e930ca4431ce03f2c363ff52aef9123c7dd17",
         "installName": "nvidia-l4t-arm64-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13578,14 +13633,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:78776bc9da9222e67c7ae883eb20fe569c9fbafbac4962dde1e6576473c86d52",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:893ef67b03a63d08e96e6113083fd96a45c244b28e9c3e30b4fd3885739eb8ac",
         "installName": "cuda12-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-qwen3-tts-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13615,14 +13670,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9eff8e63f7d3bc0e276f3973e1fa8c11812a28604f570cc2ff66dfd770b7c38e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bc5842fc2bae7f62b749f88e3588aba946a43626e2f845cb70af29cae7c1a761",
         "installName": "vulkan-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-qwen3-tts-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "streaming",
@@ -13646,14 +13701,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0fb8e01b33877378150fc8faca59ab0de90160a19d7a75845cace87a8e04a62",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9cafd3d8d9704c13a06b7ec6c25f30568a177f0508ad649ae8254e937b189d7e",
         "installName": "vulkan-qwen3-tts-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-qwen3-tts-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-qwen3-tts-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -13680,14 +13735,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dcd2c4ccca7df39c15574a526183e7bdc8fbe7140141639b3fdbf09774399a17",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:def466c472349435170541fd3dca77dd6d218ae977fb227d54f4ed6efc2d3d17",
         "installName": "rocm-rerankers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-rerankers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-rerankers",
       "systemPackages": [
         "pciutils"
       ],
@@ -13719,14 +13774,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:568db5092c0b776e3e15a83f6ae2bdafbe00ff955c4d14d22acda7e565f6b356",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e9ddb7c89efc67eac233d039fdfb1820784c33aa7fc39d8c17fdb340539ef187",
         "installName": "intel-rerankers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-rerankers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-rerankers",
       "runnerProfile": "unsupported"
     },
     {
@@ -13744,14 +13799,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:93898f0c31c72e2fafcfccce026342a5a52b9117a4965247f59195bfd1166ace",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:542c242239ea58017a9edd144458cf7b7b748eeb43dfefaee5396cdeeab94743",
         "installName": "cuda12-rerankers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-rerankers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-rerankers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13775,14 +13830,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccc75730cbfdbbc330d56678e35821f160b8a1e426bca10925247895760f415e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:77ecfdfc10f70010bfe577db49af2798563f6c5daaffda6c7840b1d4ee7aa39f",
         "installName": "cpu-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-rfdetr-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -13807,14 +13862,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:099825572dc78776bfb4d74ed8f334b588750bf0cacbee5d1d89e4a2cfffefbc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:35fe5e86dac2864f8893fe589d7258d90de6ef12b8d0dc32a880b5add797935d",
         "installName": "intel-sycl-f32-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f32-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f32-rfdetr-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -13839,14 +13894,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ff2643e26a3ad8bd4f0a304eb164aef2c0a3e6f6cd75bd9668c35611c8d56898",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1357fb5515c90db6f3f16ca360e31fcb9488e10ec1e3b281d2d146720e668389",
         "installName": "cuda12-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13877,14 +13932,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dc58660bcd1f9c8f036fc5b073f2e88bf019b174ba4ba6b63b13fcf9d32fed07",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f1779a8cccfa06b9516eccc607ecee4c461b12411776ca7b7d35e1e304ca23b3",
         "installName": "cuda13-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -13915,14 +13970,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c29fd0fac78b54dba56bf6a26b764c211d0efd9ff076b38f9ba0e3cbeff65846",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2779eb161aeffda3668ee0a0939e605d70db10aa1a630ae6e8406aaffd4ffad3",
         "installName": "nvidia-l4t-arm64-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13956,14 +14011,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4dc96e1c30252d9aac4eb9a25bfaeb23ba1236cf9a91ddbe399eed09ec7f5aa9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dd0efec21e2071d69e51ca63c80d5edad1928bec387b83ddcc3bf1414be8076e",
         "installName": "cuda13-nvidia-l4t-arm64-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -13997,14 +14052,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c29fd0fac78b54dba56bf6a26b764c211d0efd9ff076b38f9ba0e3cbeff65846",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2779eb161aeffda3668ee0a0939e605d70db10aa1a630ae6e8406aaffd4ffad3",
         "installName": "nvidia-l4t-arm64-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14038,14 +14093,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ff2643e26a3ad8bd4f0a304eb164aef2c0a3e6f6cd75bd9668c35611c8d56898",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1357fb5515c90db6f3f16ca360e31fcb9488e10ec1e3b281d2d146720e668389",
         "installName": "cuda12-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-rfdetr-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14076,14 +14131,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a8902b49e308cb3d9a702e35679bcae6972218505ced274790a4617d828b8948",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9e86b0e408172ea82d0c22757dc40dddd3afbee1ddf01ed896f414ea04f39d0a",
         "installName": "vulkan-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-rfdetr-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14108,14 +14163,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aaed3fa74a62ae3546f8e34e6483b7a503aeec9700e9a46f023c3017dac4efef",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0bac67842c775d958ab306aed1a03832ebd53411b30f773febc6aa0bbcfbb923",
         "installName": "vulkan-rfdetr-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-rfdetr-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-rfdetr-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -14143,14 +14198,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:243665d0b63c852ce01731348a6194d541216208a1f2b033c4195c5b3baf40ea",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:347fdcb684b49b5cf4e914ed80946edd63d8b9fc358d355ad41048932f6b9358",
         "installName": "cpu-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-rfdetr",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14174,14 +14229,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d0c3684175efac4a97faef8e9dab05262bae5a5c628c0685e8cf72b2c3408b49",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:30db326938c19b1fa4ffd8609796bb0ce1ffe62297b272a5511e20222dc7ed84",
         "installName": "cpu-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-rfdetr",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14205,14 +14260,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:de19fec26cd858f09a65655509a1105d148d1d09df02356051d0da8f31838a95",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88b2fbeec36617ba1fa110709e2cb713b7129aecbd35bb24fe247e6d828f32bb",
         "installName": "intel-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-rfdetr",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14236,14 +14291,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d75dc45d3a66305d4257b728119b55b5e9c4c997a4a6035bea405490cfdcb88e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e2139327546ff9527e1599d0056a253f56fb7734782dadd8c4276747b58e24bd",
         "installName": "cuda12-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-rfdetr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14273,14 +14328,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7953ffb33b6418b0ccab60e2ec6104d2d9f7eb91cf05354ac7da79b1b7e6d804",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7c9b0da597b9275647bcd0892f84ffc01b3696ed388e10204433a13e4ccd98a5",
         "installName": "cuda13-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-rfdetr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14310,14 +14365,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62c3311425f65e4d9491e98816d39d13dd63573e267eb90ca4ad501bfa4a8a1b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0dd8f93688f793cc72ee87060b638d36c6c35c18e6029a7f2f11947dcc2994f3",
         "installName": "nvidia-l4t-arm64-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-rfdetr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14350,14 +14405,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62c3311425f65e4d9491e98816d39d13dd63573e267eb90ca4ad501bfa4a8a1b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0dd8f93688f793cc72ee87060b638d36c6c35c18e6029a7f2f11947dcc2994f3",
         "installName": "nvidia-l4t-arm64-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-rfdetr",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14390,14 +14445,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d75dc45d3a66305d4257b728119b55b5e9c4c997a4a6035bea405490cfdcb88e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e2139327546ff9527e1599d0056a253f56fb7734782dadd8c4276747b58e24bd",
         "installName": "cuda12-rfdetr"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-rfdetr",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-rfdetr",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14427,14 +14482,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e1e091d0988f87cbb25ac63124148a88cde4df5b272a2b7168a12f81bc8bad87",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c4b0558b6f5129cd4aacab6ad3a655d1d670943aafdfd16e1ae6f9259f58ee93",
         "installName": "cpu-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-sam3-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14459,14 +14514,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:74517638ef3ffeeb8925282531f008e942f1116da70278c0e7b726f2fbd91fa0",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4131a14260afa76fe23cce02fb230b20835a7da01ef947d39b26383fdeaf1aa4",
         "installName": "intel-sycl-f32-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f32-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f32-sam3-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14491,14 +14546,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fa9e7362a52febbdb341854ca630394b99a277cbf54dbbe311566bf42f0dc7c3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:48eaf98c56ab529ed3bbcd858f8624c47865c828370c9aedb49e64a9734c39fc",
         "installName": "cuda12-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14529,14 +14584,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c069b2f6e71baa39e533213a5ac692c0e0c3a2fe7142847231e6b2d226b9f4d2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:670fa2a4d2a5ab873569d3ad326fdebf325869cab23036d1430e747a99c4862d",
         "installName": "cuda13-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14567,14 +14622,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:482025f6764df9a130722ade475e7d08f0921a7f0643b7d9ba4eac86ca72abff",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f9d1a0eb99c705d19562a95864a1dd32dada9db79513a719386ee2257725c1c1",
         "installName": "nvidia-l4t-arm64-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14608,14 +14663,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d1f8145da429cc816a2bd98329adad2a36b0ce9e6a05a4012ce8bdebb7e7ccb0",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d6ac0c4b71cb8a8b2452225d0bb40477fdcf7a61acdf63d23299268ae795b905",
         "installName": "cuda13-nvidia-l4t-arm64-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14649,14 +14704,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:482025f6764df9a130722ade475e7d08f0921a7f0643b7d9ba4eac86ca72abff",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f9d1a0eb99c705d19562a95864a1dd32dada9db79513a719386ee2257725c1c1",
         "installName": "nvidia-l4t-arm64-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -14690,14 +14745,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fa9e7362a52febbdb341854ca630394b99a277cbf54dbbe311566bf42f0dc7c3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:48eaf98c56ab529ed3bbcd858f8624c47865c828370c9aedb49e64a9734c39fc",
         "installName": "cuda12-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sam3-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14728,14 +14783,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ef143a9b01ff00d6f44928edd6d722f3a202d8c3ed853c53afbd813d4f4782a2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:59c21e83833716f02a9f046172bea0f532e4552d876b52cf6c9791157bc5db76",
         "installName": "vulkan-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-sam3-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -14760,14 +14815,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c8c9a76d3498c29a3496347b4879b34e3a215dd8387a439ec4dc721db91881c9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b6c13de59240d7ed2b5a7cb9681b59e8ce89ce949bd9cc05d0fcdc4cdef997d1",
         "installName": "vulkan-sam3-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-sam3-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-sam3-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -14795,14 +14850,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ba29d4d2b2022187888dbf4e7b64457eb51194202b8eac82fb9a8688b21f4879",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e26e9c897d9fa7b3fb93847dc943c6b361de67f4d4f7a42c7a33d1471693d98a",
         "installName": "rocm-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-sglang",
       "systemPackages": [
         "pciutils"
       ],
@@ -14838,14 +14893,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eb12302e9fae67dfda9cd2f614aec71bfa174346119c4d126e6b99e0345be5a8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccad475928d04d1b57a34a0d05ab3eb26c1c282dff243c25d74adcb7beab726f",
         "installName": "cpu-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-sglang",
       "runnerProfile": "unsupported",
       "workloads": [
         "multimodal",
@@ -14867,14 +14922,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c613491fd1ae19ed5e4dc52934e091300abecd985e53421eb2fe5ed39a5be9e7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:29ecc7113d9b7ad0633ce53ebad69a244a82a0e62b6106c3cb69e57ad104c950",
         "installName": "intel-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sglang",
       "runnerProfile": "unsupported",
       "workloads": [
         "multimodal",
@@ -14896,14 +14951,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c73b9d8972178b81904a05caff9396aef466187d45df776c589c82bfd3ff057",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a818964f5d648f3258b7587ab26060fc4bcbf425528e820bb3502c41c41335a2",
         "installName": "cuda12-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sglang",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14931,14 +14986,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ce0719727903c01dd5ca763af453e48e5013175dfb5efa34c4823cb6b0e0aed6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c919ffe645423b9ab7ecf594532793ae267c12c47da04f2366f0de877121438c",
         "installName": "cuda13-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-sglang",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -14966,14 +15021,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8cf7549b3cca1960356ab54019168ffadb8c814d8cebc984f4d41c934f8ec1e7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eb03b53885e15bd13e81f5178414067847825198f23520795a0144ee27defa90",
         "installName": "cuda13-nvidia-l4t-arm64-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-sglang",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -15004,14 +15059,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c73b9d8972178b81904a05caff9396aef466187d45df776c589c82bfd3ff057",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a818964f5d648f3258b7587ab26060fc4bcbf425528e820bb3502c41c41335a2",
         "installName": "cuda12-sglang"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sglang",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sglang",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15039,14 +15094,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a1a23afba6c9582e60b4059e3fa06671f56cfba0165aaced7a84d1918186698b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a0932ed1e23d9c83e4c5b8ffe8a9f0e9119965177e9c9acacd2c54bb47581b90",
         "installName": "cpu-sherpa-onnx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-sherpa-onnx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-sherpa-onnx",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -15070,14 +15125,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:df5e554609f8807fa681c79e15120ef66f87a1776ed522c2b59cf599224a461c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:04afcc873cac714e4d4566788c452c8192f5cb7709517b3a585f3f6d938c29f1",
         "installName": "cpu-sherpa-onnx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-sherpa-onnx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-sherpa-onnx",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -15101,14 +15156,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:59dbd2ff6231fea8138a637cd855bdd34053d73c07a3fb4e3080d2206fd76977",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e323bc6e295b8281ca89a3d7d83f7d6128b461ff356c343c85035c6a3cf8a1c",
         "installName": "cuda12-sherpa-onnx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sherpa-onnx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sherpa-onnx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15138,14 +15193,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:59dbd2ff6231fea8138a637cd855bdd34053d73c07a3fb4e3080d2206fd76977",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4e323bc6e295b8281ca89a3d7d83f7d6128b461ff356c343c85035c6a3cf8a1c",
         "installName": "cuda12-sherpa-onnx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-sherpa-onnx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-sherpa-onnx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15175,14 +15230,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:414c412b71b5d9b359654ea122cb6e6fc3b18fa8ed9e0687d5b8a71bec341da9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:672f1402c9f4da28d046b965277e342e1c8e84eee89ecdd4121a616de3000aac",
         "installName": "cpu-silero-vad"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-silero-vad",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-silero-vad",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15206,14 +15261,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:368ab37de2983ef0cc1d36ce0526a0af4d93f199f15c98f52bc7b25ac2707e60",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c1d7d9965ca08bd28d703ab8b78504b5060d72f116cef80fb258613f8c34ff65",
         "installName": "cpu-silero-vad"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-silero-vad",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-silero-vad",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15237,14 +15292,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dcb54069f9a6fcdc2bebba151e124edd25ac46f7b72bef615c73e8e37156adb5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e2f0b0599c65338226447cada12318f390d7bb40614676f3b70ea4b3abfe4f5",
         "installName": "cpu-speaker-recognition"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-speaker-recognition",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-speaker-recognition",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15269,14 +15324,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:029eb1db69fc444022edd17471b09221f207f53678f3c0cec1c80e0df5545777",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b4e55b0fb11662ec1f531b4a10d9d09b83c7576cdde861025a9ba0b0a71a9b83",
         "installName": "cpu-speaker-recognition"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-speaker-recognition",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-speaker-recognition",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15301,14 +15356,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:638b7bca54bf8425d9f70de49c129d54f72a474c1d0c3090b14082006db95abc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccc3093e42482488ef8d342204896cca8ffe08acf1b2c4d69617f692ff6bba25",
         "installName": "cuda12-speaker-recognition"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-speaker-recognition",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-speaker-recognition",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15339,14 +15394,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:638b7bca54bf8425d9f70de49c129d54f72a474c1d0c3090b14082006db95abc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccc3093e42482488ef8d342204896cca8ffe08acf1b2c4d69617f692ff6bba25",
         "installName": "cuda12-speaker-recognition"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-speaker-recognition",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-speaker-recognition",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15377,14 +15432,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:484ce6aa8697aa667aedf8ed03ce6474114e4055e3cf115688cf4aa7a4965540",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:abff658f8c851b200cda8e3856325cbf9abc98418c1a4405b46a960296714ed2",
         "installName": "cpu-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-stablediffusion-ggml",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15410,14 +15465,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6981d002fe25d0e20f40ca6e857dd083fd521c4c7453b7602d2ddc05a7bc50c7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1981884ec1fda0baf47e9db3532d5fd3692d59af2d762532458b8d637846c299",
         "installName": "intel-sycl-f16-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-stablediffusion-ggml",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15443,14 +15498,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:37d177cf31d82283b3132ea26aad181d228e1465812a25a4db92345da9e8e329",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0adc1bd5f56fc07df560a1305ab26c67f94b16d844cde5b99270206aa028008",
         "installName": "cuda12-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15482,14 +15537,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2b6ea74d493fd3439d359e20748524d97df70eb0cb6724eb8017d5be2825b011",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d186025a389d113a84181fa48ce4d6fe553f0e944b95308082fba07507b1fe3b",
         "installName": "cuda13-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15521,14 +15576,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:14fee562a4a6b45de5d347c15e168afbb6ccf9f2d7b5c9567a56bc339034ad1f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6185c51e533d0780bcc579c2391454c4acf25838e278c38bc7d118e59c2d53ec",
         "installName": "nvidia-l4t-arm64-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -15563,14 +15618,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f71d7dc8b82c08e81d85bcf067772bcc61f3ed14f1f32fc8d83f36f7aa679da5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8e53e6adbc38833606ec11a551a9ebba3af26b283b0aaf1f23dab4e90fb28aee",
         "installName": "cuda13-nvidia-l4t-arm64-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -15605,14 +15660,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:14fee562a4a6b45de5d347c15e168afbb6ccf9f2d7b5c9567a56bc339034ad1f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6185c51e533d0780bcc579c2391454c4acf25838e278c38bc7d118e59c2d53ec",
         "installName": "nvidia-l4t-arm64-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -15647,14 +15702,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:37d177cf31d82283b3132ea26aad181d228e1465812a25a4db92345da9e8e329",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b0adc1bd5f56fc07df560a1305ab26c67f94b16d844cde5b99270206aa028008",
         "installName": "cuda12-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-stablediffusion-ggml",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15686,14 +15741,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:32d80375769279b5f522f93016a26e7a5cb465d189aa2c85ecbbffff9d727995",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0e1cb144849d2ca96aa732f563b383ee87d9787e90da6875654b4c2ef03e8472",
         "installName": "vulkan-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-stablediffusion-ggml",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -15719,14 +15774,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:447de224b963b2cc019f8b8e53febeecb2c26469ec5ab809e2580eae3a351943",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b2bcd6f81b4bedf34b8bdda43fcbaf26e1d3748347e91908051c836368a1c5c2",
         "installName": "vulkan-stablediffusion-ggml"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-stablediffusion-ggml",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-stablediffusion-ggml",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -15755,14 +15810,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0267237e5157b5cd4f37d69611159247b474c19c571b50d6ab91b709cd167d08",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b7fa87435884bc3813f13666ba45b62b52538ec5af67529525a1d72f760c3e40",
         "installName": "cpu-supertonic"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-supertonic",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-supertonic",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -15784,14 +15839,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f27d2e98fad6b819e4c2e21cc6fb40d03a2a91d336c5812801f5a7272ef4a662",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f2160266569118071f019d5cc2c54981d48d8c695331890febaba197fe33fc22",
         "installName": "cpu-supertonic"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-supertonic",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-supertonic",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -15813,14 +15868,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:320873274f65e91106a3612ceac4f45c16df1e6ccc60e5a12ddf73b51b03b3ce",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:adfb01f38c2ae1007bc0b8fb7596c76610bcb0caf8f4502c33b91f54a623d0ff",
         "installName": "rocm-transformers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-transformers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-transformers",
       "systemPackages": [
         "pciutils"
       ],
@@ -15856,14 +15911,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a9188b979c4795d9e914e8a6e13213588c3e09012d4bb2c0a162a88d9ba2f05a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f7b98c556cfb1b0b123ff318f35fd01622e80aceefaa4121502b9e9767f7b874",
         "installName": "intel-transformers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-transformers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-transformers",
       "runnerProfile": "unsupported",
       "workloads": [
         "multimodal",
@@ -15885,14 +15940,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a628aa2d146077f5bf892bddc3e8aa2f50b096b1d07cf89e3f4739319bf19e69",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a5ae344992c5df50dee3bdf7f456a1a6216628638a5102352346d6d31b19735",
         "installName": "cuda12-transformers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-transformers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-transformers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15920,14 +15975,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:15ff4b72095325ca4c338dfbe0986a7ed07cd5ec69dc7bc8b83bd71ec9818201",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:853ddbd415a0c7d8058909c6c89bfc052bd95ccfd1e1994bf783005255dae5cf",
         "installName": "cuda13-transformers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-transformers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-transformers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15955,14 +16010,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a628aa2d146077f5bf892bddc3e8aa2f50b096b1d07cf89e3f4739319bf19e69",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a5ae344992c5df50dee3bdf7f456a1a6216628638a5102352346d6d31b19735",
         "installName": "cuda12-transformers"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-transformers",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-transformers",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -15990,14 +16045,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5fe47c2a703692b87505e9d60b714fb483763a4aab7d1fb941b617ca384c8d58",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ed9e75f8f91e197ab22dda692be1ad3c566cc2b8600f9fa1249f4fe62784b045",
         "installName": "cpu-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-trellis2cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "3d-generation",
@@ -16023,14 +16078,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3b634a9ad70a80d84526af66534b89103e7ec8246e0de1acc269b5225d17741b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8545c74cdbf4c32160cc300056645446dbb23d16f3750458addde0da7e4e6732",
         "installName": "cpu-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-trellis2cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "3d-generation",
@@ -16056,14 +16111,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50a6ca73ae7cff38403d99104f4c62da5fcae3a5546d83384500770ab6a8321f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51eaa1ae55a3ec610d98d80e10dc49d34848a7149ff718ad5780ce09d70cfb42",
         "installName": "cuda12-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16095,14 +16150,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e9e43b932b0b52f2d0f4985c489e1f40d89047c5fdc232700644eb5ed8c9a6f5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a0565ff78608635b10af608eabe698ab9095581b2ae7c2c1f718e7c7cb1d078b",
         "installName": "cuda13-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16134,14 +16189,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2edd7fed3da9922b23439e6c5d14b1d9b6a15d873a33695984d68bd2b6230f72",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:324cf3308c41ff04beb29bc253ec4ba5a803e5a291c1d2c19ed8482239ee9027",
         "installName": "nvidia-l4t-arm64-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16176,14 +16231,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9f71fac5cd721790e452551e959b408a22d7cc9546c8ab9a7bbcba785f295e36",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4c62c8ec8773ca7cca30c857eb289b05b4e7d7367ac97b4c4a8a44402369bcf3",
         "installName": "cuda13-nvidia-l4t-arm64-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16218,14 +16273,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2edd7fed3da9922b23439e6c5d14b1d9b6a15d873a33695984d68bd2b6230f72",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:324cf3308c41ff04beb29bc253ec4ba5a803e5a291c1d2c19ed8482239ee9027",
         "installName": "nvidia-l4t-arm64-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16260,14 +16315,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:50a6ca73ae7cff38403d99104f4c62da5fcae3a5546d83384500770ab6a8321f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:51eaa1ae55a3ec610d98d80e10dc49d34848a7149ff718ad5780ce09d70cfb42",
         "installName": "cuda12-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-trellis2cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16299,14 +16354,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:69622dd57f69497ca0d4920a3832392f9cadcc82e80a60d2f9e0c6af4c5f55a8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0ec10ed2ddc31656af16bf15016a63467bf296c9f51af0eaf4e7124965a7f496",
         "installName": "vulkan-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-trellis2cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "3d-generation",
@@ -16332,14 +16387,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:859b7d80fa90f813e33848f1cc49a23ad9f15fff7d51689698128f95e32f6eb2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:57a062f2ff3f88fd714d3db8b2b45e6debfa7d27993e5ffadd0b7b19853bee71",
         "installName": "vulkan-trellis2cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-trellis2cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-trellis2cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -16368,14 +16423,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c1ca5c217bbfb8bef589268391bf2ba79dd04a523d0638a83447ff17384c77fb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06a43b609e38bf8b5b3fbecd636f3ebb719831b08aaacd610bc682a7b0ed51b8",
         "installName": "cpu-trl"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-trl",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-trl",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16400,14 +16455,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eff2339c2addb7506711a4b25f3bb42f8cb1646839ab64d276974bf8d40237f4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88dcd72368895c7d8096ad89fc4dc6cbce7351620604e651debc3c38d41aebc9",
         "installName": "cuda12-trl"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-trl",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-trl",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16438,14 +16493,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:39f1bc9c3f85131cb73788f92e9484bc5e913cd9dc112592575edec13d5f0cac",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7346826c22551a3536b2c06719fefbea4c7c0c9ef8fc6596b10574b2d406451f",
         "installName": "cuda13-trl"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-trl",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-trl",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16476,14 +16531,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:eff2339c2addb7506711a4b25f3bb42f8cb1646839ab64d276974bf8d40237f4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88dcd72368895c7d8096ad89fc4dc6cbce7351620604e651debc3c38d41aebc9",
         "installName": "cuda12-trl"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-trl",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-trl",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16514,14 +16569,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06bafa65e18b1e11e96dc002c6b939c73bbc7076911b2b8854ae90ea68cdacaa",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5639b2b6e5c40d7bb019f4c5ce1f324a344110bdd5edb9b6669ba761c79fa4d5",
         "installName": "cpu-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-turboquant",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16549,14 +16604,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c95ff756f7507a5912376ee5587e13e99560ef52eeb3c8c6b44e007fe045f94a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:57e6af1e458a9c5e96fc5b2b7084d16b0b7124ff549d7560d5e3c64f513603c7",
         "installName": "cpu-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-turboquant",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16584,14 +16639,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dbd37ceb7cfc492b2d79dce033e63f55028ab63e09d1a936c0e33729ce3fd5ff",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:92429fc1b99ec71dbb98a28f41f951f5658f1d87061ccc1c88e17e6db12ffdc8",
         "installName": "intel-sycl-f16-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-turboquant",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16619,14 +16674,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6c75341089c392bb533bc668ba19fcd0ac1a457feb0f34b8f157a31f81b782a3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3cfb20342447a74444b4b16716939ef4e49777b30f1b0b8edf354c90c4216d3",
         "installName": "cuda12-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16660,14 +16715,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bee36ace7599f7c95ef5ddf2e463261210661f053676c9e97fe69fd6e9c0ce87",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:43084acf210e972e496dcec61620ffbcf4646ae5b87e30abf88a5c45b872d23f",
         "installName": "cuda13-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16701,14 +16756,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:110900b62832f53e3eb05f304f6810ce9588d415921aec5484e76b6090d94033",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e728dcdd56b20629d2e1f04b2f328a4705eaa8d890f29fef79c2b296ab5a28ad",
         "installName": "nvidia-l4t-arm64-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16745,14 +16800,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:20bd0c6e7974213974f90c76db2def41f0ea24fca60f5fbde3515b13938bbcc7",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88bad925b89b3b79a6a39201da17f9bf2c29fcf12727eff214c247e91a017ac5",
         "installName": "cuda13-nvidia-l4t-arm64-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16789,14 +16844,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:110900b62832f53e3eb05f304f6810ce9588d415921aec5484e76b6090d94033",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e728dcdd56b20629d2e1f04b2f328a4705eaa8d890f29fef79c2b296ab5a28ad",
         "installName": "nvidia-l4t-arm64-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -16833,14 +16888,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6c75341089c392bb533bc668ba19fcd0ac1a457feb0f34b8f157a31f81b782a3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3cfb20342447a74444b4b16716939ef4e49777b30f1b0b8edf354c90c4216d3",
         "installName": "cuda12-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-turboquant",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -16874,14 +16929,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fa4e932e07fe17bc2ee597c9e11d56037bfa76b207f4c857d406e1fe706446b3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:957e1f7341246272d425f53046dd80fd3797d4d06e4a4e106dbbfbba47a4eaf2",
         "installName": "vulkan-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-turboquant",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16909,14 +16964,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:99335208cddea58db468763f510276abba1b15d4581a6f6e4e8dcc014b77e1f8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9edcdfd3df782bff9ffdd2240db463288f5633340f5ecf6fcb075ffe2f210029",
         "installName": "vulkan-turboquant"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-turboquant",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-turboquant",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -16947,14 +17002,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7041ab239b25859027c5724cf553d3913c09b51c775854152931ccc8861efd95",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1afd4e28a3ebf18b510448e278c61f6e56b5713fb9756771cbe5bf4a34907ad6",
         "installName": "cpu-valkey-store"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-valkey-store",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-valkey-store",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -16978,14 +17033,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a6b41a7d8e4cbb68193dfe49037f8c10c09fe58ee865499973ff33790baab6fb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e353b9d92b02491b87e91af846ec7642d4c468733309100c4f9e36c46e402378",
         "installName": "cpu-valkey-store"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-valkey-store",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-valkey-store",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -17009,14 +17064,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:09376b6f0a020e3142ed5beb010e3e8d7c2d5f5aef0e5f346814a5ed4bc4b4fc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5d35c61728fa7993e4402ccecb7ac43eecc0c4a5f8bb284d8a51d882e35239f4",
         "installName": "rocm-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-vibevoice-cpp",
       "systemPackages": [
         "pciutils"
       ],
@@ -17056,14 +17111,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:44928630c09accfa2ab53640d34f3c90fbdbb8a103e1560ab94926bc1a07a69a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fdce4b18a6f9992a8e3ec302105041c54ffd55fc301ef9c7673c9c068ca395d6",
         "installName": "cpu-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vibevoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -17089,14 +17144,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:12fe66b596b28d108909b9ac0b74d46de0e87b7a28a5fbe13aa0fce20885c9be",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d17d853c5cea9cc06b2559411ee35992e830a2f8820dbf3423de61fdb4545885",
         "installName": "cpu-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vibevoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -17122,14 +17177,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:38fef74d878a86317501798450b9819d4f48db5f3841f945d210c3cb6a6cc3cf",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c34ecc6e54db88fe56c3e753c180d802d1b157ea2adbd600c22c5d5935bf344d",
         "installName": "intel-sycl-f16-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-vibevoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -17155,14 +17210,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d847853c9f342eb29a72e2a8c53c00967f7f4ffb9be6cfbfe24fce9aeac0b88c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:08f66e57fffa03b39a9aeda66c07ba788b96a9e8af4c5e759d5c891d2982032e",
         "installName": "cuda12-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17194,14 +17249,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3e9863c6d9cab11eb5491582238d8f6d039e28595417e0e81cd4e00fcb566cd2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccde76d2067b03ca2ed3d451acda7fcc3e420ea27f20d83eb38193024eeafd23",
         "installName": "cuda13-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17233,14 +17288,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0bc8ace81ac4084e5f02b046e96460761a92d1ad1d129dc9a939c57e8831ce60",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7f6f0aea748c08cc6beb0838e34b99ad45b7fa34259450928762fcf613a882fe",
         "installName": "nvidia-l4t-arm64-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17275,14 +17330,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bbab2194832c1d77c67ca3862e01a5524144b63cc9b34c598a9095a9ee0d59b9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f948b206e509ee19116fe4e672e819ac6a11c9542b278f4bbc7e505533c856da",
         "installName": "cuda13-nvidia-l4t-arm64-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17317,14 +17372,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0bc8ace81ac4084e5f02b046e96460761a92d1ad1d129dc9a939c57e8831ce60",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7f6f0aea748c08cc6beb0838e34b99ad45b7fa34259450928762fcf613a882fe",
         "installName": "nvidia-l4t-arm64-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17359,14 +17414,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d847853c9f342eb29a72e2a8c53c00967f7f4ffb9be6cfbfe24fce9aeac0b88c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:08f66e57fffa03b39a9aeda66c07ba788b96a9e8af4c5e759d5c891d2982032e",
         "installName": "cuda12-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vibevoice-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17398,14 +17453,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62dd76b4eec6c886876157d736f069041b4a96d255797946404bcc1bcff60933",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8b70dc3a48d2146f053e7188e5b4fb0b5638f7dd2a96cdbedb35bbfc623dcee9",
         "installName": "vulkan-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-vibevoice-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "asr",
@@ -17431,14 +17486,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e040488cea4a6be22e71c6ebeaa1acb0420ea5557570c1b1810be3f766fb7c4d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1f06a9acbaed14f16c5aa3bacc0bbce025fb7156dbd4121b5c07e322691f8843",
         "installName": "vulkan-vibevoice-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-vibevoice-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-vibevoice-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -17467,14 +17522,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0d3fe09c442c1c05ea45d6b3a93053c2aea761a8024c8b0d581590db037f1816",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:40e797bc7de07d540ebff0b59b8faa21ede492ca7f7829b628a5eaba289c5561",
         "installName": "rocm-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-vibevoice",
       "systemPackages": [
         "pciutils"
       ],
@@ -17510,14 +17565,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:936f1278650080c978ee4c7e1c582b4e20d02f5f43dc728380ed0d8bf47c5e74",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8108a0082a00f0ac6acf4976fd84d465a05c66c9e3eeabbfab137b7a65cbf878",
         "installName": "cpu-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vibevoice",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -17539,14 +17594,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:da4762b3ee1d20c6fd20779a2885d6f6a4654126f18998f23ab75243e65ba994",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:25ce55506bf29410af80af4d261631c757a87105d9ec32466d69fac6f561f918",
         "installName": "cpu-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vibevoice",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -17568,14 +17623,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:638d63f2e41318cd5644cbb87ab77e58c9f8d90d6971a976049032a3a05eff39",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b923210d640fb42fae0e50d0a4b57c229298a68033b7f5f083bc9eb374aa9f49",
         "installName": "intel-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-vibevoice",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -17597,14 +17652,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccfb79c0d8988991642b1e1d77e7d4ad732c86dbdc1ac0ffc3ea21c6766597e3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fc3a099f2663a175b0790c43ff0ec29577117f2485235157785a9edc79c541af",
         "installName": "cuda12-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17632,14 +17687,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d81d6caccd6b16369d39db0b161589996273f8fd33148c9102c225d64a83c70d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06960ab09dd39dba29c2973fdc7cd9c3b53756d70385b1fc2c7edcc091d3a3c0",
         "installName": "cuda13-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17667,14 +17722,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:05c63a9e1f7d39cc9a83eb50ed72fa097f7d45a3bc638b6efe5277a2db8dc6e5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62a1b6eb8b234882c18e326b552328d95692da0c1048edaed9c3c9f6949858ee",
         "installName": "nvidia-l4t-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17705,14 +17760,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3d421cd536347cb9d6c02ee9ae9e796a57ea3758c7f26b34daa6c3a21a7017d8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1a4c8e30ae222a7070b74ea8cbf24db3a8c74804dafde6305af1794a15048393",
         "installName": "cuda13-nvidia-l4t-arm64-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17743,14 +17798,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:05c63a9e1f7d39cc9a83eb50ed72fa097f7d45a3bc638b6efe5277a2db8dc6e5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:62a1b6eb8b234882c18e326b552328d95692da0c1048edaed9c3c9f6949858ee",
         "installName": "nvidia-l4t-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17781,14 +17836,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ccfb79c0d8988991642b1e1d77e7d4ad732c86dbdc1ac0ffc3ea21c6766597e3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:fc3a099f2663a175b0790c43ff0ec29577117f2485235157785a9edc79c541af",
         "installName": "cuda12-vibevoice"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vibevoice",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vibevoice",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17819,14 +17874,14 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a2d69303ad41a8352640c9145244aaa5aa457b7b2a5603458f4b2c4c4008cb51",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c3584433333a8da3d57dbe1b9d70a07835b6999299dea4a494c046403fb9af49",
         "installName": "cpu-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vllm-cpp",
       "runnerProfile": "vllm-cpp",
       "workloads": [
         "cpu",
@@ -17855,14 +17910,14 @@
         "ref": "docker.io/library/ubuntu@sha256:a8cdd2158a73d7e5c02aa351fe269f48f57cf710a241db86e9ede371fc150149"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:64f807dfff4f7c55805a7f9773369c878c474223730acc254aa8cc37f06eb06f",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3530cb2873fae3d3598467a55df250ef255aa73985e2be880fee37741583ed4a",
         "installName": "cpu-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vllm-cpp",
       "runnerProfile": "vllm-cpp",
       "workloads": [
         "cpu",
@@ -17891,14 +17946,14 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:645d49a1f9a6e85dd2d2d3b95040607d5d134ec4309e62b1b25aa701bea270a9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4937f645ff1e9bc8174461254cf74f992aae0b03514ce42d9eb60874cfa1d52e",
         "installName": "cuda13-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -17930,14 +17985,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e5a95a3eddf3877539acaac7b37589a1fda8c612ad1a3ff5a6c44af05bb7336",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9179e066a61793b3437a4e8df293cc3fec973176f32a5cd7204dd611fc8ec5d0",
         "installName": "nvidia-l4t-arm64-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -17972,14 +18027,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e5a95a3eddf3877539acaac7b37589a1fda8c612ad1a3ff5a6c44af05bb7336",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:9179e066a61793b3437a4e8df293cc3fec973176f32a5cd7204dd611fc8ec5d0",
         "installName": "nvidia-l4t-arm64-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -18017,14 +18072,14 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:645d49a1f9a6e85dd2d2d3b95040607d5d134ec4309e62b1b25aa701bea270a9",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4937f645ff1e9bc8174461254cf74f992aae0b03514ce42d9eb60874cfa1d52e",
         "installName": "cuda13-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm-cpp",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18056,14 +18111,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3faa2b0fe2bf605c078737fcabc592a1ee5ce61a186f13ef3c265ecc2f265660",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ae7a9e8f5c6ae74a44fd37a5c6c32a0efecadfdea9598dae3cd6e21f39b3c916",
         "installName": "vulkan-vllm-cpp"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-vllm-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-vllm-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -18089,14 +18144,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f57edc41e25acbc2ae92c608d9eee46250b881a77340fc0d8bc769c93d420a7d",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7559fc085bf6a98317416b3dc4c295fd96c2579143a655b4795052d538bcf642",
         "installName": "rocm-vllm-omni"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-vllm-omni",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-vllm-omni",
       "systemPackages": [
         "pciutils"
       ],
@@ -18138,14 +18193,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d0f6ee0d3b9d93e37a189b25c1bd6d060b7e60b6aabe80421ade03ea887ce623",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7285467c504aa7bbff8ff23eeca7d1f3236ea2ff1e9ea4ef38a4a284100e4db0",
         "installName": "cuda12-vllm-omni"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm-omni",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm-omni",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18179,14 +18234,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e33e4c6b7d269ea2f568b8020bbd09b38ccf13e6cfb38989b41b8eed791bdd64",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3996e798d7b202b41212eda65ae88bc408e3b6b249ea83403a594d2ca594b143",
         "installName": "cuda13-vllm-omni"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vllm-omni",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm-omni",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18220,14 +18275,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f10e67667a8f9796c6f8868d42934a8b635bedd0c39916e65d37d5bb35b7fcd2",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:faa29331f1abba1bcb8ea456b38620b9a2a7f8ed0de0ced38685b71bc6ac59fd",
         "installName": "cuda13-nvidia-l4t-arm64-vllm-omni"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vllm-omni",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm-omni",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -18264,14 +18319,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d0f6ee0d3b9d93e37a189b25c1bd6d060b7e60b6aabe80421ade03ea887ce623",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7285467c504aa7bbff8ff23eeca7d1f3236ea2ff1e9ea4ef38a4a284100e4db0",
         "installName": "cuda12-vllm-omni"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm-omni",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm-omni",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18305,14 +18360,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ae6857a01b8341ea3e48189dd22c19aec5ddf8a8674bc68f4d10528fca425252",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f858a4a9b6de66a42c1ac4ee0ab88640b2190ec03319ceef592dc0ddbf98e07a",
         "installName": "rocm-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev",
@@ -18356,14 +18411,53 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1bc4549c6f602e4d9b4136ced1227fdd6b36c7f3a02df60afa427868aa99015a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2b702209d07115c710f0f021d893c53142fe7cc9aedb1e31737ad3da78ead534",
         "installName": "cpu-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-vllm",
+      "systemPackages": [
+        "gcc",
+        "libc6-dev"
+      ],
+      "runnerProfile": "unsupported",
+      "workloads": [
+        "autoround",
+        "awq",
+        "fp8",
+        "gptq",
+        "int4",
+        "int8",
+        "multimodal",
+        "text-to-text"
+      ]
+    },
+    {
+      "family": "vllm",
+      "selector": "intel",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      },
+      "runtime": "cpu",
+      "targetProfile": "intel",
+      "status": "experimental",
+      "channel": "stable",
+      "runtimeBase": {
+        "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
+      },
+      "core": {
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
+      },
+      "backend": {
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:990192efb512fc37821515610c6a15b601e876d58845b8643680ef53d78a4b25",
+        "installName": "intel-vllm"
+      },
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev"
@@ -18395,14 +18489,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:73df4be1fb891a23e370d81b884205c74012bf5d76e0e8acc5e711d02029d80a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:35afb0e759a5aece8ee502c4b8a9e8620489b407f9a355bb371e98afce842e8c",
         "installName": "cuda12-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev"
@@ -18441,14 +18535,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:040f82204597702f509f17bbdabf8d8fa54b2882e413f4ab35b71fda752d1493",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a820da917b17ca97c366df67476c41e9f0abce839dd73fc27b8758b31c357f2f",
         "installName": "cuda13-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev"
@@ -18486,14 +18580,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3f13d6f3ddfee364edea89b2f9b62253aafb969294a969294fc3248a79b1248e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:583556079bbaecac4acddc9f05f9d5cf0dd0d75d13a2a958accb3d01d7f49e1d",
         "installName": "cuda13-nvidia-l4t-arm64-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev"
@@ -18534,14 +18628,14 @@
         "ref": "docker.io/library/ubuntu@sha256:0199853f6d6b20b0424f3c5694a72a62764f01e6a771b1eb48a4197848986c7e"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:73df4be1fb891a23e370d81b884205c74012bf5d76e0e8acc5e711d02029d80a",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:35afb0e759a5aece8ee502c4b8a9e8620489b407f9a355bb371e98afce842e8c",
         "installName": "cuda12-vllm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-vllm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-vllm",
       "systemPackages": [
         "gcc",
         "libc6-dev"
@@ -18580,14 +18674,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:697276ebc28a0d1dea7190c0d766d7c0d1394b93d413b11ff728c3acdcd7ea11",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1e75178db948fe4223a0ce97d498f24bf8898caead83e5885f6bd958b24bb2ab",
         "installName": "rocm-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-voice-detect",
       "systemPackages": [
         "pciutils"
       ],
@@ -18628,14 +18722,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4588b7480a67ee182427b5859ab7268764d9395ce0e6f114d41c5960007fefaa",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:0cdc74e926545a3dde082ffe93dfe23b9d09d54406d00e04da967a91893ee494",
         "installName": "cpu-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-voice-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -18662,14 +18756,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d0d51577888527444b1637b273aa43abc9f6610ba85ef334296dec158fbbe2b4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4911f9b1eae00353d3e0ce7dac436e48b00f8ba9e29c9dbe500ac6b9b621d4cf",
         "installName": "cpu-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-voice-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -18696,14 +18790,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:04bc2edfe266c787a8a3c68b0999bd5b5029e75a97000031e90bc941df50debe",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4b16db660334fc340bf2d249f970890d2e5253c48d37e531c783ed8e0339757a",
         "installName": "intel-sycl-f16-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-voice-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -18730,14 +18824,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:65b136e5c8d7b9384356c87aeb38f8cd3e49fcb59d3411a39e774ae8cc83092b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c17d5c4d6cab850c2ee7de24f19856062cf54e9d4144c41fa360edd03535ec6",
         "installName": "cuda12-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18770,14 +18864,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:f7f1d01754a7235182848de3f01bdf64055302542a36ddafe7dfb9356fdc302c",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:4098f85496e03a2cc90cc2088c48ef5c2d462654f4f89a5de5232b57b50e91b3",
         "installName": "cuda13-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18810,14 +18904,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ffea9db7577f0d5c15625bd6eb86da606fd57c83d3bfe95c0debc5846a9f404e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dbf065b020c2f00e0b0120a75af41075422908f5ecb241334aeeb18a94880fe7",
         "installName": "nvidia-l4t-arm64-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -18853,14 +18947,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:68a75fce1ac261f9d9ad3dae6a44444d67eff072e039fbc45bf03f1b3231137e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5544ca25bddeb61f1ef38c38fa98843bdcc60eeb4bf9bcd0bedb942fdd0dd2a9",
         "installName": "cuda13-nvidia-l4t-arm64-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -18896,14 +18990,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ffea9db7577f0d5c15625bd6eb86da606fd57c83d3bfe95c0debc5846a9f404e",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dbf065b020c2f00e0b0120a75af41075422908f5ecb241334aeeb18a94880fe7",
         "installName": "nvidia-l4t-arm64-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -18939,14 +19033,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:65b136e5c8d7b9384356c87aeb38f8cd3e49fcb59d3411a39e774ae8cc83092b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5c17d5c4d6cab850c2ee7de24f19856062cf54e9d4144c41fa360edd03535ec6",
         "installName": "cuda12-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-voice-detect",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -18979,14 +19073,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5a62745aa82db94c90b4ec866bdcf99eb30a23842acfff351b818750881102e8",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3a51ce4d89cb00de2ed9fed9b24907bdf6c802c80609be65b060973aff184909",
         "installName": "vulkan-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-voice-detect",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -19013,14 +19107,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:37579a98cde3cbc7096843809f5cc3625c8b2923dffaebaf24fc15752dbbbb23",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b8cf6484c1eeb85d60ce0f4a22f1b28d970f7b24df7401e661824306d8736e71",
         "installName": "vulkan-voice-detect"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-voice-detect",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-voice-detect",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -19050,14 +19144,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1727a16e5555814eee0688c1d294037910ee5f862bdb421545a2f181648a88d6",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:3f1c13f45eae52e60a51678c02f5cf10588dfaacc0d0227a3d61b184671df03a",
         "installName": "rocm-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-voxcpm",
       "systemPackages": [
         "pciutils"
       ],
@@ -19093,14 +19187,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:88a99f60cb27554e728453a54e4d0b5933ad5270058bf6be3aac151d2f4cfde3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c41e61a245e36fc3c40ecec356b3b3aa4232dc9e5eea767d19de5bf5f0540d66",
         "installName": "cpu-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-voxcpm",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -19122,14 +19216,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2b585a412e9134d297c80a6fcca05305c45ace3f10320ae8e4651df42dc64ad4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:20328648b93351bad01c2b3cdc4047b18768c6864c2a98594df83acb43e6f55a",
         "installName": "intel-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-voxcpm",
       "runnerProfile": "unsupported",
       "workloads": [
         "text-to-speech",
@@ -19151,14 +19245,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c62bb460133f88640672173ebb0d33683d6228827c2dfb51832879f35697c1fd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5d8218591246493e05c2b215d692b6581d01de4d3b44bb19db93ba1ace3dfd6d",
         "installName": "cuda12-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-voxcpm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19186,14 +19280,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c5b8e09efaf42a0cadbb29e036a223e2ad57013d8d5edc0177f52e54ecca7deb",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dcd97cc1f17bb9f86cd5759806d3c9335db27e234b953b4c7a204b017e9673f4",
         "installName": "cuda13-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-voxcpm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19221,14 +19315,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c62bb460133f88640672173ebb0d33683d6228827c2dfb51832879f35697c1fd",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5d8218591246493e05c2b215d692b6581d01de4d3b44bb19db93ba1ace3dfd6d",
         "installName": "cuda12-voxcpm"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-voxcpm",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-voxcpm",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19256,14 +19350,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a7c5b3aa181429b1b0199261ca83df065d6a851de1b499b0abc659cf9c02d649",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:502573ddc40a0f5ee07728367fe131ec389acfb31f227f5903e36c318820e4bb",
         "installName": "cpu-voxtral"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-voxtral",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-voxtral",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19286,14 +19380,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d47006d50b7ece7c6f5f96d7bae70b929a03206fe0430bef8e769f88ecda25be",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:2484793c5eda40f7840e4e455a2f5710f2619e09296630b4de45d7b5aea87acd",
         "installName": "cpu-voxtral"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-voxtral",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-voxtral",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19316,14 +19410,14 @@
         "ref": "docker.io/rocm/dev-ubuntu-24.04@sha256:fe29799baf7b8db986a707110c15579dc0fb6e39d48973fbb82dfc33a0c7e179"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e0b283cec662f0ec2107878dcf141e643279a5704c0f56217c7d52cc6b8eb8d0",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:85ecb8ebb726b7ecbcc883d6c7e6d66895a2d7a5d3ce6744f9aead1bc80efffb",
         "installName": "rocm-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-rocm-hipblas-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-rocm-hipblas-whisper",
       "systemPackages": [
         "pciutils"
       ],
@@ -19362,14 +19456,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:42145bdc26d5b50dd56ba701a55b293d0061a4fb21fa3064df9bbf226db0eb35",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a65d0d50579f82592ff7baf14465fb5cf6f32ede3626a8e1dddf6b3f6ebd4cbf",
         "installName": "cpu-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19394,14 +19488,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:035ebcd68218cbb03cf28f8181d177ee0162685285438d14bc7f9b75a689d168",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e1543862b7c2566d7e8649533af134d533ac1d1e528180def5ce79b0cff372c6",
         "installName": "cpu-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19426,14 +19520,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:74d77c87c62b809fd952c0280543c1d7402893aaec729226459e20874aab7d91",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7734caaaaab6840d6cd8359f906d779e332662ecbc959f6fcbde93fb73faf467",
         "installName": "intel-sycl-f16-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-intel-sycl-f16-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-intel-sycl-f16-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19458,14 +19552,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6d3a6a854418196c0ddac567e460cc440ec7695d568fa673376b7d206b630c4b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ceff5f1b0c450ea98a76775a022b220e1317d2142eaacd87a9ea6b62a62524be",
         "installName": "cuda12-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19496,14 +19590,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:06744884e19b2bf0f0a7e938e18b9eddfd18a10ae73a1dac66c8ecb88d6c86fc",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:aed443957a40da91c04f83bf6a6111a97e50892037936ed9c92a493c1e8c5ccf",
         "installName": "cuda13-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19534,14 +19628,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e07802ac6331af415693965fd22d371204394a3714a52f53656ddcb8bfeb9ce3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c89808de811c1526fdc1bc103f108b531a41a07f51441cca21b231fb848bb5b6",
         "installName": "nvidia-l4t-arm64-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -19575,14 +19669,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:cd44e9546c1e5c99f9db839e3d7883170a4d70721cd6818a932d72b93053902b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:26e12760e0d93c96a69a9f51f9a3922486f508634035ff374e6ef5ac2738fe37",
         "installName": "cuda13-nvidia-l4t-arm64-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-cuda-13-arm64-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-cuda-13-arm64-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -19616,14 +19710,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e07802ac6331af415693965fd22d371204394a3714a52f53656ddcb8bfeb9ce3",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c89808de811c1526fdc1bc103f108b531a41a07f51441cca21b231fb848bb5b6",
         "installName": "nvidia-l4t-arm64-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-arm64-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-arm64-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -19657,14 +19751,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:6d3a6a854418196c0ddac567e460cc440ec7695d568fa673376b7d206b630c4b",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ceff5f1b0c450ea98a76775a022b220e1317d2142eaacd87a9ea6b62a62524be",
         "installName": "cuda12-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-whisper",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19695,14 +19789,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:049a783bf648fc4d9a34d25265e1dc669b36960b815d08ca2d34e75997cdc572",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e795a1cfe4fe88152f576a1572dfb204ca672cc7bfaa99b51a7c3e48afeb3f0a",
         "installName": "vulkan-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-whisper",
       "runnerProfile": "unsupported",
       "workloads": [
         "audio-transcription",
@@ -19727,14 +19821,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:887a38fa27354d7f4e1f0a7eafc3d3bc452f697df8fabd63d3c723e29d94d9a5",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:110a1368052d54e13b81099d56e233039729fab129e9b0ef7b01e9d0e504fbcf",
         "installName": "vulkan-whisper"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-vulkan-whisper",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-whisper",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],
@@ -19762,14 +19856,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ad379692b4622a13f0c523c94847be90b62280f3d3e59a4f63f18ca2bed304be",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:1b50e8267b002abccc5d1c56ac1eb12c22fa89d8a9768790245d33add2dc7dfc",
         "installName": "cpu-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-whisperx",
       "runnerProfile": "unsupported",
       "workloads": [
         "diarization",
@@ -19792,14 +19886,14 @@
         "ref": "docker.io/library/ubuntu@sha256:b17516cd982bf06bdd5d5600253d12a8de017b9eb831cc052b532a0363d294f9"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:8df340ceb95555389789118fc2a069def61d76c6befba356306b7f8f9dd5cc41",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:5bd54f8b0e860c9f5ee65b288fc2c4d61ec0351ecc02f13b28e5829254158f41",
         "installName": "cpu-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-cpu-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-cpu-whisperx",
       "runnerProfile": "unsupported",
       "workloads": [
         "diarization",
@@ -19822,14 +19916,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dea7c111dc62082d6f0176541632255b2cdbb1515c7a99bc13b1a69291226a97",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7f76e52442e589ab9cbf723fe3473f32307ae1bb3282a5ee3871c6bce2ef59f8",
         "installName": "cuda12-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-whisperx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19858,14 +19952,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:ae360b272fd3cf2993ea24d13469bfad670c32bfc8b02ddf9871cd83060f12aa",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:e227eab3b6397ea4e6eed5c39e648cff2a90c1c7521212059c399fdd9b9ca50c",
         "installName": "cuda13-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-13-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-13-whisperx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",
@@ -19894,14 +19988,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bdf3ce1d5ac3db60fb5646665b480fd46b206fc8377e4c3ca744ab0b966a7807",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a5dda77c2664297ecfaeecfe12558745e73c52c2feac11c5535929d96364726e",
         "installName": "nvidia-l4t-arm64-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-whisperx",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -19933,14 +20027,14 @@
         "ref": "nvcr.io/nvidia/l4t-jetpack@sha256:34ccf0f3b63c6da9eee45f2e79de9bf7fdf3beda9abfd72bbf285ae9d40bb673"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:9ee767ea4cb4f567f2d08fa3f68b0edc0a3df666d77b33779abd7431cc25c17f"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:bdf3ce1d5ac3db60fb5646665b480fd46b206fc8377e4c3ca744ab0b966a7807",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:a5dda77c2664297ecfaeecfe12558745e73c52c2feac11c5535929d96364726e",
         "installName": "nvidia-l4t-arm64-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-nvidia-l4t-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-nvidia-l4t-whisperx",
       "environment": [
         "BUILD_TYPE=cublas",
         "CUDA_HOME=/usr/local/cuda",
@@ -19972,14 +20066,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:01c90f6df2a9d5e8d16c80f60a277d45b3c89622251c84a3f833324e0322ee8d"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:dea7c111dc62082d6f0176541632255b2cdbb1515c7a99bc13b1a69291226a97",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:7f76e52442e589ab9cbf723fe3473f32307ae1bb3282a5ee3871c6bce2ef59f8",
         "installName": "cuda12-whisperx"
       },
-      "version": "v4.8.2",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.8.2-gpu-nvidia-cuda-12-whisperx",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-nvidia-cuda-12-whisperx",
       "environment": [
         "BUILD_TYPE=cublas",
         "NVIDIA_DRIVER_CAPABILITIES=compute,utility",

--- a/pkg/backendcatalog/catalog_test.go
+++ b/pkg/backendcatalog/catalog_test.go
@@ -55,7 +55,7 @@ func TestDefaultResolvesCurrentRunnerTuples(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse default catalog: %v", err)
 	}
-	if got, want := len(catalog.Entries), 544; got != want {
+	if got, want := len(catalog.Entries), 546; got != want {
 		t.Fatalf("default entry count = %d, want %d", got, want)
 	}
 	if !regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(catalog.Digest()) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates LocalAI from v4.8.2 to [v4.9.0](https://github.com/mudler/LocalAI/releases/tag/v4.9.0). Regenerates the backend catalog from the pinned release index and verified OCI manifests, and updates the binary mirror workflow default.

The catalog grows from 544 to 546 entries because Kokoros CPU and vLLM Intel now publish release artifacts.

Go image references and test expectations use shared release constants. Support policies keep a separate constant for the approved release, and the source pin has a stable name for future updates.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Existing runtime image digests, legacy Diffusers and Vulkan compatibility pins, and backend quarantines are preserved. TurboQuant ROCm remains excluded because its release artifact is still missing. The mirrored AMD64 and ARM64 binary checksums match the upstream release assets.

Validation:

- `make test` passes with race detection.
- `make lint` passes with CI's golangci-lint v2.11.2.
- Catalog regeneration with `--check` passes; `go mod tidy` leaves the module files unchanged.
- Simulated changing only the import version to v5.0.0; the future-release policy test passes.
- GitHub CI passes, including AMD64 and ARM64 inference, runner, packaging, and Kubernetes tests.
