### PR TITLE
docs: add Colima Apple Silicon GPU setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,15 @@ If it doesn't include a specific model, you can always [create your own images](
 ### Apple Silicon (experimental)
 
 > [!NOTE]
-> To enable GPU acceleration on Apple Silicon, please see [Podman Desktop documentation](https://podman-desktop.io/docs/podman/gpu). For more information, please see [GPU Acceleration](https://kaito-project.github.io/aikit/docs/gpu).
+> For Apple Silicon GPU acceleration, use [Podman Desktop](https://podman-desktop.io/docs/podman/gpu)
+> or [Colima with Docker Engine](https://kaito-project.github.io/aikit/docs/gpu#colima-with-docker).
+> See [GPU Acceleration](https://kaito-project.github.io/aikit/docs/gpu#apple-silicon-experimental) for setup.
 >
 > Apple Silicon is an _experimental_ runtime and it may change in the future. This runtime is specific to Apple Silicon only, and it will not work as expected on other architectures, including Intel Macs.
 >
 > Only `gguf` models are supported on Apple Silicon.
+
+With the Colima profile from the guide, replace `podman` in the commands below with `docker --context colima-aikit-gpu`.
 
 | Model       | Optimization | Parameters | Command                                                                                                  | Model Name              | License                                                                            |
 | ----------- | ------------ | ---------- | -------------------------------------------------------------------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------- |

--- a/website/docs/gpu.md
+++ b/website/docs/gpu.md
@@ -266,9 +266,10 @@ AMD recommends setting VRAM to the minimum needed and using the `amd-ttm` tool t
 Apple Silicon is an experimental runtime and it may change in the future. This runtime is specific to Apple Silicon only, and it will not work as expected on other architectures, including Intel Macs.
 :::
 
-AIKit supports Apple Silicon GPU acceleration with Podman Desktop for Mac with [`libkrun`](https://github.com/containers/libkrun). Please see [Podman Desktop documentation](https://podman-desktop.io/docs/podman/gpu) on how to enable GPU support.
+Apple Silicon GPU acceleration uses a [`libkrun`](https://github.com/containers/libkrun)/[`krunkit`](https://github.com/containers/krunkit)
+virtual machine to expose the GPU through Vulkan. This section covers Podman Desktop for Mac and Docker Engine with Colima.
 
-To get started with Apple Silicon GPU-accelerated inferencing, make sure to set the following in your `aikitfile` and build your model.
+For custom images, set the runtime in your `aikitfile` and [build the image](create-images.md) for `linux/arm64`:
 
 ```yaml
 runtime: applesilicon         # use Apple Silicon runtime
@@ -276,14 +277,61 @@ runtime: applesilicon         # use Apple Silicon runtime
 
 This guide and the published Apple Silicon model images use the default `llama-cpp` Apple Silicon profile with GGUF models. A frontend release can contain other experimental Apple Silicon tuples for standard builds; catalog presence does not promise a published image or a validated end-to-end workflow, and runner mode still requires an explicit runner profile.
 
-After building the model, you can run it with:
+### Podman
+
+Follow the [Podman Desktop GPU setup](https://podman-desktop.io/docs/podman/gpu) to create a machine using `libkrun`.
+After building the model, run it with:
 
 ```bash
 # for pre-made models, replace "my-model" with the image name
 podman run --rm --device /dev/dri -p 8080:8080 my-model
 ```
 
-If GPU acceleration is working, you'll see output that is similar to following in the debug logs:
+### Colima with Docker
+
+This experimental setup requires an Apple Silicon Mac running macOS 14 or newer,
+[Colima 0.10.0 or newer](https://github.com/abiosoft/colima#ai-models-gpu-accelerated), the Docker CLI, and [krunkit](https://github.com/containers/krunkit).
+
+These commands target Colima's Docker Engine. Docker Desktop can build the images, but its
+[GPU support](https://docs.docker.com/desktop/features/gpu/) does not provide Apple GPU access to these containers.
+
+Install Colima, the Docker CLI, and krunkit with Homebrew:
+
+```bash
+brew install colima docker
+brew tap slp/krun
+brew install krunkit
+```
+
+Create a dedicated Colima profile with the `krunkit` VM type and Docker Engine:
+
+```bash
+colima start aikit-gpu --runtime docker --vm-type krunkit \
+  --memory 8 --activate=false
+```
+
+This creates the `colima-aikit-gpu` Docker context. The example allocates 8 GiB of VM memory; adjust `--memory` for your model.
+
+Run a published Apple Silicon image:
+
+```bash
+docker --context colima-aikit-gpu run --rm \
+  --device /dev/dri -p 8080:8080 \
+  ghcr.io/kaito-project/aikit/applesilicon/llama3.2:1b
+```
+
+To run a custom image, replace the image name. Docker Desktop and Colima store images separately.
+If `my-model` was built in Docker Desktop, transfer it to Colima before running it:
+
+```bash
+docker --context desktop-linux save my-model | \
+  docker --context colima-aikit-gpu load
+```
+
+### Verify GPU acceleration
+
+After sending an inference request, check the debug logs for an Apple `Virtio-GPU Venus` device
+and a nonzero number of layers offloaded to the GPU:
 
 ```bash
 6:16AM DBG GRPC(phi-3.5-3.8b-instruct-127.0.0.1:39883): stderr ggml_vulkan: Found 1 Vulkan devices:

--- a/website/docs/premade-models.md
+++ b/website/docs/premade-models.md
@@ -65,12 +65,15 @@ The documented ROCm image path uses `llama-cpp` on `linux/amd64`. Other experime
 ## Apple Silicon (experimental)
 
 :::note
-To enable GPU acceleration on Apple Silicon, please see [Podman Desktop documentation](https://podman-desktop.io/docs/podman/gpu).
+For Apple Silicon GPU acceleration, use [Podman Desktop](https://podman-desktop.io/docs/podman/gpu)
+or [Colima with Docker Engine](gpu.md#colima-with-docker). See [GPU Acceleration](gpu.md#apple-silicon-experimental) for setup.
 
 Apple Silicon is an _experimental_ runtime and it may change in the future. This runtime is specific to Apple Silicon only, and it will not work as expected on other architectures, including Intel Macs.
 
 The published Apple Silicon images use the experimental `llama-cpp` Apple Silicon profile with GGUF models. Other experimental catalog tuples, if present, are not a promise that a published image or end-to-end model workflow is available.
 :::
+
+With the Colima profile from the guide, replace `podman` in the commands below with `docker --context colima-aikit-gpu`.
 
 | Model       | Optimization | Parameters | Command                                                                                                  | Model Name              | License                                                            |
 | ----------- | ------------ | ---------- | -------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------ |


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents Colima with Docker Engine as an Apple Silicon GPU option alongside Podman. Includes prerequisites, krunkit setup, an explicit Docker context, transferring images from Docker Desktop, and checking GPU offload. Updates the README and pre-made model guide to link to the setup and explain the Docker command substitution.

**Special notes for your reviewer**:

Validated with a production website build on Node 20, ShellCheck on the new Bash examples, rendered documentation and link checks, and `git diff --check`.

Colima GPU inference was not exercised locally.
