### PR TITLE
fix: update Apple Silicon Vulkan to LocalAI v4.9.0

### DIFF
--- a/.github/workflows/test-podman-applesilicon.yaml
+++ b/.github/workflows/test-podman-applesilicon.yaml
@@ -29,10 +29,9 @@ jobs:
         run: |
           docker buildx build . -t sozercan/testmodel:test \
             --push \
-            -f test/aikitfile-llama.yaml \
+            -f test/aikitfile-llama-applesilicon.yaml \
             --provenance=false --progress plain \
-            --platform "linux/arm64" \
-            --build-arg="runtime=applesilicon"
+            --platform "linux/arm64"
 
       - name: list images
         run: docker images
@@ -48,18 +47,24 @@ jobs:
         run: |
           result=$(curl --fail --retry 10 --retry-all-errors http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
             "model": "llama-3.2-1b-instruct",
-            "messages": [{"role": "user", "content": "explain kubernetes in a sentence"}]
+            "messages": [{"role": "user", "content": "Explain Kubernetes in one sentence."}],
+            "temperature": 0,
+            "max_tokens": 64
           }')
-          echo $result
+          echo "$result"
 
-          choices=$(echo "$result" | jq '.choices')
-          if [ -z "$choices" ]; then
-            exit 1
-          fi
+          echo "$result" | jq -e '
+            .object == "chat.completion" and
+            (.usage.completion_tokens > 0) and
+            (.choices[0].message.content | type == "string" and length > 0)
+          '
+          podman logs testmodel > /tmp/podman-gpu.log 2>&1
+          grep -E 'Virtio-GPU Venus.*Apple' /tmp/podman-gpu.log
+          grep -E 'offloaded [1-9][0-9]*/[1-9][0-9]* layers to GPU' /tmp/podman-gpu.log
 
       - name: save logs
         if: always()
-        run: podman logs testmodel > /tmp/podman-gpu.log
+        run: podman logs testmodel > /tmp/podman-gpu.log 2>&1
 
       - run: podman stop testmodel
         if: always()

--- a/.github/workflows/test-podman-applesilicon.yaml
+++ b/.github/workflows/test-podman-applesilicon.yaml
@@ -59,7 +59,7 @@ jobs:
             (.choices[0].message.content | type == "string" and length > 0)
           '
           podman logs testmodel > /tmp/podman-gpu.log 2>&1
-          grep -E 'Virtio-GPU Venus.*Apple' /tmp/podman-gpu.log
+          grep -E 'using device Vulkan[0-9]+ \(Virtio-GPU Venus.*Apple' /tmp/podman-gpu.log
           grep -E 'offloaded [1-9][0-9]*/[1-9][0-9]* layers to GPU' /tmp/podman-gpu.log
 
       - name: save logs

