### PR TITLE
feat(build): use native OCI blobs and share remote caches

### DIFF
--- a/.github/workflows/patch-models.yaml
+++ b/.github/workflows/patch-models.yaml
@@ -51,6 +51,9 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      with:
+        version: v0.37.0
+        driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
 
     - name: Login to GHCR
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -46,6 +46,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
 
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/release-base.yaml
+++ b/.github/workflows/release-base.yaml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
 
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/release-hf-cli.yaml
+++ b/.github/workflows/release-hf-cli.yaml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
 
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/release-runners.yaml
+++ b/.github/workflows/release-runners.yaml
@@ -83,6 +83,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
       - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Login to GHCR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
       - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Login to GHCR

--- a/.github/workflows/test-oci-platforms.yaml
+++ b/.github/workflows/test-oci-platforms.yaml
@@ -81,6 +81,7 @@ jobs:
             --name oci-platforms \
             --driver docker-container \
             --driver-opt network=host \
+            --driver-opt image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3 \
             --platform linux/amd64 \
             --use
           docker buildx inspect --bootstrap | tee "$RUNNER_TEMP/buildx-inspect.txt"
@@ -108,28 +109,45 @@ jobs:
             tee "$RUNNER_TEMP/multi-platform-index.json" |
             jq .
 
-      - name: Build arm64 targets and verify selected model bytes
+      - name: Verify arm64 model downloads and remote cache reuse
         run: |
           set -euo pipefail
 
           build_and_verify() {
-            local case_name=$1
-            local expected_payload=$2
-            local output_dir="$RUNNER_TEMP/oci-platform-output/$case_name"
-            local build_log="$RUNNER_TEMP/$case_name-build.log"
+            local builder=$1
+            local case_name=$2
+            local expected_payload=$3
+            local output_dir="$RUNNER_TEMP/oci-platform-output/$builder/$case_name"
+            local build_log="$RUNNER_TEMP/$builder-$case_name-build.log"
+            local cache_ref="localhost:5000/aikit/cache:$case_name"
+            local cache_args=(--cache-to "type=registry,ref=$cache_ref,mode=max")
+            if [[ "$builder" == oci-platforms-cache ]]; then
+              cache_args=(--cache-from "type=registry,ref=$cache_ref")
+            fi
 
             mkdir -p "$output_dir"
             docker buildx build . \
-              --builder oci-platforms \
+              --builder "$builder" \
               --file "test/ci/oci-platforms/$case_name.aikitfile.yaml" \
               --platform linux/arm64 \
               --output "type=local,dest=$output_dir" \
+              "${cache_args[@]}" \
               --provenance=false \
               --progress=plain 2>&1 | tee "$build_log"
 
-            # The target is arm64. The x86_64 apk index proves the ORAS helper
-            # actually executed on the amd64 builder rather than the target.
-            grep -E '/x86_64/APKINDEX' "$build_log"
+            # Model bytes must use native blob sources on this builder.
+            grep -F 'docker-image+blob://' "$build_log"
+            if grep -E '/APKINDEX|apk add --no-cache jq curl' "$build_log"; then
+              echo 'OCI model download used the legacy helper' >&2
+              exit 1
+            fi
+            if [[ "$builder" == oci-platforms-cache ]]; then
+              awk '
+                /Verifying OCI model blob/ { model[$1] = 1 }
+                $2 == "CACHED" && model[$1] { hit = 1 }
+                END { exit !hit }
+              ' "$build_log"
+            fi
             test -f "$output_dir/models/model.gguf"
             test "$(find "$output_dir/models" -maxdepth 1 -type f | wc -l)" -eq 1
             test ! -e "$output_dir/models/predicate.json"
@@ -140,12 +158,31 @@ jobs:
           # The sole descriptor is stamped amd64, but a neutral ModelPack-style
           # index must still pull successfully for an arm64 target.
           build_and_verify \
+            oci-platforms \
             single-stamped \
             test/ci/oci-platforms/payloads/single/model.gguf
 
           # The real two-platform index must select arm64 while ignoring its
           # unknown-platform attestation descriptor.
           build_and_verify \
+            oci-platforms \
+            multi-platform \
+            test/ci/oci-platforms/payloads/multi-arm64/model.gguf
+
+          # A fresh builder must reuse the registry cache without local build state.
+          docker buildx create \
+            --name oci-platforms-cache \
+            --driver docker-container \
+            --driver-opt network=host \
+            --driver-opt image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3 \
+            --platform linux/amd64
+          docker buildx inspect oci-platforms-cache --bootstrap
+          build_and_verify \
+            oci-platforms-cache \
+            single-stamped \
+            test/ci/oci-platforms/payloads/single/model.gguf
+          build_and_verify \
+            oci-platforms-cache \
             multi-platform \
             test/ci/oci-platforms/payloads/multi-arm64/model.gguf
 
@@ -155,6 +192,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/oci-platform-diagnostics"
           docker logs oci-platform-registry > "$RUNNER_TEMP/oci-platform-diagnostics/registry.log" 2>&1 || true
           docker buildx inspect oci-platforms > "$RUNNER_TEMP/oci-platform-diagnostics/buildx.txt" 2>&1 || true
+          docker buildx inspect oci-platforms-cache > "$RUNNER_TEMP/oci-platform-diagnostics/buildx-cache.txt" 2>&1 || true
           cp "$RUNNER_TEMP"/*-index.json "$RUNNER_TEMP/oci-platform-diagnostics/" 2>/dev/null || true
           cp "$RUNNER_TEMP"/*-build.log "$RUNNER_TEMP/oci-platform-diagnostics/" 2>/dev/null || true
 

--- a/.github/workflows/test-packager-inference.yaml
+++ b/.github/workflows/test-packager-inference.yaml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Setup buildx with host network access
         run: |
-          docker buildx create --use --name host-network --driver-opt network=host || true
+          docker buildx create --use --name host-network \
+            --driver-opt network=host \
+            --driver-opt image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
           docker buildx inspect --bootstrap
 
       - name: Start local registry

--- a/.github/workflows/update-models.yaml
+++ b/.github/workflows/update-models.yaml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          version: v0.37.0
+          driver-opts: image=moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
       - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Login to GHCR

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/kaito-project/aikit
 go 1.26.3
 
 require (
+	github.com/containerd/containerd/v2 v2.3.4
 	github.com/containerd/platforms v1.0.0-rc.5
+	github.com/distribution/reference v0.6.0
 	github.com/moby/buildkit v0.33.0
 	github.com/modelpack/model-spec v0.0.7
 	github.com/opencontainers/go-digest v1.0.0
@@ -18,12 +20,10 @@ require (
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/containerd/v2 v2.3.4 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/ttrpc v1.2.9 // indirect
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/pkg/aikit2llb/inference/convert.go
+++ b/pkg/aikit2llb/inference/convert.go
@@ -15,13 +15,27 @@ import (
 
 const standardRuntimeCABundlePath = "/etc/ssl/certs/ca-certificates.crt"
 
+// ConvertOption configures model source resolution during conversion.
+type ConvertOption func(*convertOptions)
+
+type convertOptions struct {
+	ociResolver OCIResolver
+}
+
+// WithOCIResolver enables native registry blob downloads through a BuildKit gateway.
+func WithOCIResolver(resolver OCIResolver) ConvertOption {
+	return func(opts *convertOptions) {
+		opts.ociResolver = resolver
+	}
+}
+
 // Aikit2LLB converts an InferenceConfig to an LLB state.
-func Aikit2LLB(c *config.InferenceConfig, targetPlatform *specs.Platform) (llb.State, *specs.Image, error) {
-	return Aikit2LLBWithPlatforms(c, targetPlatform, targetPlatform)
+func Aikit2LLB(c *config.InferenceConfig, targetPlatform *specs.Platform, opts ...ConvertOption) (llb.State, *specs.Image, error) {
+	return Aikit2LLBWithPlatforms(c, targetPlatform, targetPlatform, opts...)
 }
 
 // Aikit2LLBWithPlatforms converts an InferenceConfig using separate build and target platforms.
-func Aikit2LLBWithPlatforms(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform) (llb.State, *specs.Image, error) {
+func Aikit2LLBWithPlatforms(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform, opts ...ConvertOption) (llb.State, *specs.Image, error) {
 	if targetPlatform == nil {
 		return llb.State{}, nil, fmt.Errorf("target platform is required")
 	}
@@ -31,11 +45,11 @@ func Aikit2LLBWithPlatforms(c *config.InferenceConfig, buildPlatform, targetPlat
 		return llb.State{}, nil, err
 	}
 
-	return aikit2LLBWithResolvedBackend(c, buildPlatform, targetPlatform, backend)
+	return aikit2LLBWithResolvedBackend(c, buildPlatform, targetPlatform, backend, opts...)
 }
 
 // Aikit2LLBWithBackend converts an InferenceConfig using a pre-resolved immutable backend plan.
-func Aikit2LLBWithBackend(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform, backend backendcatalog.Resolution) (llb.State, *specs.Image, error) {
+func Aikit2LLBWithBackend(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform, backend backendcatalog.Resolution, opts ...ConvertOption) (llb.State, *specs.Image, error) {
 	if targetPlatform == nil {
 		return llb.State{}, nil, fmt.Errorf("target platform is required")
 	}
@@ -47,12 +61,16 @@ func Aikit2LLBWithBackend(c *config.InferenceConfig, buildPlatform, targetPlatfo
 		return llb.State{}, nil, fmt.Errorf("pre-resolved backend plan does not match the embedded catalog")
 	}
 
-	return aikit2LLBWithResolvedBackend(c, buildPlatform, targetPlatform, backend)
+	return aikit2LLBWithResolvedBackend(c, buildPlatform, targetPlatform, backend, opts...)
 }
 
-func aikit2LLBWithResolvedBackend(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform, backend backendcatalog.Resolution) (llb.State, *specs.Image, error) {
+func aikit2LLBWithResolvedBackend(c *config.InferenceConfig, buildPlatform, targetPlatform *specs.Platform, backend backendcatalog.Resolution, opts ...ConvertOption) (llb.State, *specs.Image, error) {
 	if buildPlatform == nil {
 		buildPlatform = targetPlatform
+	}
+	var options convertOptions
+	for _, opt := range opts {
+		opt(&options)
 	}
 
 	var merge llb.State
@@ -69,7 +87,7 @@ func aikit2LLBWithResolvedBackend(c *config.InferenceConfig, buildPlatform, targ
 		state, merge = installRunnerEntrypoint(c, backend, state, merge)
 	} else {
 		// Standard mode materializes models and config on an isolated branch.
-		state, merge, err = copyModels(c, base, buildBase, *buildPlatform, *targetPlatform)
+		state, merge, err = copyModels(c, base, buildBase, *buildPlatform, *targetPlatform, WithOCIResolver(options.ociResolver))
 		if err != nil {
 			return state, nil, err
 		}
@@ -134,7 +152,11 @@ func writeConfig(c *config.InferenceConfig, base llb.State, s llb.State, platfor
 }
 
 // copyModels copies models to the image and writes the config.
-func copyModels(c *config.InferenceConfig, base llb.State, s llb.State, buildPlatform, targetPlatform specs.Platform) (llb.State, llb.State, error) {
+func copyModels(c *config.InferenceConfig, base llb.State, s llb.State, buildPlatform, targetPlatform specs.Platform, opts ...ConvertOption) (llb.State, llb.State, error) {
+	var options convertOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	savedState := s
 	localSources := make([]string, 0, len(c.Models))
 	for _, model := range c.Models {
@@ -150,7 +172,11 @@ func copyModels(c *config.InferenceConfig, base llb.State, s llb.State, buildPla
 		if _, err := url.ParseRequestURI(model.Source); err == nil {
 			switch {
 			case strings.HasPrefix(model.Source, "oci://"):
-				s = handleOCI(model.Source, s, buildPlatform, targetPlatform)
+				if options.ociResolver != nil {
+					s = copyOCIModel(model.Source, s, targetPlatform, options.ociResolver)
+				} else {
+					s = handleOCI(model.Source, s, buildPlatform, targetPlatform)
+				}
 			case strings.HasPrefix(model.Source, "http://"), strings.HasPrefix(model.Source, "https://"):
 				s = handleHTTP(model.Source, model.Name, model.SHA256, s)
 			case strings.HasPrefix(model.Source, "huggingface://"):

--- a/pkg/aikit2llb/inference/oci.go
+++ b/pkg/aikit2llb/inference/oci.go
@@ -1,0 +1,311 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/flightcontrol"
+	"github.com/moby/buildkit/util/imageutil"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	ociManifestFilename = "/manifest.json"
+	ociResolvedRefPath  = "/resolved-ref"
+	ociBlobFilename     = "blob"
+	maxOCIManifestSize  = 4 << 20
+	maxOCIIndexDepth    = 8
+	ollamaModelType     = "application/vnd.ollama.image.model"
+	orasUnpack          = "io.deis.oras.content.unpack"
+)
+
+// OCIResolver resolves a model reference to a tree of downloaded files.
+type OCIResolver interface {
+	Resolve(context.Context, string, specs.Platform) (llb.State, error)
+}
+
+type ociResolver struct {
+	client        client.Client
+	buildPlatform specs.Platform
+	cacheImports  []client.CacheOptionsEntry
+	manifests     flightcontrol.CachedGroup[resolvedOCIManifest]
+}
+
+type resolvedOCIManifest struct {
+	ref  reference.Canonical
+	data []byte
+}
+
+// NewOCIResolver shares manifest lookups across a build's target platforms.
+// Older builders retain the ORAS download path when blob sources are unavailable.
+func NewOCIResolver(c client.Client, buildPlatform specs.Platform, cacheImports []client.CacheOptionsEntry) OCIResolver {
+	caps := c.BuildOpts().LLBCaps
+	if !caps.Contains(pb.CapSourceImageBlob) || caps.Supports(pb.CapSourceImageBlob) != nil {
+		return nil
+	}
+	return &ociResolver{client: c, buildPlatform: buildPlatform, cacheImports: cacheImports}
+}
+
+func copyOCIModel(source string, state llb.State, target specs.Platform, resolver OCIResolver) llb.State {
+	return state.Async(func(ctx context.Context, state llb.State, _ *llb.Constraints) (llb.State, error) {
+		model, err := resolver.Resolve(ctx, source, target)
+		if err != nil {
+			return llb.State{}, errors.Wrapf(err, "resolving OCI model %s", source)
+		}
+		return state.File(
+			llb.Copy(model, "/", "/models/", &llb.CopyInfo{CopyDirContentsOnly: true, CreateDestPath: true}),
+			llb.WithCustomName("Copying OCI model "+source+" to /models"),
+		), nil
+	})
+}
+
+func (r *ociResolver) Resolve(ctx context.Context, source string, target specs.Platform) (llb.State, error) {
+	named, err := reference.ParseNormalizedNamed(strings.TrimPrefix(source, "oci://"))
+	if err != nil {
+		return llb.State{}, errors.Wrap(err, "invalid OCI model reference")
+	}
+	named = reference.TagNameOnly(named)
+	manifest, err := r.readManifest(ctx, named)
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	for depth := 0; ; depth++ {
+		mediaType, err := imageutil.DetectManifestBlobMediaType(manifest.data)
+		if err != nil {
+			return llb.State{}, errors.Wrap(err, "invalid OCI manifest")
+		}
+		switch mediaType {
+		case specs.MediaTypeImageIndex, images.MediaTypeDockerSchema2ManifestList:
+			if depth >= maxOCIIndexDepth {
+				return llb.State{}, errors.New("OCI model index nesting exceeds limit")
+			}
+			var index specs.Index
+			if err := json.Unmarshal(manifest.data, &index); err != nil {
+				return llb.State{}, errors.Wrap(err, "decoding OCI index")
+			}
+			if index.SchemaVersion != 2 {
+				return llb.State{}, errors.New("OCI model index must use schema version 2")
+			}
+			child, err := selectOCIManifest(index, target)
+			if err != nil {
+				return llb.State{}, err
+			}
+			childRef, err := reference.WithDigest(reference.TrimNamed(manifest.ref), child.Digest)
+			if err != nil {
+				return llb.State{}, errors.Wrap(err, "invalid OCI manifest digest")
+			}
+			manifest, err = r.readManifest(ctx, childRef)
+			if err != nil {
+				return llb.State{}, err
+			}
+			if int64(len(manifest.data)) != child.Size {
+				return llb.State{}, errors.New("OCI model manifest size mismatch")
+			}
+		case specs.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+			var image specs.Manifest
+			if err := json.Unmarshal(manifest.data, &image); err != nil {
+				return llb.State{}, errors.Wrap(err, "decoding OCI model manifest")
+			}
+			if image.SchemaVersion != 2 {
+				return llb.State{}, errors.New("OCI model manifest must use schema version 2")
+			}
+			return r.modelFiles(manifest.ref, image)
+		default:
+			return llb.State{}, errors.Errorf("unsupported OCI model manifest type %q", mediaType)
+		}
+	}
+}
+
+func (r *ociResolver) readManifest(ctx context.Context, named reference.Named) (resolvedOCIManifest, error) {
+	return r.manifests.Do(ctx, named.String(), func(ctx context.Context) (resolvedOCIManifest, error) {
+		var result resolvedOCIManifest
+		// Registry manifests use a different endpoint from native blob sources.
+		// ORAS also handles artifact configs that the image metadata API cannot resolve.
+		script := "ref=\"$1\"\nshift\n"
+		opts := []llb.RunOption{llb.WithCustomName("Resolving OCI model manifest " + named.String())}
+		if canonical, ok := named.(reference.Canonical); ok {
+			result.ref = canonical
+		} else {
+			// Resolve mutable tags once per request, without caching the lookup across builds.
+			script += "ref=$(oras resolve \"$@\" --full-reference \"$ref\")\nprintf '%s\\n' \"$ref\" > /resolved-ref\n"
+			opts = append(opts, llb.IgnoreCache)
+		}
+		script += "oras manifest fetch \"$@\" \"$ref\" > /manifest.json\n"
+		args := []string{"/bin/sh", "-ec", script, "aikit-oci-manifest", named.String()}
+		if isLocalOCIRegistry(reference.Domain(named)) {
+			args = append(args, "--insecure")
+		}
+		state := orasToolingImage(r.buildPlatform).Run(append(opts, llb.Args(args))...).Root()
+		definition, err := state.Marshal(ctx)
+		if err != nil {
+			return result, errors.Wrap(err, "marshaling OCI manifest lookup")
+		}
+		solved, err := r.client.Solve(ctx, client.SolveRequest{Definition: definition.ToPB(), CacheImports: r.cacheImports})
+		if err != nil {
+			return result, errors.Wrap(err, "fetching OCI model manifest")
+		}
+		ref, err := solved.SingleRef()
+		if err != nil {
+			return result, err
+		}
+		if ref == nil {
+			return result, errors.New("OCI manifest lookup returned no reference")
+		}
+		if result.ref == nil {
+			data, err := ref.ReadFile(ctx, client.ReadRequest{Filename: ociResolvedRefPath, Range: &client.FileRange{Length: 4096}})
+			if err != nil {
+				return result, errors.Wrap(err, "reading resolved OCI reference")
+			}
+			resolved, err := reference.ParseNormalizedNamed(strings.TrimSpace(string(data)))
+			if err != nil {
+				return result, errors.Wrap(err, "invalid resolved OCI reference")
+			}
+			canonical, ok := resolved.(reference.Canonical)
+			if !ok || canonical.Name() != named.Name() {
+				return result, errors.New("OCI manifest lookup did not return a digest in the requested repository")
+			}
+			result.ref = canonical
+		}
+		result.data, err = ref.ReadFile(ctx, client.ReadRequest{Filename: ociManifestFilename, Range: &client.FileRange{Length: maxOCIManifestSize + 1}})
+		if err != nil {
+			return result, errors.Wrap(err, "reading OCI manifest")
+		}
+		if len(result.data) > maxOCIManifestSize {
+			return result, errors.New("OCI model manifest exceeds 4 MiB")
+		}
+		if err := result.ref.Digest().Validate(); err != nil {
+			return result, errors.Wrap(err, "invalid OCI manifest digest")
+		}
+		if result.ref.Digest().Algorithm().FromBytes(result.data) != result.ref.Digest() {
+			return result, errors.New("OCI model manifest digest mismatch")
+		}
+		return result, nil
+	})
+}
+
+func selectOCIManifest(index specs.Index, target specs.Platform) (specs.Descriptor, error) {
+	candidates := make([]specs.Descriptor, 0, len(index.Manifests))
+	uniquePlatforms := make(map[string]struct{})
+	for _, descriptor := range index.Manifests {
+		if descriptor.Annotations["vnd.docker.reference.type"] == "attestation-manifest" {
+			continue
+		}
+		if p := descriptor.Platform; p != nil {
+			if p.OS == "unknown" || p.Architecture == "unknown" {
+				continue
+			}
+			if p.OS != "" && p.Architecture != "" {
+				uniquePlatforms[platforms.FormatAll(platforms.Normalize(*p))] = struct{}{}
+			}
+		}
+		candidates = append(candidates, descriptor)
+	}
+	if len(candidates) == 0 {
+		return specs.Descriptor{}, errors.New("OCI model index has no model manifests")
+	}
+	// A single platform stamp is common on platform-neutral ModelPack indexes.
+	// Only require a target match when the index actually offers multiple platforms.
+	selected := candidates[0]
+	if len(uniquePlatforms) > 1 {
+		matcher := platforms.Only(target)
+		found := false
+		for _, candidate := range candidates {
+			if candidate.Platform != nil && matcher.Match(*candidate.Platform) &&
+				(!found || matcher.Less(*candidate.Platform, *selected.Platform)) {
+				selected, found = candidate, true
+			}
+		}
+		if !found {
+			return specs.Descriptor{}, errors.Errorf("OCI model index has no manifest for %s", platforms.FormatAll(target))
+		}
+	}
+	if err := selected.Digest.Validate(); err != nil {
+		return specs.Descriptor{}, errors.Wrap(err, "invalid OCI model manifest digest")
+	}
+	if selected.Size < 0 || selected.Size > maxOCIManifestSize {
+		return specs.Descriptor{}, errors.New("invalid OCI model manifest size")
+	}
+	return selected, nil
+}
+
+func (r *ociResolver) modelFiles(ref reference.Canonical, manifest specs.Manifest) (llb.State, error) {
+	state := llb.Scratch()
+	names := make(map[string]struct{})
+	ollama := reference.Domain(ref) == ollamaRegistryURL
+	layers := manifest.Layers
+	if !ollama && manifest.Config.Annotations[specs.AnnotationTitle] != "" {
+		layers = append(layers, manifest.Config)
+	}
+	for _, layer := range layers {
+		name := layer.Annotations[specs.AnnotationTitle]
+		if ollama {
+			if layer.MediaType != ollamaModelType {
+				continue
+			}
+			name = path.Base(reference.Path(ref))
+		}
+		if name == "" {
+			continue
+		}
+		clean := path.Clean(name)
+		if path.IsAbs(name) || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.ContainsAny(name, "\\\x00") {
+			return llb.State{}, errors.Errorf("unsafe OCI model filename %q", name)
+		}
+		if _, exists := names[clean]; exists {
+			return llb.State{}, errors.Errorf("duplicate OCI model filename %q", clean)
+		}
+		names[clean] = struct{}{}
+		if err := layer.Digest.Validate(); err != nil {
+			return llb.State{}, errors.Wrap(err, "invalid OCI model blob digest")
+		}
+		if layer.Digest.Algorithm() != digest.SHA256 || layer.Size < 0 {
+			return llb.State{}, errors.New("OCI model blobs require a sha256 digest and non-negative size")
+		}
+		blob := llb.ImageBlob(reference.TrimNamed(ref).Name()+"@"+layer.Digest.String(), llb.Filename(ociBlobFilename), llb.Chmod(0o644))
+		// Preserve ORAS's digest and size verification, including after cache imports.
+		verified := orasToolingImage(r.buildPlatform).Network(pb.NetMode_NONE).Run(
+			llb.Args([]string{"/bin/sh", "-ec", `test "$(wc -c < /blob/blob)" -eq "$2"
+printf '%s  /blob/blob\n' "$1" | sha256sum -c -`, "aikit-verify-blob", layer.Digest.Encoded(), strconv.FormatInt(layer.Size, 10)}),
+			llb.AddMount("/blob", blob),
+			llb.WithCustomName("Verifying OCI model blob "+layer.Digest.String()),
+		).GetMount("/blob")
+		copyInfo := &llb.CopyInfo{CreateDestPath: true}
+		destination := "/" + clean
+		if layer.Annotations[orasUnpack] == "true" {
+			unpacked := llb.Scratch().File(llb.Copy(verified, "/"+ociBlobFilename, "/", &llb.CopyInfo{AttemptUnpack: true}))
+			copyInfo.CopyDirContentsOnly = true
+			state = state.File(llb.Copy(unpacked, destination, destination, copyInfo))
+			continue
+		}
+		state = state.File(llb.Copy(verified, "/"+ociBlobFilename, destination, copyInfo))
+	}
+	if len(names) == 0 {
+		return llb.State{}, errors.New("OCI model manifest has no downloadable model files")
+	}
+	return state, nil
+}
+
+func isLocalOCIRegistry(domain string) bool {
+	host := domain
+	if h, _, err := net.SplitHostPort(domain); err == nil {
+		host = h
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/pkg/aikit2llb/inference/oci_test.go
+++ b/pkg/aikit2llb/inference/oci_test.go
@@ -1,0 +1,373 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+const testOCIRepository = "example.com/models/test"
+
+func TestNativeOCIModelFiles(t *testing.T) {
+	weight := testOCILayer("weights/model.gguf", "weight bytes")
+	config := testOCILayer("tokenizer.json", "tokenizer bytes")
+	unnamed := testOCILayer("", "unnamed bytes")
+	c := newOCIManifestClient()
+	canonical := c.addManifest(testOCIRepository, testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{weight, config, unnamed}))
+	c.tags[testOCIRepository+":latest"] = canonical
+	imports := []client.CacheOptionsEntry{{Type: "registry", Attrs: map[string]string{"ref": "example.com/models/cache:build"}}}
+	resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, imports)
+	state, err := resolver.Resolve(context.Background(), "oci://"+testOCIRepository+":latest", specs.Platform{OS: "linux", Architecture: "arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition := marshalOCIState(t, state)
+	assertOCIBlobSources(t, definition, testOCIRepository+"@"+weight.Digest.String(), testOCIRepository+"@"+config.Digest.String())
+	for _, filename := range []string{"/weights/model.gguf", "/tokenizer.json"} {
+		found := false
+		for _, op := range decodeInferenceDefinition(t, definition) {
+			if file := op.op.GetFile(); file != nil {
+				for _, action := range file.Actions {
+					if fileCopy := action.GetCopy(); fileCopy != nil && fileCopy.Dest == filename {
+						found = true
+					}
+				}
+			}
+		}
+		if !found {
+			t.Errorf("model filename %s was not preserved", filename)
+		}
+	}
+	requests := c.solveRequests()
+	if len(requests) != 1 || !reflect.DeepEqual(requests[0].CacheImports, imports) {
+		t.Fatalf("manifest solves = %#v, want one with remote cache imports", requests)
+	}
+	uncached := false
+	for _, metadata := range requests[0].Definition.Metadata {
+		uncached = uncached || metadata.IgnoreCache
+	}
+	if !uncached {
+		t.Fatal("mutable tag lookup must be refreshed on each build")
+	}
+}
+
+func TestNativeOCIDigestReferenceSkipsTagLookup(t *testing.T) {
+	c := newOCIManifestClient()
+	layer := testOCILayer("model.gguf", "model bytes")
+	canonical := c.addManifest(testOCIRepository, testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{layer}))
+	resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, nil)
+	state, err := resolver.Resolve(context.Background(), "oci://"+canonical, specs.Platform{OS: "linux", Architecture: "arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOCIBlobSources(t, marshalOCIState(t, state), testOCIRepository+"@"+layer.Digest.String())
+	requests := c.solveRequests()
+	if len(requests) != 1 {
+		t.Fatalf("manifest solves = %d, want one", len(requests))
+	}
+	for _, data := range requests[0].Definition.Def {
+		var op pb.Op
+		if err := op.Unmarshal(data); err != nil {
+			t.Fatal(err)
+		}
+		if exec := op.GetExec(); exec != nil && strings.Contains(exec.Meta.Args[2], "oras resolve") {
+			t.Fatal("digest-pinned manifest resolved a tag")
+		}
+	}
+	for _, metadata := range requests[0].Definition.Metadata {
+		if metadata.IgnoreCache {
+			t.Fatal("immutable manifest lookup disabled caching")
+		}
+	}
+}
+
+func TestNativeOCIMultiPlatformSharesManifestLookups(t *testing.T) {
+	c := newOCIManifestClient()
+	amd64 := specs.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := specs.Platform{OS: "linux", Architecture: "arm64"}
+	amdLayer := testOCILayer("model.gguf", "amd64 bytes")
+	armLayer := testOCILayer("model.gguf", "arm64 bytes")
+	amdManifest := testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{amdLayer})
+	armManifest := testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{armLayer})
+	c.addManifest(testOCIRepository, amdManifest)
+	c.addManifest(testOCIRepository, armManifest)
+	index := testOCIJSON(t, specs.MediaTypeImageIndex, "manifests", []specs.Descriptor{
+		testOCIManifestDescriptor(amdManifest, &amd64),
+		testOCIManifestDescriptor(armManifest, &arm64),
+		{Digest: digest.FromString("attestation"), Platform: &specs.Platform{OS: "unknown", Architecture: "unknown"}},
+	})
+	c.tags[testOCIRepository+":latest"] = c.addManifest(testOCIRepository, index)
+	resolver := NewOCIResolver(c, amd64, nil)
+	var group errgroup.Group
+	for i := 0; i < 20; i++ {
+		group.Go(func() error {
+			target, layer := amd64, amdLayer
+			if i%2 != 0 {
+				target, layer = arm64, armLayer
+			}
+			state, err := resolver.Resolve(context.Background(), "oci://"+testOCIRepository+":latest", target)
+			if err != nil {
+				return err
+			}
+			definition, err := state.Marshal(context.Background())
+			if err != nil {
+				return err
+			}
+			if got := ociBlobSources(definition); !reflect.DeepEqual(got, []string{testOCIRepository + "@" + layer.Digest.String()}) {
+				return errors.Errorf("%s model blobs = %v", target.Architecture, got)
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(c.solveRequests()); got != 3 {
+		t.Fatalf("manifest solves = %d, want one shared index and two platform manifests", got)
+	}
+}
+
+func TestNativeOCIMutableTagRefreshesAcrossBuilds(t *testing.T) {
+	c := newOCIManifestClient()
+	platform := specs.Platform{OS: "linux", Architecture: "amd64"}
+	for _, content := range []string{"first model", "replacement model"} {
+		layer := testOCILayer("model.gguf", content)
+		data := testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{layer})
+		c.tags[testOCIRepository+":latest"] = c.addManifest(testOCIRepository, data)
+		resolver := NewOCIResolver(c, platform, nil)
+		state, err := resolver.Resolve(context.Background(), "oci://"+testOCIRepository+":latest", platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertOCIBlobSources(t, marshalOCIState(t, state), testOCIRepository+"@"+layer.Digest.String())
+	}
+	if got := len(c.solveRequests()); got != 2 {
+		t.Fatalf("tag lookups = %d, want one per build", got)
+	}
+}
+
+func TestSelectOCIManifest(t *testing.T) {
+	amd64 := specs.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := specs.Platform{OS: "linux", Architecture: "arm64"}
+	amd := testOCIManifestDescriptor([]byte("amd64 manifest"), &amd64)
+	arm := testOCIManifestDescriptor([]byte("arm64 manifest"), &arm64)
+	neutral := testOCIManifestDescriptor([]byte("neutral manifest"), nil)
+	attestation := testOCIManifestDescriptor([]byte("attestation"), nil)
+	attestation.Annotations = map[string]string{"vnd.docker.reference.type": "attestation-manifest"}
+	tests := []struct {
+		name      string
+		manifests []specs.Descriptor
+		target    specs.Platform
+		want      digest.Digest
+		wantError string
+	}{
+		{name: "neutral index", manifests: []specs.Descriptor{neutral}, target: arm64, want: neutral.Digest},
+		{name: "single amd64 stamp stays neutral", manifests: []specs.Descriptor{amd}, target: arm64, want: amd.Digest},
+		{name: "attestation does not add a platform", manifests: []specs.Descriptor{attestation, amd}, target: arm64, want: amd.Digest},
+		{name: "two platforms select arm64", manifests: []specs.Descriptor{amd, attestation, arm}, target: arm64, want: arm.Digest},
+		{name: "two platforms select amd64", manifests: []specs.Descriptor{arm, amd}, target: amd64, want: amd.Digest},
+		{name: "missing target", manifests: []specs.Descriptor{amd, arm}, target: specs.Platform{OS: "linux", Architecture: "riscv64"}, wantError: "no manifest for"},
+		{name: "empty index", target: arm64, wantError: "no model manifests"},
+		{name: "only attestations", manifests: []specs.Descriptor{attestation}, target: arm64, wantError: "no model manifests"},
+		{name: "invalid digest", manifests: []specs.Descriptor{{Digest: "sha256:bad"}}, target: arm64, wantError: "invalid OCI model manifest digest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectOCIManifest(specs.Index{Manifests: tt.manifests}, tt.target)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil || got.Digest != tt.want {
+				t.Fatalf("selected %s, error %v, want %s", got.Digest, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestNativeOCIOllamaSelectsOnlyModelLayer(t *testing.T) {
+	c := newOCIManifestClient()
+	repository := "registry.ollama.ai/library/model"
+	layer := testOCILayer("", "ollama model bytes")
+	layer.MediaType = ollamaModelType
+	other := testOCILayer("template", "template bytes")
+	canonical := c.addManifest(repository, testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{other, layer}))
+	resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, nil)
+	state, err := resolver.Resolve(context.Background(), "oci://"+canonical, specs.Platform{OS: "linux", Architecture: "arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOCIBlobSources(t, marshalOCIState(t, state), repository+"@"+layer.Digest.String())
+}
+
+func TestNativeOCIRejectsUnsafeMetadata(t *testing.T) {
+	for _, name := range []string{"../escape", "/absolute", ".", "dir/../../escape", "dir\\escape", "nul\x00file"} {
+		t.Run(name, func(t *testing.T) {
+			c := newOCIManifestClient()
+			layer := testOCILayer(name, "bytes")
+			canonical := c.addManifest(testOCIRepository, testOCIJSON(t, specs.MediaTypeImageManifest, "layers", []specs.Descriptor{layer}))
+			resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, nil)
+			if _, err := resolver.Resolve(context.Background(), "oci://"+canonical, specs.Platform{}); err == nil || !strings.Contains(err.Error(), "unsafe OCI model filename") {
+				t.Fatalf("error = %v, want unsafe filename", err)
+			}
+		})
+	}
+	t.Run("manifest digest mismatch", func(t *testing.T) {
+		c := newOCIManifestClient()
+		canonical := c.addManifest(testOCIRepository, []byte("original bytes"))
+		c.manifests[canonical] = []byte("tampered bytes")
+		resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, nil)
+		if _, err := resolver.Resolve(context.Background(), "oci://"+canonical, specs.Platform{}); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+			t.Fatalf("error = %v, want manifest digest mismatch", err)
+		}
+	})
+}
+
+func TestNativeOCIUnavailableOnOlderBuilders(t *testing.T) {
+	c := newOCIManifestClient()
+	c.opts = client.BuildOpts{}
+	if resolver := NewOCIResolver(c, specs.Platform{OS: "linux", Architecture: "amd64"}, nil); resolver != nil {
+		t.Fatal("native OCI resolver enabled without blob source support")
+	}
+}
+
+type ociManifestClient struct {
+	client.Client
+	opts      client.BuildOpts
+	manifests map[string][]byte
+	tags      map[string]string
+	mu        sync.Mutex
+	requests  []client.SolveRequest
+}
+
+func newOCIManifestClient() *ociManifestClient {
+	return &ociManifestClient{
+		opts:      client.BuildOpts{LLBCaps: pb.Caps.CapSet(pb.Caps.All())},
+		manifests: make(map[string][]byte),
+		tags:      make(map[string]string),
+	}
+}
+
+func (c *ociManifestClient) BuildOpts() client.BuildOpts { return c.opts }
+
+func (c *ociManifestClient) addManifest(repository string, data []byte) string {
+	canonical := repository + "@" + digest.FromBytes(data).String()
+	c.manifests[canonical] = data
+	return canonical
+}
+
+func (c *ociManifestClient) Solve(_ context.Context, request client.SolveRequest) (*client.Result, error) {
+	c.mu.Lock()
+	c.requests = append(c.requests, request.Clone())
+	c.mu.Unlock()
+	canonical := ""
+	for _, data := range request.Definition.Def {
+		var op pb.Op
+		if err := op.Unmarshal(data); err != nil {
+			return nil, err
+		}
+		if source := op.GetSource(); source != nil && strings.HasPrefix(source.Identifier, "docker-image+blob://") {
+			canonical = strings.TrimPrefix(source.Identifier, "docker-image+blob://")
+		}
+		if exec := op.GetExec(); exec != nil && len(exec.Meta.Args) >= 5 && exec.Meta.Args[3] == "aikit-oci-manifest" {
+			canonical = exec.Meta.Args[4]
+			if resolved, ok := c.tags[canonical]; ok {
+				canonical = resolved
+			}
+		}
+	}
+	data, ok := c.manifests[canonical]
+	if !ok {
+		return nil, errors.Errorf("unexpected manifest lookup %q", canonical)
+	}
+	result := client.NewResult()
+	result.SetRef(&ociManifestReference{files: map[string][]byte{ociManifestFilename: data, ociResolvedRefPath: []byte(canonical)}})
+	return result, nil
+}
+
+func (c *ociManifestClient) solveRequests() []client.SolveRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]client.SolveRequest(nil), c.requests...)
+}
+
+type ociManifestReference struct {
+	client.Reference
+	files map[string][]byte
+}
+
+func (r *ociManifestReference) ReadFile(_ context.Context, request client.ReadRequest) ([]byte, error) {
+	data, ok := r.files[request.Filename]
+	if !ok {
+		return nil, errors.Errorf("unexpected metadata file %q", request.Filename)
+	}
+	if request.Range != nil && len(data) > request.Range.Length {
+		data = data[:request.Range.Length]
+	}
+	return data, nil
+}
+
+func testOCILayer(name, content string) specs.Descriptor {
+	return specs.Descriptor{
+		MediaType:   "application/vnd.cncf.model.weight.v1.raw",
+		Digest:      digest.FromString(content),
+		Size:        int64(len(content)),
+		Annotations: map[string]string{specs.AnnotationTitle: name},
+	}
+}
+
+func testOCIManifestDescriptor(data []byte, platform *specs.Platform) specs.Descriptor {
+	return specs.Descriptor{MediaType: specs.MediaTypeImageManifest, Digest: digest.FromBytes(data), Size: int64(len(data)), Platform: platform}
+}
+
+func testOCIJSON(t *testing.T, mediaType, field string, descriptors []specs.Descriptor) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"schemaVersion": 2, "mediaType": mediaType, field: descriptors})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func marshalOCIState(t *testing.T, state llb.State) *llb.Definition {
+	t.Helper()
+	definition, err := state.Marshal(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return definition
+}
+
+func ociBlobSources(definition *llb.Definition) []string {
+	var sources []string
+	for _, data := range definition.Def {
+		var op pb.Op
+		if err := op.Unmarshal(data); err != nil {
+			return nil
+		}
+		if source := op.GetSource(); source != nil && strings.HasPrefix(source.Identifier, "docker-image+blob://") {
+			sources = append(sources, strings.TrimPrefix(source.Identifier, "docker-image+blob://"))
+		}
+	}
+	return sources
+}
+
+func assertOCIBlobSources(t *testing.T, definition *llb.Definition, want ...string) {
+	t.Helper()
+	if got := ociBlobSources(definition); !reflect.DeepEqual(got, want) {
+		t.Fatalf("native blob sources = %v, want %v", got, want)
+	}
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kaito-project/aikit/pkg/backendcatalog"
 	"github.com/kaito-project/aikit/pkg/packager"
 	"github.com/kaito-project/aikit/pkg/utils"
-	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	d2llb "github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb"
@@ -37,7 +36,6 @@ const (
 	keyTarget                = "target"
 	keyOutput                = "output"
 	keyTargetPlatform        = "platform"
-	keyCacheImports          = "cache-imports"
 	nvidiaUUIDPattern        = `[A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}`
 	maximumBackendNameLength = 128
 	supportedRuntimeValues   = `"cpu", "cuda", "cuda-12", "cuda-13", "rocm", and "applesilicon"`
@@ -95,7 +93,7 @@ func buildFineTune(ctx context.Context, c client.Client, cfg *config.FineTuneCon
 	finetuneOpts.BuildSessionID = buildOpts.SessionID
 
 	// Parse cache imports
-	cacheImports, err := parseCacheOptions(opts)
+	cacheImports, err := utils.ParseCacheImports(opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse cache import options")
 	}
@@ -129,7 +127,7 @@ func buildInference(ctx context.Context, c client.Client, cfg *config.InferenceC
 	opts := buildOpts.Opts
 
 	// Parse cache imports
-	cacheImports, err := parseCacheOptions(opts)
+	cacheImports, err := utils.ParseCacheImports(opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse cache import options")
 	}
@@ -143,6 +141,7 @@ func buildInference(ctx context.Context, c client.Client, cfg *config.InferenceC
 	}
 
 	buildPlatforms := []specs.Platform{defaultBuildPlatform}
+	ociResolver := inference.NewOCIResolver(c, defaultBuildPlatform, cacheImports)
 
 	targetPlatforms := []*specs.Platform{nil}
 	if platform, exists := opts[keyTargetPlatform]; exists && platform != "" {
@@ -181,7 +180,7 @@ func buildInference(ctx context.Context, c client.Client, cfg *config.InferenceC
 						MultiPlatformRequested: isMultiPlatform,
 						CacheImports:           cacheImports,
 					},
-				})
+				}, inference.WithOCIResolver(ociResolver))
 				if err != nil {
 					return errors.Wrap(err, "failed to build image")
 				}
@@ -248,6 +247,7 @@ func buildImage(
 	cfg *config.InferenceConfig,
 	backend backendcatalog.Resolution,
 	convertOpts *d2llb.ConvertOpt,
+	inferenceOpts ...inference.ConvertOption,
 ) (*buildResult, error) {
 	result := buildResult{
 		Platform:      convertOpts.TargetPlatform,
@@ -255,7 +255,7 @@ func buildImage(
 	}
 
 	buildPlatform := buildPlatformFromConvertOpt(convertOpts)
-	state, image, err := inference.Aikit2LLBWithBackend(cfg, &buildPlatform, convertOpts.TargetPlatform, backend)
+	state, image, err := inference.Aikit2LLBWithBackend(cfg, &buildPlatform, convertOpts.TargetPlatform, backend, inferenceOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -893,19 +893,4 @@ func parsePlatforms(v string) ([]*specs.Platform, error) {
 		pp = append(pp, &p)
 	}
 	return pp, nil
-}
-
-// parseCacheOptions handles given cache imports.
-func parseCacheOptions(opts map[string]string) ([]client.CacheOptionsEntry, error) {
-	var cacheImports []client.CacheOptionsEntry
-	if cacheImportsStr := opts[keyCacheImports]; cacheImportsStr != "" {
-		var cacheImportsUM []*controlapi.CacheOptionsEntry
-		if err := json.Unmarshal([]byte(cacheImportsStr), &cacheImportsUM); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal %s (%q)", keyCacheImports, cacheImportsStr)
-		}
-		for _, um := range cacheImportsUM {
-			cacheImports = append(cacheImports, client.CacheOptionsEntry{Type: um.Type, Attrs: um.Attrs})
-		}
-	}
-	return cacheImports, nil
 }

--- a/pkg/build/platform_test.go
+++ b/pkg/build/platform_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerui"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -160,12 +161,75 @@ func TestBuildInferenceUsesBuildPlatformForArtifactHelpers(t *testing.T) {
 	}
 }
 
+func TestBuildInferenceSharesNativeOCIAndRemoteCache(t *testing.T) {
+	layerDigest := digest.FromString("model bytes")
+	manifest, err := json.Marshal(map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     specs.MediaTypeImageManifest,
+		"layers": []specs.Descriptor{{
+			MediaType: "application/vnd.cncf.model.weight.v1.raw",
+			Digest:    layerDigest, Size: 11,
+			Annotations: map[string]string{specs.AnnotationTitle: "model.gguf"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const repository = "example.com/models/test"
+	imports := []client.CacheOptionsEntry{{Type: "registry", Attrs: map[string]string{"ref": "example.com/models/cache:build"}}}
+	cacheJSON, err := json.Marshal(imports)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gatewayClient := &recordingBuildClient{
+		buildOpts: client.BuildOpts{
+			Opts:    map[string]string{keyTargetPlatform: "linux/amd64,linux/arm64", "cache-imports": string(cacheJSON)},
+			Workers: []client.WorkerInfo{{Platforms: []specs.Platform{{OS: "linux", Architecture: "amd64"}}}},
+			LLBCaps: pb.Caps.CapSet(pb.Caps.All()),
+		},
+		files: map[string][]byte{
+			"/manifest.json": manifest,
+			"/resolved-ref":  []byte(repository + "@" + digest.FromBytes(manifest).String()),
+		},
+	}
+	cfg := &config.InferenceConfig{
+		APIVersion: utils.APIv1alpha1,
+		Models:     []config.Model{{Name: testBuildModelName, Source: "oci://" + repository + ":latest"}},
+	}
+	result, err := buildInference(context.Background(), gatewayClient, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definitions := gatewayClient.solveDefinitions()
+	if len(definitions) != 3 || len(result.Refs) != 2 {
+		t.Fatalf("got %d solves and %d outputs, want one shared metadata solve and two platform outputs", len(definitions), len(result.Refs))
+	}
+	nativeBuilds := 0
+	for i, definition := range definitions {
+		if !reflect.DeepEqual(gatewayClient.cacheImports[i], imports) {
+			t.Errorf("solve %d did not receive remote cache imports", i)
+		}
+		blobs := findBuildSourceOps(t, definition, "docker-image+blob://"+repository+"@"+layerDigest.String())
+		if len(blobs) == 1 {
+			nativeBuilds++
+			if blobs[0].Platform != nil {
+				t.Error("model blob source unexpectedly depends on the target platform")
+			}
+		}
+	}
+	if nativeBuilds != 2 {
+		t.Fatalf("native model builds = %d, want two", nativeBuilds)
+	}
+}
+
 type recordingBuildClient struct {
 	client.Client
 
 	buildOpts     client.BuildOpts
 	mu            sync.Mutex
 	definitions   []*pb.Definition
+	cacheImports  [][]client.CacheOptionsEntry
+	files         map[string][]byte
 	nextReference int
 }
 
@@ -176,8 +240,9 @@ func (c *recordingBuildClient) BuildOpts() client.BuildOpts {
 func (c *recordingBuildClient) Solve(_ context.Context, request client.SolveRequest) (*client.Result, error) {
 	c.mu.Lock()
 	c.definitions = append(c.definitions, request.Definition.CloneVT())
+	c.cacheImports = append(c.cacheImports, request.CacheImports)
 	c.nextReference++
-	reference := &recordingBuildReference{id: c.nextReference}
+	reference := &recordingBuildReference{id: c.nextReference, files: c.files}
 	c.mu.Unlock()
 
 	result := client.NewResult()
@@ -198,7 +263,16 @@ func (c *recordingBuildClient) solveDefinitions() []*pb.Definition {
 
 type recordingBuildReference struct {
 	client.Reference
-	id int
+	id    int
+	files map[string][]byte
+}
+
+func (r *recordingBuildReference) ReadFile(_ context.Context, request client.ReadRequest) ([]byte, error) {
+	data, ok := r.files[request.Filename]
+	if !ok {
+		return nil, fmt.Errorf("unexpected metadata file %s", request.Filename)
+	}
+	return data, nil
 }
 
 func findBuildSourceOp(t *testing.T, definition *pb.Definition, identifierFragment string) *pb.Op {

--- a/pkg/packager/build.go
+++ b/pkg/packager/build.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kaito-project/aikit/pkg/utils"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/gateway/client"
@@ -67,12 +68,16 @@ func parseBuildConfig(opts map[string]string, sessionID string, isModelpack bool
 // and constructs a client.Result with the appropriate image config.
 // This eliminates the repeated marshal→solve→getRef→createConfig→buildResult pattern.
 func solveAndBuildResult(ctx context.Context, c client.Client, state llb.State, customName string) (*client.Result, error) {
+	cacheImports, err := utils.ParseCacheImports(c.BuildOpts().Opts)
+	if err != nil {
+		return nil, err
+	}
 	def, err := state.Marshal(ctx, llb.WithCustomName(customName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal %s LLB definition: %w", customName, err)
 	}
 
-	resSolve, err := c.Solve(ctx, client.SolveRequest{Definition: def.ToPB()})
+	resSolve, err := c.Solve(ctx, client.SolveRequest{Definition: def.ToPB(), CacheImports: cacheImports})
 	if err != nil {
 		return nil, fmt.Errorf("failed to solve %s build: %w", customName, err)
 	}

--- a/pkg/packager/cache_test.go
+++ b/pkg/packager/cache_test.go
@@ -1,0 +1,58 @@
+package packager
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+)
+
+func TestPackagersImportRemoteCache(t *testing.T) {
+	for name, build := range map[string]client.BuildFunc{"modelpack": BuildModelpack, "generic": BuildGeneric} {
+		t.Run(name, func(t *testing.T) {
+			c := &cacheRecordingClient{opts: map[string]string{
+				"build-arg:source": "model.gguf",
+				"cache-imports":    "[{\"Type\":\"registry\",\"Attrs\":{\"ref\":\"example.com/models/cache:build\"}}]",
+			}}
+			if _, err := build(context.Background(), c); err != nil {
+				t.Fatal(err)
+			}
+			want := []client.CacheOptionsEntry{{Type: "registry", Attrs: map[string]string{"ref": "example.com/models/cache:build"}}}
+			if !reflect.DeepEqual(c.imports, want) {
+				t.Fatalf("cache imports = %#v, want %#v", c.imports, want)
+			}
+		})
+	}
+}
+
+func TestPackagerRejectsInvalidRemoteCacheOptions(t *testing.T) {
+	c := &cacheRecordingClient{opts: map[string]string{"build-arg:source": "model.gguf", "cache-imports": "invalid JSON"}}
+	if _, err := BuildModelpack(context.Background(), c); err == nil {
+		t.Fatal("invalid cache-imports was silently ignored")
+	}
+	if c.solved {
+		t.Fatal("packaging started with invalid cache imports")
+	}
+}
+
+type cacheRecordingClient struct {
+	client.Client
+	opts    map[string]string
+	imports []client.CacheOptionsEntry
+	solved  bool
+}
+
+func (c *cacheRecordingClient) BuildOpts() client.BuildOpts {
+	return client.BuildOpts{Opts: c.opts}
+}
+
+func (c *cacheRecordingClient) Solve(_ context.Context, request client.SolveRequest) (*client.Result, error) {
+	c.imports = request.CacheImports
+	c.solved = true
+	result := client.NewResult()
+	result.SetRef(&cacheRecordingReference{})
+	return result, nil
+}
+
+type cacheRecordingReference struct{ client.Reference }

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"encoding/json"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/pkg/errors"
+)
+
+// ParseCacheImports reads the remote caches supplied by buildx to the frontend.
+func ParseCacheImports(opts map[string]string) ([]client.CacheOptionsEntry, error) {
+	var entries []client.CacheOptionsEntry
+	if value := opts["cache-imports"]; value != "" {
+		if err := json.Unmarshal([]byte(value), &entries); err != nil {
+			return nil, errors.Wrap(err, "invalid cache-imports")
+		}
+	}
+	return entries, nil
+}

--- a/website/docs/create-images.md
+++ b/website/docs/create-images.md
@@ -6,10 +6,13 @@ title: Creating Model Images
 This section shows how to create a custom image with models of your choosing. If you want to use one of the pre-made models, skip to [running models](#running-models).
 :::
 
-First, create a buildx buildkit instance.
+Create a builder with BuildKit 0.33.0 to use native OCI blob downloads and the current parallel-build and remote-cache fixes. The BuildKit daemon version is independent of the AIKit frontend version.
 
 ```bash
-docker buildx create --use --name aikit-builder
+docker buildx create --use --name aikit-builder \
+    --driver docker-container \
+    --driver-opt image=moby/buildkit:v0.33.0
+docker buildx inspect --bootstrap
 ```
 
 ## Quick Start
@@ -61,6 +64,20 @@ docker buildx build -t my-model --load \
 ```
 
 Resulting model name will be the image name. In this case, `llama3`.
+
+On builders with native blob support, AIKit downloads OCI model files by blob digest. Mutable tags are resolved once per build, shared across target platforms, and refreshed on subsequent builds. Digest-pinned references skip tag resolution. Named artifact files retain their paths, and Ollama model layers retain the repository's model name. Older builders use the existing ORAS download path.
+
+BuildKit fetches model blobs using its registry credentials and configuration. Manifest lookups still run in ORAS and do not inherit those credentials, so private OCI artifacts retain the existing authentication limitation.
+
+Use an external cache to reuse model downloads across builders. For example:
+
+```bash
+docker buildx build . -f aikitfile.yaml -t my-model --load \
+    --cache-from type=registry,ref=ghcr.io/your-org/my-model:buildcache \
+    --cache-to type=registry,ref=ghcr.io/your-org/my-model:buildcache,mode=max
+```
+
+Inference, fine-tuning, and packaging targets all accept cache imports. Give independent cache writers separate cache references or scopes to avoid replacing each other's exported cache.
 
 After building the image, you can proceed to [running models](#running-models) to start the server.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

OCI models currently download through an ORAS build step for each target platform, and packaging targets discard external cache imports. This change downloads model files through native BuildKit blob sources, shares manifest lookups across target platforms, and forwards cache imports to both packaging targets.

Model files retain their paths, including archived directories and Ollama model names. Downloads check blob digests and sizes. Mutable tags refresh on each build, while digest-pinned metadata and model blobs can reuse cached results. Builders without native blob support keep the existing ORAS download path.

Managed CI builders now use BuildKit 0.33.0 and Buildx 0.37.0. The OCI integration workflow checks model contents and registry cache reuse on a fresh builder. Documentation includes builder setup and external cache examples.

**Special notes for your reviewer**:

Manifest lookups still use ORAS and retain the existing private-registry authentication limitation.

Validation completed:

- `make test`, including race detection, with Go 1.26.3.
- `make lint` with CI's pinned golangci-lint 2.11.2.
- Live BuildKit 0.33.0 builds for amd64 and arm64, with one shared tag lookup and the correct platform-specific model files.
- Registry cache export and reuse on a fresh builder.
- Archived directory downloads and rejection of incorrect blob sizes and digests.
- `actionlint` on the changed integration workflows.