--- a/internal/backendcatalogimport/availability.go
+++ b/internal/backendcatalogimport/availability.go
@@ -13,11 +13,11 @@ type unavailableSourcePolicy struct {
 
 var reviewedUnavailableSources = []unavailableSourcePolicy{
 	{
-		Version:    reviewedLocalAIVersion,
+		Version:    LocalAIVersion,
 		Family:     "turboquant",
 		Selector:   selectorAMD,
 		Target:     "rocm-turboquant",
-		SourceRef:  "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-rocm-hipblas-turboquant",
+		SourceRef:  "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-turboquant",
 		ErrorClass: resolutionErrorNotFound,
 	},
 }

--- a/internal/backendcatalogimport/generate.go
+++ b/internal/backendcatalogimport/generate.go
@@ -38,7 +38,7 @@ func Generate(ctx context.Context, source []byte, options GenerateOptions) (Cata
 func localAIReviewedPolicyRequirements() reviewedPolicyRequirements {
 	return reviewedPolicyRequirements{
 		Source:   LocalAISource,
-		Version:  reviewedLocalAIVersion,
+		Version:  LocalAIVersion,
 		Overlays: reviewedPolicyOverlays,
 	}
 }

--- a/internal/backendcatalogimport/generate_test.go
+++ b/internal/backendcatalogimport/generate_test.go
@@ -272,7 +272,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
   uri: quay.io/go-skynet/local-ai-backends:latest-gpu-nvidia-cuda-12-vllm
 `
 	vllmKey := reviewedPolicyKey{
-		Version:  reviewedLocalAIVersion,
+		Version:  LocalAIVersion,
 		Family:   familyVLLM,
 		Selector: selectorNVIDIA,
 		Platform: linuxPlatform(architectureAMD64),
@@ -342,7 +342,7 @@ func TestGenerateRequiresEveryApplicableReviewedPolicyOverlay(t *testing.T) {
 				},
 			}, reviewedPolicyRequirements{
 				Source:   pin,
-				Version:  reviewedLocalAIVersion,
+				Version:  LocalAIVersion,
 				Overlays: []reviewedPolicyOverlay{vllmOverlay},
 			})
 			if test.wantErr == "" {

--- a/internal/backendcatalogimport/generate_test.go
+++ b/internal/backendcatalogimport/generate_test.go
@@ -130,9 +130,9 @@ func TestGenerateDeterministicCatalog(t *testing.T) {
 		t.Fatalf("NVIDIA fallbacks = %#v, want %#v", nvidia.Fallbacks, amd64CPU.Backend)
 	}
 	vulkan := findGeneratedEntry(t, first, runnerLlamaCpp, targetVulkan, Platform{OS: platformLinux, Architecture: architectureARM64})
-	if vulkan.Version != LegacyLocalAIVersion || vulkan.SourceRef != reviewedSourceVulkanLLM ||
+	if vulkan.Version != LocalAIVersion || vulkan.SourceRef != reviewedSourceVulkanLLM || vulkan.Core != arm64CPU.Core ||
 		vulkan.Backend.InstallName != backendInstallVulkanLLM || vulkan.Status != statusExperimental || vulkan.RunnerProfile != runnerUnsupported {
-		t.Fatalf("Vulkan legacy compatibility entry = %#v", vulkan)
+		t.Fatalf("Vulkan entry = %#v", vulkan)
 	}
 	if strings.Contains(string(firstJSON), "development") || strings.Contains(string(firstJSON), "latest-") {
 		t.Fatalf("generated catalog contains development or mutable latest data:\n%s", firstJSON)

--- a/internal/backendcatalogimport/policy.go
+++ b/internal/backendcatalogimport/policy.go
@@ -228,7 +228,7 @@ func artifactVersionFor(requestedVersion, family, selector string) string {
 	}
 
 	switch family + "/" + selector {
-	case familyDiffusers + "/" + selectorNVIDIA, runnerLlamaCpp + "/" + targetVulkan:
+	case familyDiffusers + "/" + selectorNVIDIA:
 		return LegacyLocalAIVersion
 	default:
 		return requestedVersion

--- a/internal/backendcatalogimport/policy.go
+++ b/internal/backendcatalogimport/policy.go
@@ -58,7 +58,7 @@ type reviewedPolicyOverlay struct {
 
 var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -68,7 +68,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               "cpu-llama-cpp",
 		SourceRef:            reviewedSourceCPULLM,
 		TargetProfile:        runtimeCPU,
@@ -78,9 +78,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        runnerLlamaCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDALLM,
-		SourceRef:            "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
+		SourceRef:            "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-llama-cpp",
 		TargetProfile:        targetCUDA12,
 		Status:               statusSupported,
 		RuntimeBaseRef:       chiseledRuntimeBase,
@@ -89,9 +89,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:            []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorAMD, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "rocm-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-rocm-hipblas-llama-cpp",
 		TargetProfile:  targetROCm,
 		Status:         statusExperimental,
 		RuntimeBaseRef: rocmRuntimeBase,
@@ -100,7 +100,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorNVIDIAL4T, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -110,7 +110,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA12, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetL4TLLM,
 		SourceRef:      reviewedSourceL4TLLM,
 		TargetProfile:  targetL4TCUDA12,
@@ -120,9 +120,9 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: selectorL4TCUDA13, Platform: linuxPlatform(architectureARM64)},
 		Target:         "cuda13-nvidia-l4t-arm64-llama-cpp",
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-nvidia-l4t-cuda-13-arm64-llama-cpp",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-cuda-13-arm64-llama-cpp",
 		TargetProfile:  targetL4TCUDA13,
 		Status:         statusExperimental,
 		RuntimeBaseRef: ubuntuRuntimeBase,
@@ -130,7 +130,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		Fallbacks:      []fallbackTarget{{Family: runnerLlamaCpp, Selector: selectorDefault}},
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: runnerLlamaCpp, Selector: targetVulkan, Platform: linuxPlatform(architectureARM64)},
 		Target:         backendTargetVulkanLLM,
 		SourceRef:      reviewedSourceVulkanLLM,
 		TargetProfile:  targetVulkan,
@@ -140,7 +140,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:  runnerUnsupported,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyDiffusers, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         "cuda12-diffusers",
 		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-nvidia-cuda-12-diffusers",
 		TargetProfile:  targetCUDA12,
@@ -149,16 +149,16 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:            reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:            reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLM, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:         backendTargetCUDAVLLM,
-		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
+		SourceRef:      "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-12-vllm",
 		TargetProfile:  targetCUDA12,
 		Status:         statusSupported,
 		RuntimeBaseRef: ubuntu22RuntimeBase,
 		RunnerProfile:  runnerHFConfig,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -168,7 +168,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorDefault, Platform: linuxPlatform(architectureARM64)},
 		Target:               backendTargetCPUVLLM,
 		SourceRef:            reviewedSourceCPUVLLM,
 		TargetProfile:        runtimeCPU,
@@ -178,7 +178,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIA, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -188,7 +188,7 @@ var reviewedPolicyOverlays = []reviewedPolicyOverlay{
 		RunnerProfile:        familyVLLMCpp,
 	},
 	{
-		Key:                  reviewedPolicyKey{Version: reviewedLocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
+		Key:                  reviewedPolicyKey{Version: LocalAIVersion, Family: familyVLLMCpp, Selector: selectorNVIDIACUDA13, Platform: linuxPlatform(architectureAMD64)},
 		Target:               backendTargetCUDAVLLMCpp,
 		SourceRef:            reviewedSourceCUDAVLLMCpp,
 		TargetProfile:        targetCUDA13,
@@ -223,7 +223,7 @@ func hasReviewedOverlayMapping(version, family, selector, target, sourceRef stri
 }
 
 func artifactVersionFor(requestedVersion, family, selector string) string {
-	if requestedVersion != reviewedLocalAIVersion {
+	if requestedVersion != LocalAIVersion {
 		return requestedVersion
 	}
 

--- a/internal/backendcatalogimport/policy_test.go
+++ b/internal/backendcatalogimport/policy_test.go
@@ -16,7 +16,7 @@ func TestCompatibilityArtifactVersions(t *testing.T) {
 	}{
 		{name: "Diffusers default CUDA", version: LocalAIVersion, family: familyDiffusers, selector: selectorNVIDIA, want: LegacyLocalAIVersion},
 		{name: "Diffusers explicit CUDA 12", version: LocalAIVersion, family: familyDiffusers, selector: selectorNVIDIACUDA12, want: LocalAIVersion},
-		{name: "Apple Silicon Vulkan", version: LocalAIVersion, family: runnerLlamaCpp, selector: targetVulkan, want: LegacyLocalAIVersion},
+		{name: "Apple Silicon Vulkan", version: LocalAIVersion, family: runnerLlamaCpp, selector: targetVulkan, want: LocalAIVersion},
 		{name: "vLLM default CUDA", version: LocalAIVersion, family: familyVLLM, selector: selectorNVIDIA, want: LocalAIVersion},
 		{name: "different imported release", version: fixtureFutureVersion, family: familyDiffusers, selector: selectorNVIDIA, want: fixtureFutureVersion},
 	}

--- a/internal/backendcatalogimport/testdata/resolutions.json
+++ b/internal/backendcatalogimport/testdata/resolutions.json
@@ -58,7 +58,7 @@
       ]
     },
     {
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-vulkan-llama-cpp",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-llama-cpp",
       "manifests": [
         {
           "digest": "sha256:abababababababababababababababababababababababababababababababab",

--- a/internal/backendcatalogimport/types.go
+++ b/internal/backendcatalogimport/types.go
@@ -4,14 +4,11 @@ const (
 	// SchemaVersion is the generated backend catalog schema version.
 	SchemaVersion = "v2"
 
-	// LocalAIVersion is the LocalAI release imported by this generator.
+	// LocalAIVersion is the LocalAI release used by the generator and its policies.
 	LocalAIVersion = "v4.9.0"
 
 	// LegacyLocalAIVersion is the LocalAI release retained for compatibility backends.
 	LegacyLocalAIVersion = "v3.12.1"
-
-	// Keep policy approval pinned independently of LocalAIVersion.
-	reviewedLocalAIVersion = "v4.9.0"
 
 	architectureAMD64         = "amd64"
 	architectureARM64         = "arm64"
@@ -75,11 +72,11 @@ const (
 	cudaPath                  = "PATH=/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	cudaVisibleDevices        = "NVIDIA_VISIBLE_DEVICES=all"
 	vllmNativeSampler         = "VLLM_USE_FLASHINFER_SAMPLER=0"
-	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-cpu-llama-cpp"
-	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-cpu-vllm-cpp"
-	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
-	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
-	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-vulkan-llama-cpp"
+	reviewedSourceCPULLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-llama-cpp"
+	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-cpu-vllm-cpp"
+	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
+	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
+	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + LocalAIVersion + "-gpu-vulkan-llama-cpp"
 )
 
 // LocalAISource pins the exact upstream input accepted by the command.

--- a/internal/backendcatalogimport/types.go
+++ b/internal/backendcatalogimport/types.go
@@ -79,7 +79,7 @@ const (
 	reviewedSourceCPUVLLM     = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-cpu-vllm-cpp"
 	reviewedSourceCUDAVLLMCpp = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-nvidia-cuda-13-vllm-cpp"
 	reviewedSourceL4TLLM      = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-nvidia-l4t-arm64-llama-cpp"
-	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + LegacyLocalAIVersion + "-gpu-vulkan-llama-cpp"
+	reviewedSourceVulkanLLM   = "quay.io/go-skynet/local-ai-backends:" + reviewedLocalAIVersion + "-gpu-vulkan-llama-cpp"
 )
 
 // LocalAISource pins the exact upstream input accepted by the command.

--- a/pkg/aikit2llb/inference/backend.go
+++ b/pkg/aikit2llb/inference/backend.go
@@ -330,10 +330,17 @@ func installBackendArtifact(
 
 	metadata := marshalBackendMetadata(backend, runtime, artifact, primary)
 
+	actions := llb.Copy(backendState, "/", backendDir+"/", &llb.CopyInfo{
+		CreateDestPath: true,
+	}).Mkfile(backendDir+"/metadata.json", 0o644, metadata)
+	if runtime == backendcatalog.RuntimeAppleSilicon && backend.TargetProfile == backendcatalog.TargetProfileVulkan {
+		// LocalAI prefers bundled ICD manifests over VK_ICD_FILENAMES. Remove them
+		// so Apple Silicon uses the runtime base's patched Venus driver.
+		actions = actions.Rm(backendDir+"/vulkan/icd.d", llb.WithAllowNotFound(true))
+	}
+
 	s = s.File(
-		llb.Copy(backendState, "/", backendDir+"/", &llb.CopyInfo{
-			CreateDestPath: true,
-		}).Mkfile(backendDir+"/metadata.json", 0o644, metadata),
+		actions,
 		llb.WithCustomName(fmt.Sprintf("Creating metadata.json for backend %s", artifact.InstallName)),
 	)
 

--- a/pkg/aikit2llb/inference/backend_test.go
+++ b/pkg/aikit2llb/inference/backend_test.go
@@ -115,13 +115,13 @@ func TestResolveBackendCurrentCompatibility(t *testing.T) {
 			wantEnvironment: testCUDA12Environment,
 		},
 		{
-			name: "Apple Silicon llama-cpp preserves legacy default",
+			name: "Apple Silicon llama-cpp Vulkan",
 			config: &config.InferenceConfig{
 				Runtime: utils.RuntimeAppleSilicon,
 			},
 			platform:        specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformARM64},
 			wantName:        "gpu-vulkan-llama-cpp",
-			wantVersion:     testLegacyLocalAI,
+			wantVersion:     testLocalAIVersion,
 			wantProfile:     backendcatalog.TargetProfileVulkan,
 			wantRunner:      backendcatalog.RunnerProfileUnsupported,
 			wantEnvironment: []string{"VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"},
@@ -495,6 +495,69 @@ func TestInstallBackendKeepsCopyAndMetadataInOneFileOp(t *testing.T) {
 	}
 	if fileOps != 1 {
 		t.Errorf("backend file operations = %d, want 1", fileOps)
+	}
+}
+
+func TestInstallBackendsPreservesAppleSiliconVulkanDriver(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtime    backendcatalog.Runtime
+		profile    backendcatalog.TargetProfile
+		wantRemove bool
+	}{
+		{name: "Apple Silicon Vulkan", runtime: backendcatalog.RuntimeAppleSilicon, profile: backendcatalog.TargetProfileVulkan, wantRemove: true},
+		{name: "Apple Silicon Metal", runtime: backendcatalog.RuntimeAppleSilicon, profile: backendcatalog.TargetProfileMetal},
+		{name: "Linux Vulkan", runtime: backendcatalog.RuntimeCPU, profile: backendcatalog.TargetProfileVulkan},
+		{name: "CPU", runtime: backendcatalog.RuntimeCPU, profile: backendcatalog.TargetProfileCPU},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			platform := specs.Platform{OS: utils.PlatformLinux, Architecture: utils.PlatformARM64}
+			if test.runtime == backendcatalog.RuntimeCPU {
+				platform.Architecture = utils.PlatformAMD64
+			}
+			resolved := testArbitraryBackendPlan(platform)
+			resolved.Runtime = test.runtime
+			resolved.TargetProfile = test.profile
+			resolved.Fallbacks = nil
+			resolved.SystemPackages = nil
+			base := llb.Image(resolved.RuntimeBase.Ref, llb.Platform(platform))
+			state := installBackends(resolved, test.runtime, platform, base, base)
+			definition, err := state.Marshal(context.Background())
+			if err != nil {
+				t.Fatalf("marshal backend definition: %v", err)
+			}
+
+			backendDir := "/backends/" + resolved.Backend.InstallName
+			removed := false
+			for _, data := range definition.Def {
+				op := new(pb.Op)
+				if err := op.Unmarshal(data); err != nil {
+					t.Fatalf("unmarshal LLB op: %v", err)
+				}
+				if op.GetFile() == nil {
+					continue
+				}
+				copied := false
+				for _, action := range op.GetFile().Actions {
+					if copyAction := action.GetCopy(); copyAction != nil && strings.HasPrefix(copyAction.Dest, backendDir) {
+						copied = true
+					}
+					if rm := action.GetRm(); rm != nil && rm.Path == backendDir+"/vulkan/icd.d" {
+						removed = true
+						if !copied {
+							t.Error("bundled ICD removal must follow the backend copy")
+						}
+						if !rm.AllowNotFound {
+							t.Error("backends without bundled ICD manifests must remain installable")
+						}
+					}
+				}
+			}
+			if removed != test.wantRemove {
+				t.Errorf("bundled ICD removal = %v, want %v", removed, test.wantRemove)
+			}
+		})
 	}
 }
 

--- a/pkg/backendcatalog/catalog.lock.json
+++ b/pkg/backendcatalog/catalog.lock.json
@@ -6343,14 +6343,14 @@
         "ref": "docker.io/library/ubuntu@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:c9f061c7d002abf967820487dfa26d6228ef6e752002e4448e348149fd7b0771"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:dafcc4fb739a44e039c35d731daa1bf404044c0aa9921f71e400d2f6e6bc7f62"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:c97cca0cfaefb44ba2ebbdc7f181601f05811fd75f71be9a1c2bc75813c095e4",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:b8a3fe7f45f0c29462d0e5ae7b943e876b0034a93151654b23043fe266cb6cf1",
         "installName": "vulkan-llama-cpp"
       },
-      "version": "v3.12.1",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-vulkan-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-llama-cpp",
       "runnerProfile": "unsupported",
       "workloads": [
         "cpu",
@@ -6379,14 +6379,14 @@
         "ref": "ghcr.io/kaito-project/aikit/applesilicon/base@sha256:e1447388a566e6e902c99988bb072f88763975c0850f50e064fb1e33f3d4c830"
       },
       "core": {
-        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:cea173afc320181d11d7385f74338a3614a9e204804fd7627980523ab31df77e"
+        "ref": "ghcr.io/kaito-project/aikit/localai@sha256:08c9af486171f49593bf69ea4409578784aaa7b1541d966ee86f719355aebf76"
       },
       "backend": {
-        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d3aeacc6a4376a6e76541f56403bdc79e966952025a3e77df13924750e63f4fa",
+        "ref": "quay.io/go-skynet/local-ai-backends@sha256:d6e9a4f88eab2ccadf416c0da75bf046969a99118e47934308e4a2a33a162d9f",
         "installName": "gpu-vulkan-llama-cpp"
       },
-      "version": "v3.12.1",
-      "sourceRef": "quay.io/go-skynet/local-ai-backends:v3.12.1-gpu-vulkan-llama-cpp",
+      "version": "v4.9.0",
+      "sourceRef": "quay.io/go-skynet/local-ai-backends:v4.9.0-gpu-vulkan-llama-cpp",
       "environment": [
         "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/virtio_icd.aarch64.json"
       ],

--- a/test/aikitfile-llama-applesilicon.yaml
+++ b/test/aikitfile-llama-applesilicon.yaml
@@ -1,0 +1,23 @@
+#syntax=aikit:test
+apiVersion: v1alpha1
+debug: true
+runtime: applesilicon
+backends:
+  - llama-cpp
+models:
+  - name: llama-3.2-1b-instruct
+    source: https://huggingface.co/MaziyarPanahi/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct.Q4_K_M.gguf
+    sha256: "e4650dd6b45ef456066b11e4927f775eef4dd1e0e8473c3c0f27dd19ee13cc4e"
+config: |
+  - name: llama-3.2-1b-instruct
+    backend: llama-cpp
+    debug: true
+    context_size: 2048
+    gpu_layers: 99
+    parameters:
+      model: Llama-3.2-1B-Instruct.Q4_K_M.gguf
+    template:
+      use_tokenizer_template: true
+    # Include llama.cpp device selection and GPU layer offload in the test logs.
+    options:
+      - verbosity:4


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade the Vulkan backend and matching LocalAI core from v3.12.1 to v4.9.0. LocalAI 4.9.0 prefers bundled Vulkan ICD manifests over the configured runtime driver, causing CPU fallback on Apple Silicon. Remove those manifests during Apple Silicon Vulkan image assembly so inference uses the runtime base's patched Venus driver.

Use `LocalAIVersion` for the importer, policy overlays, and availability exceptions. An explicit release-version change now advances those policies together; exact source, target, platform, and unknown-version checks still apply.

Add an Apple Silicon Llama 3.2 1B fixture and require the Podman smoke test to produce a valid chat response, select an Apple Venus device, and offload model layers to the GPU. Regression tests cover driver handling for Apple Silicon Vulkan, Apple Silicon Metal, Linux Vulkan, and CPU backends.

**Special notes for your reviewer**:

Verified a freshly built image on an Apple M1 Max using Podman 6.0.2 with libkrun. LocalAI reports v4.9.0 and Llama 3.2 1B returns a successful chat response with both 8 GiB and 2 GiB VM memory. Logs confirm:

```text
using device Vulkan0 (Virtio-GPU Venus (Apple M1 Max))
load_tensors: offloaded 17/17 layers to GPU
```

Validation passed:

- `make test` with Go 1.26.3, including race detection.
- `make lint` with the CI-pinned golangci-lint 2.11.2.
- `actionlint .github/workflows/test-podman-applesilicon.yaml`.
- The updated Podman workflow smoke step against the freshly built image.

